### PR TITLE
FIX: KMS Key(s)

### DIFF
--- a/environments/common/cloudwatch/README.md
+++ b/environments/common/cloudwatch/README.md
@@ -26,13 +26,13 @@ No modules.
 | [aws_kms_key.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_kms_key_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key_policy) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_name"></a> [name](#input\_name) | Name of the log group. | `string` | n/a | yes |
-| <a name="input_region"></a> [region](#input\_region) | AWS region to use. | `string` | n/a | yes |
 | <a name="input_retention_in_days"></a> [retention\_in\_days](#input\_retention\_in\_days) | Retention time in days. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653. Defaults to 0: that is, no expiry. | `number` | `0` | no |
 
 ## Outputs

--- a/environments/common/cloudwatch/cloudwatch.tf
+++ b/environments/common/cloudwatch/cloudwatch.tf
@@ -3,7 +3,10 @@ resource "aws_cloudwatch_log_group" "this" {
   retention_in_days = var.retention_in_days
   skip_destroy      = true
   kms_key_id        = aws_kms_key.this.arn
-  depends_on        = [aws_kms_key.this]
+  depends_on = [
+    aws_kms_key.this,
+    aws_kms_key_policy.this
+  ]
 }
 
 resource "aws_kms_key" "this" {
@@ -34,7 +37,7 @@ resource "aws_kms_key_policy" "this" {
       {
         Effect = "Allow",
         Principal = {
-          Service = "logs.${var.region}.amazonaws.com"
+          Service = "logs.${local.region}.amazonaws.com"
         },
         Action = [
           "kms:Encrypt*",
@@ -46,7 +49,7 @@ resource "aws_kms_key_policy" "this" {
         Resource = "*",
         Condition = {
           ArnEquals = {
-            "kms:EncryptionContext:aws:logs:arn" = aws_cloudwatch_log_group.this.arn
+            "kms:EncryptionContext:aws:logs:arn" = "arn:aws:logs:${local.region}:${local.account_id}:log-group:${var.name}"
           }
         }
     }]

--- a/environments/common/cloudwatch/locals.tf
+++ b/environments/common/cloudwatch/locals.tf
@@ -1,5 +1,8 @@
 data "aws_caller_identity" "current" {}
 
+data "aws_region" "current" {}
+
 locals {
   account_id = data.aws_caller_identity.current.account_id
+  region     = data.aws_region.current.name
 }

--- a/environments/common/cloudwatch/variables.tf
+++ b/environments/common/cloudwatch/variables.tf
@@ -3,11 +3,6 @@ variable "name" {
   type        = string
 }
 
-variable "region" {
-  description = "AWS region to use."
-  type        = string
-}
-
 variable "retention_in_days" {
   description = "Retention time in days. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653. Defaults to 0: that is, no expiry."
   type        = number

--- a/environments/common/cloudwatch/versions.tf
+++ b/environments/common/cloudwatch/versions.tf
@@ -7,5 +7,3 @@ terraform {
     }
   }
 }
-
-provider "aws" {}

--- a/environments/common/cloudwatch/versions.tf
+++ b/environments/common/cloudwatch/versions.tf
@@ -8,6 +8,4 @@ terraform {
   }
 }
 
-provider "aws" {
-  region = var.region
-}
+provider "aws" {}

--- a/environments/common/ecr/ecr.tf
+++ b/environments/common/ecr/ecr.tf
@@ -3,7 +3,6 @@ resource "aws_kms_key" "ecr_kms" {
   enable_key_rotation = true
 }
 
-
 # tfsec:ignore:aws-ecr-enforce-immutable-repository
 resource "aws_ecr_repository" "trade_tariff_ecr_repo" {
   name                 = "trade-tariff-ecr-${var.environment}"
@@ -17,6 +16,6 @@ resource "aws_ecr_repository" "trade_tariff_ecr_repo" {
 
   encryption_configuration {
     encryption_type = "KMS"
-    kms_key         = aws_kms_key.ecr_kms.key_id
+    kms_key         = aws_kms_key.ecr_kms.arn
   }
 }

--- a/environments/development/common/cloudwatch.tf
+++ b/environments/development/common/cloudwatch.tf
@@ -2,5 +2,4 @@ module "cloudwatch" {
   source            = "../../common/cloudwatch/"
   name              = "platform-logs-${var.environment}"
   retention_in_days = 30
-  region            = var.region
 }


### PR DESCRIPTION
# Pull Request

## What?

I have:

1. Changed the `kms_key` input to the ECR resource to use the key ARN.
2. Created the KMS key policy for the CloudWatch log group key using only string interpolation.
3. Removed redundant `var.region` and AWS provider blocks.

## Why?

I am doing this because:

1. The resource can take either the `key_id` or ARN, but converts either to an ARN. On subsequent runs, using the `key_id` will produce a diff, and Terraform will destroy and recreate the resource on every run. By using the ARN, the value isn't changing on each apply, so there's no diff.
2. There was, despite a `depends_on` block, a reference to the CloudWatch log group resource in the KMS key policy. This meant that there was a circular dependency - one not picked up by `terraform validate`. The policy couldn't be created until the log group was, but the policy needs to have the ARN of the log group in order for the key to be able to be used with the log group. This led to consistent `AccessDeniedException`s at apply-time.
3. By using the data source for the AWS region, I was able to remove `var.region` from the module, as it's set at runtime.
