### PR TITLE
lifecycle to destroy and recreate

### DIFF
--- a/environments/common/application-load-balancer/alb.tf
+++ b/environments/common/application-load-balancer/alb.tf
@@ -50,6 +50,10 @@ resource "aws_lb_listener" "trade_tariff_listeners" {
     type             = "forward"
     target_group_arn = aws_lb_target_group.trade_tariff_target_groups[each.key].arn
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_lb_listener_certificate" "https_cert_resource" {


### PR DESCRIPTION
# Pull Request

## What? 

  lifecycle {
    create_before_destroy = true
  }
}

## Why
As TF is attempting to recreate the listener that were already created but not fully attached, and it keeps errored out, I have added a life cycle to delete the resource  and then recreate it in-order for it to be completely deploy


