### PR TITLE
BAU: Fix log_delivery through dynamic blocks

### DIFF
--- a/environments/common/elasticache/elasticache.tf
+++ b/environments/common/elasticache/elasticache.tf
@@ -23,19 +23,28 @@ resource "aws_elasticache_replication_group" "this" {
   security_group_names       = var.security_group_names
   transit_encryption_enabled = var.transit_encryption_enabled
 
-  log_delivery_configuration {
-    destination      = var.cloudwatch_log_group
-    destination_type = "cloudwatch-logs"
-    log_format       = "json"
-    log_type         = "slow-log"
+  # Logging requires Redis >=6.0 (SLOWLOG), and >=6.2 (engine log)
+  # https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Log_Delivery.html
+
+  dynamic "log_delivery_configuration" {
+    for_each = var.redis_version >= 6 && var.cloudwatch_log_group != null ? [1] : []
+    content {
+      destination      = var.cloudwatch_log_group
+      destination_type = "cloudwatch-logs"
+      log_format       = "json"
+      log_type         = "slow-log"
+    }
   }
 
-  # log_delivery_configuration {
-  #   destination      = aws_kinesis_firehose_delivery_stream.example.name
-  #   destination_type = "kinesis-firehose"
-  #   log_format       = "json"
-  #   log_type         = "engine-log"
-  # }
+  dynamic "log_delivery_configuration" {
+    for_each = var.redis_version >= 6.2 && var.cloudwatch_log_group != null ? [1] : []
+    content {
+      destination      = var.cloudwatch_log_group
+      destination_type = "cloudwatch-logs"
+      log_format       = "json"
+      log_type         = "engine-log"
+    }
+  }
 
   lifecycle {
     ignore_changes = [num_cache_clusters]

--- a/environments/common/elasticache/elasticache.tf
+++ b/environments/common/elasticache/elasticache.tf
@@ -27,7 +27,7 @@ resource "aws_elasticache_replication_group" "this" {
   # https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Log_Delivery.html
 
   dynamic "log_delivery_configuration" {
-    for_each = var.redis_version >= 6 && var.cloudwatch_log_group != null ? [1] : []
+    for_each = local.redis_major_version >= 6 && var.cloudwatch_log_group != null ? [1] : []
     content {
       destination      = var.cloudwatch_log_group
       destination_type = "cloudwatch-logs"
@@ -37,7 +37,7 @@ resource "aws_elasticache_replication_group" "this" {
   }
 
   dynamic "log_delivery_configuration" {
-    for_each = var.redis_version >= 6.2 && var.cloudwatch_log_group != null ? [1] : []
+    for_each = local.redis_major_version >= 6 && local.redis_minor_version >= 2 && var.cloudwatch_log_group != null ? [1] : []
     content {
       destination      = var.cloudwatch_log_group
       destination_type = "cloudwatch-logs"

--- a/environments/common/elasticache/locals.tf
+++ b/environments/common/elasticache/locals.tf
@@ -1,0 +1,4 @@
+locals {
+  redis_major_version = tonumber(split(".", var.redis_version)[0])
+  redis_minor_version = tonumber(split(".", var.redis_version)[1])
+}


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Added `dynamic` blocks for `log_delivery_configuration`.

## Why?

I am doing this because:

- SLOWLOG requires Redis >=6.0
- Engine log requires Redis >=6.2

- Currently, we are using 5.0.6, but we may change upward in future so I'm leaving support for log delivery in the module.

