### PR TITLE
BAU: Allow db deletion through variable

### DIFF
--- a/environments/common/rds/README.md
+++ b/environments/common/rds/README.md
@@ -38,6 +38,7 @@ No modules.
 | <a name="input_allocated_storage"></a> [allocated\_storage](#input\_allocated\_storage) | Storage to allocate initially to the instance in gibibytes (i.e. 2^30 bytes). Can autoscale. | `number` | `5` | no |
 | <a name="input_backup_retention_period"></a> [backup\_retention\_period](#input\_backup\_retention\_period) | Amount of time, in days, (between 0 and 35) that backups should be retained for. | `number` | `30` | no |
 | <a name="input_backup_window"></a> [backup\_window](#input\_backup\_window) | The daily time range (in UTC) during which automated backups are created if they are enabled, eg: `09:46-10:16` | `string` | n/a | yes |
+| <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Whether to protect the database from deletion. Defaults to `true`. | `bool` | `true` | no |
 | <a name="input_engine"></a> [engine](#input\_engine) | Database engine to use. | `string` | n/a | yes |
 | <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | Version of the database engine to use. | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | Deployment environment. | `string` | n/a | yes |

--- a/environments/common/rds/rds.tf
+++ b/environments/common/rds/rds.tf
@@ -6,10 +6,12 @@ resource "aws_db_instance" "this" {
   allocated_storage = var.allocated_storage
   storage_encrypted = true
 
-  deletion_protection     = true
+  #tfsec:ignore:aws-rds-enable-deletion-protection
+  deletion_protection     = var.deletion_protection
   backup_retention_period = var.backup_retention_period
   backup_window           = var.backup_window
   maintenance_window      = var.maintenance_window
+  skip_final_snapshot     = true
 
   allow_major_version_upgrade = false
   auto_minor_version_upgrade  = true

--- a/environments/common/rds/variables.tf
+++ b/environments/common/rds/variables.tf
@@ -68,3 +68,9 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "deletion_protection" {
+  description = "Whether to protect the database from deletion. Defaults to `true`."
+  type        = bool
+  default     = true
+}

--- a/environments/development/common/rds.tf
+++ b/environments/development/common/rds.tf
@@ -5,6 +5,8 @@ module "postgres" {
   engine         = "postgres"
   engine_version = "13.11"
 
+  deletion_protection = false # while configuring
+
   # smallest that supports encryption at rest and postgres 13.11
   instance_type      = "db.t3.micro"
   backup_window      = "22:00-23:00"


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Added the ability to configure deletion protection for RDS.
- Turned off final snapshots on deletion.

## Why?

I am doing this because:

- While we're configuring it, we'll probably need to make changes that force deletion, which will just block the pipeline. So in this case, I've set it to `false` for `development`.
- We don't need a final snapshot if we're deleting the database through a TF action here. With deletion protection turned on in `production`, we won't see this behaviour.
