### PR TITLE
HOTT-2782: Add ElastiCache (Redis) Module

### DIFF
--- a/environments/common/elasticache/.terraform.lock.hcl
+++ b/environments/common/elasticache/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.67.0"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:P43vwcDPG99x5WBbmqwUPgfJrfXf6/ucAIbGlRb7k1w=",
+    "zh:0843017ecc24385f2b45f2c5fce79dc25b258e50d516877b3affee3bef34f060",
+    "zh:19876066cfa60de91834ec569a6448dab8c2518b8a71b5ca870b2444febddac6",
+    "zh:24995686b2ad88c1ffaa242e36eee791fc6070e6144f418048c4ce24d0ba5183",
+    "zh:4a002990b9f4d6d225d82cb2fb8805789ffef791999ee5d9cb1fef579aeff8f1",
+    "zh:559a2b5ace06b878c6de3ecf19b94fbae3512562f7a51e930674b16c2f606e29",
+    "zh:6a07da13b86b9753b95d4d8218f6dae874cf34699bca1470d6effbb4dee7f4b7",
+    "zh:768b3bfd126c3b77dc975c7c0e5db3207e4f9997cf41aa3385c63206242ba043",
+    "zh:7be5177e698d4b547083cc738b977742d70ed68487ce6f49ecd0c94dbf9d1362",
+    "zh:8b562a818915fb0d85959257095251a05c76f3467caa3ba95c583ba5fe043f9b",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9c385d03a958b54e2afd5279cd8c7cbdd2d6ca5c7d6a333e61092331f38af7cf",
+    "zh:b3ca45f2821a89af417787df8289cb4314b273d29555ad3b2a5ab98bb4816b3b",
+    "zh:da3c317f1db2469615ab40aa6baba63b5643bae7110ff855277a1fb9d8eb4f2c",
+    "zh:dc6430622a8dc5cdab359a8704aec81d3825ea1d305bbb3bbd032b1c6adfae0c",
+    "zh:fac0d2ddeadf9ec53da87922f666e1e73a603a611c57bcbc4b86ac2821619b1d",
+  ]
+}

--- a/environments/common/elasticache/README.md
+++ b/environments/common/elasticache/README.md
@@ -51,5 +51,6 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_endpoint"></a> [endpoint](#output\_endpoint) | Configuration endpoint of the replication group. |
+| <a name="output_replica_arns"></a> [replica\_arns](#output\_replica\_arns) | List of ARNs of the replica nodes. |
 | <a name="output_replication_group_arn"></a> [replication\_group\_arn](#output\_replication\_group\_arn) | ARN of the replication group. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/environments/common/elasticache/README.md
+++ b/environments/common/elasticache/README.md
@@ -38,6 +38,7 @@ No modules.
 | <a name="input_group_name"></a> [group\_name](#input\_group\_name) | Name of the replication group. | `string` | n/a | yes |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type, i.e. `cache.t3.small`. | `string` | n/a | yes |
 | <a name="input_maintenance_window"></a> [maintenance\_window](#input\_maintenance\_window) | The weekly time range for maintenance periods on the cluster. Format: `ddd:hh22:mi-ddd:hh23:mi` (UTC). Minimum period must be 60 minutes. For example, `sun:05:00-sun:06:00`. | `string` | n/a | yes |
+| <a name="input_parameter_group"></a> [parameter\_group](#input\_parameter\_group) | Parameter group for replication group. For example, `default.redis3.2.cluster.on`. | `string` | n/a | yes |
 | <a name="input_redis_version"></a> [redis\_version](#input\_redis\_version) | Engine version to use. | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | AWS region to use. | `string` | n/a | yes |
 | <a name="input_replicas"></a> [replicas](#input\_replicas) | Number of replicas to create. Defaults to `0`. | `number` | `0` | no |
@@ -47,5 +48,8 @@ No modules.
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_endpoint"></a> [endpoint](#output\_endpoint) | Configuration endpoint of the replication group. |
+| <a name="output_replication_group_arn"></a> [replication\_group\_arn](#output\_replication\_group\_arn) | ARN of the replication group. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/environments/common/elasticache/README.md
+++ b/environments/common/elasticache/README.md
@@ -1,0 +1,51 @@
+# AWS ElastiCache Module
+
+A module to create a Redis replication group/ cluster.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.6 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.67.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_elasticache_cluster.replica](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_cluster) | resource |
+| [aws_elasticache_replication_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_replication_group) | resource |
+| [aws_kms_key.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_apply_immediately"></a> [apply\_immediately](#input\_apply\_immediately) | Whether to apply changes to the replication group immediately (`true`), or to wait for the next maintenance window (`false`). | `bool` | `false` | no |
+| <a name="input_cloudwatch_log_group"></a> [cloudwatch\_log\_group](#input\_cloudwatch\_log\_group) | Cloudwatch log group name for logs to flow into. | `string` | n/a | yes |
+| <a name="input_environment"></a> [environment](#input\_environment) | Deployment environment (i.e., `development`, `staging`, `production`). | `string` | n/a | yes |
+| <a name="input_group_name"></a> [group\_name](#input\_group\_name) | Name of the replication group. | `string` | n/a | yes |
+| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type, i.e. `cache.t3.small`. | `string` | n/a | yes |
+| <a name="input_maintenance_window"></a> [maintenance\_window](#input\_maintenance\_window) | The weekly time range for maintenance periods on the cluster. Format: `ddd:hh22:mi-ddd:hh23:mi` (UTC). Minimum period must be 60 minutes. For example, `sun:05:00-sun:06:00`. | `string` | n/a | yes |
+| <a name="input_redis_version"></a> [redis\_version](#input\_redis\_version) | Engine version to use. | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | AWS region to use. | `string` | n/a | yes |
+| <a name="input_replicas"></a> [replicas](#input\_replicas) | Number of replicas to create. Defaults to `0`. | `number` | `0` | no |
+| <a name="input_security_group_names"></a> [security\_group\_names](#input\_security\_group\_names) | List of security group names to associate with the group. | `list(string)` | `null` | no |
+| <a name="input_snapshot_window"></a> [snapshot\_window](#input\_snapshot\_window) | Daily time range during which ElastiCache will take a snapshot of the cache cluster. Minimum time of 60 minutes. For example: `05:00-06:00`. | `string` | n/a | yes |
+| <a name="input_transit_encryption_enabled"></a> [transit\_encryption\_enabled](#input\_transit\_encryption\_enabled) | Whether to enable encryption in transit. Defaults to `true`. | `bool` | `true` | no |
+
+## Outputs
+
+No outputs.
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/environments/common/elasticache/elasticache.tf
+++ b/environments/common/elasticache/elasticache.tf
@@ -1,0 +1,54 @@
+resource "aws_elasticache_replication_group" "this" {
+  replication_group_id = var.group_name
+  description          = "Redis replica group for ${var.environment}."
+
+  multi_az_enabled           = true
+  automatic_failover_enabled = true
+  apply_immediately          = var.apply_immediately
+
+  engine         = "redis"
+  engine_version = var.redis_version
+  port           = 6739
+
+  at_rest_encryption_enabled = true
+  kms_key_id                 = aws_kms_key.this.arn
+
+  maintenance_window = var.maintenance_window
+  snapshot_window    = var.snapshot_window
+
+  num_cache_clusters = 2
+  node_type          = var.instance_type
+
+  security_group_names       = var.security_group_names
+  transit_encryption_enabled = var.transit_encryption_enabled
+
+  log_delivery_configuration {
+    destination      = var.cloudwatch_log_group
+    destination_type = "cloudwatch-logs"
+    log_format       = "json"
+    log_type         = "slow-log"
+  }
+
+  # log_delivery_configuration {
+  #   destination      = aws_kinesis_firehose_delivery_stream.example.name
+  #   destination_type = "kinesis-firehose"
+  #   log_format       = "json"
+  #   log_type         = "engine-log"
+  # }
+
+  lifecycle {
+    ignore_changes = [num_cache_clusters]
+  }
+}
+
+resource "aws_kms_key" "this" {
+  description         = "KMS key for Redis on ${var.environment}."
+  key_usage           = "ENCRYPT_DECRYPT"
+  enable_key_rotation = true
+}
+
+resource "aws_elasticache_cluster" "replica" {
+  count                = var.replicas
+  cluster_id           = "replica-${count.index}"
+  replication_group_id = aws_elasticache_replication_group.this.id
+}

--- a/environments/common/elasticache/elasticache.tf
+++ b/environments/common/elasticache/elasticache.tf
@@ -6,9 +6,10 @@ resource "aws_elasticache_replication_group" "this" {
   automatic_failover_enabled = true
   apply_immediately          = var.apply_immediately
 
-  engine         = "redis"
-  engine_version = var.redis_version
-  port           = 6739
+  engine               = "redis"
+  engine_version       = var.redis_version
+  port                 = 6739
+  parameter_group_name = var.parameter_group
 
   at_rest_encryption_enabled = true
   kms_key_id                 = aws_kms_key.this.arn

--- a/environments/common/elasticache/outputs.tf
+++ b/environments/common/elasticache/outputs.tf
@@ -1,0 +1,9 @@
+output "endpoint" {
+  description = "Configuration endpoint of the replication group."
+  value       = aws_elasticache_replication_group.this.configuration_endpoint_address
+}
+
+output "replication_group_arn" {
+  description = "ARN of the replication group."
+  value       = aws_elasticache_replication_group.this.arn
+}

--- a/environments/common/elasticache/outputs.tf
+++ b/environments/common/elasticache/outputs.tf
@@ -7,3 +7,8 @@ output "replication_group_arn" {
   description = "ARN of the replication group."
   value       = aws_elasticache_replication_group.this.arn
 }
+
+output "replica_arns" {
+  description = "List of ARNs of the replica nodes."
+  value       = aws_elasticache_cluster.replica[*].arn
+}

--- a/environments/common/elasticache/variables.tf
+++ b/environments/common/elasticache/variables.tf
@@ -1,0 +1,63 @@
+variable "group_name" {
+  description = "Name of the replication group."
+  type        = string
+}
+
+variable "apply_immediately" {
+  description = "Whether to apply changes to the replication group immediately (`true`), or to wait for the next maintenance window (`false`)."
+  type        = bool
+  default     = false
+}
+
+variable "redis_version" {
+  description = "Engine version to use."
+  type        = string
+}
+
+variable "environment" {
+  description = "Deployment environment (i.e., `development`, `staging`, `production`)."
+  type        = string
+}
+
+variable "region" {
+  description = "AWS region to use."
+  type        = string
+}
+
+variable "instance_type" {
+  description = "Instance type, i.e. `cache.t3.small`."
+  type        = string
+}
+
+variable "replicas" {
+  description = "Number of replicas to create. Defaults to `0`."
+  type        = number
+  default     = 0
+}
+
+variable "cloudwatch_log_group" {
+  description = "Cloudwatch log group name for logs to flow into."
+  type        = string
+}
+
+variable "maintenance_window" {
+  description = "The weekly time range for maintenance periods on the cluster. Format: `ddd:hh22:mi-ddd:hh23:mi` (UTC). Minimum period must be 60 minutes. For example, `sun:05:00-sun:06:00`."
+  type        = string
+}
+
+variable "snapshot_window" {
+  description = "Daily time range during which ElastiCache will take a snapshot of the cache cluster. Minimum time of 60 minutes. For example: `05:00-06:00`."
+  type        = string
+}
+
+variable "security_group_names" {
+  description = "List of security group names to associate with the group."
+  type        = list(string)
+  default     = null
+}
+
+variable "transit_encryption_enabled" {
+  description = "Whether to enable encryption in transit. Defaults to `true`."
+  type        = bool
+  default     = true
+}

--- a/environments/common/elasticache/variables.tf
+++ b/environments/common/elasticache/variables.tf
@@ -61,3 +61,8 @@ variable "transit_encryption_enabled" {
   type        = bool
   default     = true
 }
+
+variable "parameter_group" {
+  description = "Parameter group for replication group. For example, `default.redis3.2.cluster.on`."
+  type        = string
+}

--- a/environments/common/elasticache/versions.tf
+++ b/environments/common/elasticache/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.4.6"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4" # Don't upgrade to 5.x.x yet
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}

--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -35,6 +35,7 @@ No outputs.
 
 | Name | Version |
 |------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.67.0 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
@@ -46,11 +47,14 @@ No outputs.
 | <a name="module_alb-security-group"></a> [alb-security-group](#module\_alb-security-group) | ../../common/security-group/ | n/a |
 | <a name="module_ecr"></a> [ecr](#module\_ecr) | ../../common/ecr/ | n/a |
 | <a name="module_postgres"></a> [postgres](#module\_postgres) | ../../common/rds | n/a |
+| <a name="module_redis"></a> [redis](#module\_redis) | ../../common/elasticache/ | n/a |
 
 ## Resources
 
 | Name | Type |
 |------|------|
+| [aws_cloudwatch_log_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_kms_key.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [terraform_remote_state.base](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 
 ## Inputs
@@ -63,7 +67,7 @@ No outputs.
 | <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | Name of the test Domain | `string` | `"transformtariff.co.uk"` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Build environment | `string` | `"development"` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region to use. Defaults to `eu-west-2`. | `string` | `"eu-west-2"` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to the resource | `map(string)` | <pre>{<br>  "name": "elastic-container-registery"<br>}</pre> | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to resources. | `map(string)` | <pre>{<br>  "Terraform": true<br>}</pre> | no |
 
 ## Outputs
 

--- a/environments/development/common/cloudwatch.tf
+++ b/environments/development/common/cloudwatch.tf
@@ -1,0 +1,13 @@
+resource "aws_cloudwatch_log_group" "this" {
+  name              = "trade-tariff-logs-${var.environment}"
+  retention_in_days = 7
+  skip_destroy      = true
+  kms_key_id        = aws_kms_key.this.arn
+}
+
+resource "aws_kms_key" "this" {
+  description             = "KMS key to encrypt CloudWatch logs."
+  deletion_window_in_days = 10
+  key_usage               = "ENCRYPT_DECRYPT"
+  enable_key_rotation     = true
+}

--- a/environments/development/common/redis.tf
+++ b/environments/development/common/redis.tf
@@ -1,0 +1,17 @@
+module "redis" {
+  source = "../../common/elasticache/"
+
+  environment = var.environment
+  region      = var.region
+
+  cloudwatch_log_group = aws_cloudwatch_log_group.this.name
+
+  group_name      = "tariff-redis-${var.environment}"
+  redis_version   = "5.0.6"
+  instance_type   = "cache.t3.micro"
+  parameter_group = "default.redis5.0.cluster.on"
+  replicas        = 1
+
+  maintenance_window = "sun:00:00-sun:03:00"
+  snapshot_window    = "sun:04:00-sun:06:00"
+}

--- a/environments/development/common/redis.tf
+++ b/environments/development/common/redis.tf
@@ -13,5 +13,5 @@ module "redis" {
   replicas        = 1
 
   maintenance_window = "sun:00:00-sun:03:00"
-  snapshot_window    = "sun:04:00-sun:06:00"
+  snapshot_window    = "00:00-02:00"
 }

--- a/environments/development/common/redis.tf
+++ b/environments/development/common/redis.tf
@@ -13,5 +13,5 @@ module "redis" {
   replicas        = 1
 
   maintenance_window = "sun:00:00-sun:03:00"
-  snapshot_window    = "00:00-02:00"
+  snapshot_window    = "04:00-06:00"
 }

--- a/environments/development/common/variables.tf
+++ b/environments/development/common/variables.tf
@@ -28,12 +28,6 @@ variable "alb_name" {
   default     = "trade-tariff-alb"
 }
 
-# variable "public_subnet_id" {
-#   description = "The name of the alb"
-#   type        = string
-#   default     = "VPC public subnet"
-# }
-
 variable "aws_account_id" {
   description = "Development Account ID."
   type        = string
@@ -41,9 +35,9 @@ variable "aws_account_id" {
 }
 
 variable "tags" {
-  description = "A map of tags to assign to the resource"
+  description = "A map of tags to assign to resources."
   type        = map(string)
   default = {
-    name = "elastic-container-registery",
+    Terraform = true
   }
 }


### PR DESCRIPTION
# Pull Request

This pull request forms part of [HOTT-2782](https://transformuk.atlassian.net/browse/HOTT-2782).

## What?

I have:

- Added an ElastiCache replication group resource with replica support. This has defaults baked-in for Redis.

## Why?

I am doing this because:

- Redis is a requirement for the applications, so we need that up and running first.