### PR TITLE
BAU: Fix ElastiCache cluster mode

### DIFF
--- a/environments/common/elasticache/README.md
+++ b/environments/common/elasticache/README.md
@@ -24,7 +24,6 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_elasticache_cluster.replica](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_cluster) | resource |
 | [aws_elasticache_replication_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_replication_group) | resource |
 | [aws_kms_key.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 
@@ -41,8 +40,9 @@ No modules.
 | <a name="input_parameter_group"></a> [parameter\_group](#input\_parameter\_group) | Parameter group for replication group. For example, `default.redis3.2.cluster.on`. | `string` | n/a | yes |
 | <a name="input_redis_version"></a> [redis\_version](#input\_redis\_version) | Engine version to use. | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | AWS region to use. | `string` | n/a | yes |
-| <a name="input_replicas"></a> [replicas](#input\_replicas) | Number of replicas to create. Defaults to `0`. | `number` | `0` | no |
+| <a name="input_replicas"></a> [replicas](#input\_replicas) | Number of replicas to create, between 0 (none) and 5. Defaults to `0`. | `number` | `0` | no |
 | <a name="input_security_group_names"></a> [security\_group\_names](#input\_security\_group\_names) | List of security group names to associate with the group. | `list(string)` | `null` | no |
+| <a name="input_shards"></a> [shards](#input\_shards) | Number of node groups (shards) for this group. Defaults to `1`. | `number` | `1` | no |
 | <a name="input_snapshot_window"></a> [snapshot\_window](#input\_snapshot\_window) | Daily time range during which ElastiCache will take a snapshot of the cache cluster. Minimum time of 60 minutes. For example: `05:00-06:00`. | `string` | n/a | yes |
 | <a name="input_transit_encryption_enabled"></a> [transit\_encryption\_enabled](#input\_transit\_encryption\_enabled) | Whether to enable encryption in transit. Defaults to `true`. | `bool` | `true` | no |
 
@@ -51,6 +51,4 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_endpoint"></a> [endpoint](#output\_endpoint) | Configuration endpoint of the replication group. |
-| <a name="output_replica_arns"></a> [replica\_arns](#output\_replica\_arns) | List of ARNs of the replica nodes. |
-| <a name="output_replication_group_arn"></a> [replication\_group\_arn](#output\_replication\_group\_arn) | ARN of the replication group. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/environments/common/elasticache/elasticache.tf
+++ b/environments/common/elasticache/elasticache.tf
@@ -16,9 +16,10 @@ resource "aws_elasticache_replication_group" "this" {
 
   maintenance_window = var.maintenance_window
   snapshot_window    = var.snapshot_window
-
-  num_cache_clusters = 2
   node_type          = var.instance_type
+
+  num_node_groups         = var.shards
+  replicas_per_node_group = var.replicas
 
   security_group_names       = var.security_group_names
   transit_encryption_enabled = var.transit_encryption_enabled
@@ -45,20 +46,10 @@ resource "aws_elasticache_replication_group" "this" {
       log_type         = "engine-log"
     }
   }
-
-  lifecycle {
-    ignore_changes = [num_cache_clusters]
-  }
 }
 
 resource "aws_kms_key" "this" {
   description         = "KMS key for Redis on ${var.environment}."
   key_usage           = "ENCRYPT_DECRYPT"
   enable_key_rotation = true
-}
-
-resource "aws_elasticache_cluster" "replica" {
-  count                = var.replicas
-  cluster_id           = "replica-${count.index}"
-  replication_group_id = aws_elasticache_replication_group.this.id
 }

--- a/environments/common/elasticache/outputs.tf
+++ b/environments/common/elasticache/outputs.tf
@@ -2,13 +2,3 @@ output "endpoint" {
   description = "Configuration endpoint of the replication group."
   value       = aws_elasticache_replication_group.this.configuration_endpoint_address
 }
-
-output "replication_group_arn" {
-  description = "ARN of the replication group."
-  value       = aws_elasticache_replication_group.this.arn
-}
-
-output "replica_arns" {
-  description = "List of ARNs of the replica nodes."
-  value       = aws_elasticache_cluster.replica[*].arn
-}

--- a/environments/common/elasticache/variables.tf
+++ b/environments/common/elasticache/variables.tf
@@ -29,8 +29,14 @@ variable "instance_type" {
   type        = string
 }
 
+variable "shards" {
+  description = "Number of node groups (shards) for this group. Defaults to `1`."
+  type        = number
+  default     = 1
+}
+
 variable "replicas" {
-  description = "Number of replicas to create. Defaults to `0`."
+  description = "Number of replicas to create, between 0 (none) and 5. Defaults to `0`."
   type        = number
   default     = 0
 }

--- a/environments/development/common/redis.tf
+++ b/environments/development/common/redis.tf
@@ -10,7 +10,9 @@ module "redis" {
   redis_version   = "5.0.6"
   instance_type   = "cache.t3.micro"
   parameter_group = "default.redis5.0.cluster.on"
-  replicas        = 1
+
+  shards   = 2
+  replicas = 1
 
   maintenance_window = "sun:00:00-sun:03:00"
   snapshot_window    = "04:00-06:00"


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Updated `aws_elasticache_replica_group` to use `num_node_groups` and `replicas_per_node_group`.
- Removed the `aws_elasticache_cluster.replica` resource.
- Removed unused outputs.

## Why?

I am doing this because:

- The documentation was confusing: when using Redis in cluster mode, you need to use `num_node_groups` and `replicas_per_node_group`, to create shards with primary and read replicas respectively.
- The previous configuration was configured for Redis with cluster mode _disabled_, with fine-grained control of the replicas. However, we _don't_ wish to do this as we want automatic cluster failover.