### PR TITLE
HOTT-3343: Change to db.t3.micro

### DIFF
--- a/environments/development/common/rds.tf
+++ b/environments/development/common/rds.tf
@@ -5,7 +5,8 @@ module "postgres" {
   engine         = "postgres"
   engine_version = "13.11"
 
-  instance_type      = "db.t2.small" # smallest that supports encryption at rest
+  # smallest that supports encryption at rest and postgres 13.11
+  instance_type      = "db.t3.micro"
   backup_window      = "22:00-23:00"
   maintenance_window = "Fri:23:00-Sat:01:00"
 


### PR DESCRIPTION
# Pull Request

This PR fixes #18...

## What?

I have:

- Changed the instance type to `db.t3.micro`.

## Why?

I am doing this because:

- According to [the documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html#Concepts.DBInstanceClass.Support) `db.t2.micro` doesn't support encryption at rest, and `db.t2` instances don't support Postgres >=13. 😞 
