### PR TITLE
BAU: RDS DB names cannot contain hyphens

### DIFF
--- a/environments/development/common/rds.tf
+++ b/environments/development/common/rds.tf
@@ -1,7 +1,7 @@
 module "postgres" {
   source = "../../common/rds"
 
-  name           = "trade-tariff-postgres-${var.environment}"
+  name           = "TradeTariffPostgres${title(var.environment)}"
   engine         = "postgres"
   engine_version = "13.11"
 


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Changed the database name to `TradeTariffPostgres${title(var.environment)}`

## Why?

I am doing this because:

- The database name cannot contain hyphens (what year is it?)
