### PR TITLE
BAU: Add depends_on block for cloudwatch key

### DIFF
--- a/environments/development/common/cloudwatch.tf
+++ b/environments/development/common/cloudwatch.tf
@@ -3,6 +3,7 @@ resource "aws_cloudwatch_log_group" "this" {
   retention_in_days = 7
   skip_destroy      = true
   kms_key_id        = aws_kms_key.this.arn
+  depends_on        = [aws_kms_key.this]
 }
 
 resource "aws_kms_key" "this" {


### PR DESCRIPTION
# Pull Request

PR to fix the interaction between the KMS key and the Cloudwatch log group.

## What?

I have:

- Added a `depends_on` block on the CW group

## Why?

I am doing this because:

- There's a race condition between the two resources, but one of them does actually rely on the other or we get weird output.
- It's better that I just fix this now instead of having to run apply twice down the road.