### PR TITLE
BAU: Update Cloudwatch KMS key policy

### DIFF
--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -54,8 +54,8 @@ No outputs.
 | Name | Type |
 |------|------|
 | [aws_cloudwatch_log_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_kms_alias.cloudwatch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_key.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [terraform_remote_state.base](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 
 ## Inputs

--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -56,6 +56,7 @@ No outputs.
 | [aws_cloudwatch_log_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_kms_alias.cloudwatch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_key.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_kms_key_policy.cloudwatch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key_policy) | resource |
 | [terraform_remote_state.base](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 
 ## Inputs

--- a/environments/development/common/cloudwatch.tf
+++ b/environments/development/common/cloudwatch.tf
@@ -21,7 +21,8 @@ resource "aws_kms_alias" "cloudwatch" {
 resource "aws_kms_key_policy" "cloudwatch" {
   key_id = aws_kms_key.this.id
   policy = jsonencode({
-    Effect = "Allow",
+    Version = "2012-10-17",
+    Effect  = "Allow",
     Principal = {
       Service = "logs.${var.region}.amazonaws.com"
     },

--- a/environments/development/common/cloudwatch.tf
+++ b/environments/development/common/cloudwatch.tf
@@ -11,6 +11,15 @@ resource "aws_kms_key" "this" {
   deletion_window_in_days = 10
   key_usage               = "ENCRYPT_DECRYPT"
   enable_key_rotation     = true
+}
+
+resource "aws_kms_alias" "cloudwatch" {
+  name          = "alias/cloudwatch-${var.environment}"
+  target_key_id = aws_kms_key.this.key_id
+}
+
+resource "aws_kms_key_policy" "cloudwatch" {
+  key_id = aws_kms_key.this.id
   policy = jsonencode({
     Effect = "Allow",
     Principal = {
@@ -25,9 +34,4 @@ resource "aws_kms_key" "this" {
     ],
     Resource = aws_kms_key.this.arn
   })
-}
-
-resource "aws_kms_alias" "cloudwatch" {
-  name          = "alias/cloudwatch-${var.environment}"
-  target_key_id = aws_kms_key.this.key_id
 }

--- a/environments/development/common/cloudwatch.tf
+++ b/environments/development/common/cloudwatch.tf
@@ -23,11 +23,11 @@ resource "aws_kms_key" "this" {
       "kms:GenerateDataKey*",
       "kms:Describe*"
     ],
-    Resource = "*",
-    Condition = {
-      ArnEquals = {
-        "kms:EncryptionContext:aws:logs:arn" : "arn:aws:logs:${var.region}:${local.account_id}:*"
-      }
-    }
+    Resource = aws_kms_key.this.arn
   })
+}
+
+resource "aws_kms_alias" "cloudwatch" {
+  name          = "alias/cloudwatch-${var.environment}"
+  target_key_id = aws_kms_key.this.key_id
 }

--- a/environments/development/common/locals.tf
+++ b/environments/development/common/locals.tf
@@ -1,5 +1,0 @@
-data "aws_caller_identity" "current" {}
-
-locals {
-  account_id = data.aws_caller_identity.current.account_id
-}


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Removed `condition` block in key policy
- Specify key arn in `resource` block
- Add key alias
- Remove unused `locals.tf`

## Why?

I am doing this because:

- The previous PR left us with a `MalformedPolicyDocument` exception. I realised after this applied that what I did was actually more complicated than just specifying the key arn.
- We should have key aliases on our keys; I haven't updated all of them but I will do this in a second/later PR as if we need to look at keys via the AWS CLI or console they are all just specified by ID and that's not useful to us.
