### PR TITLE
HOTT-3343: Fix instance type

### DIFF
--- a/environments/development/common/rds.tf
+++ b/environments/development/common/rds.tf
@@ -5,7 +5,7 @@ module "postgres" {
   engine         = "postgres"
   engine_version = "13.11"
 
-  instance_type      = "db.t2.micro" # for now, the smallest one we can use.
+  instance_type      = "db.t2.small" # smallest that supports encryption at rest
   backup_window      = "22:00-23:00"
   maintenance_window = "Fri:23:00-Sat:01:00"
 


### PR DESCRIPTION
# Pull Request

This PR is a fix for #17's apply failure.

## What?

I have:

- Changed the instance type on the RDS module to `db.t2.small`.

## Why?

I am doing this because:

- `db.t2.micro` does not support encryption at rest (for some reason).
