### PR TITLE
BAU: Put ECR repo URL into SSM for consumption

### DIFF
--- a/environments/common/ecr/README.md
+++ b/environments/common/ecr/README.md
@@ -35,5 +35,7 @@ No modules.
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_repository_url"></a> [repository\_url](#output\_repository\_url) | ECR repository URL |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/environments/common/ecr/ecr.tf
+++ b/environments/common/ecr/ecr.tf
@@ -19,3 +19,8 @@ resource "aws_ecr_repository" "trade_tariff_ecr_repo" {
     kms_key         = aws_kms_key.ecr_kms.arn
   }
 }
+
+output "repository_url" {
+  description = "ECR repository URL"
+  value       = aws_ecr_repository.trade_tariff_ecr_repo.repository_url
+}

--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -35,6 +35,7 @@ No outputs.
 
 | Name | Version |
 |------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.67.0 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
@@ -53,6 +54,7 @@ No outputs.
 
 | Name | Type |
 |------|------|
+| [aws_ssm_parameter.ecr_url](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [terraform_remote_state.base](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 
 ## Inputs

--- a/environments/development/common/ecr.tf
+++ b/environments/development/common/ecr.tf
@@ -3,3 +3,11 @@ module "ecr" {
   tags        = var.tags
   environment = var.environment
 }
+
+resource "aws_ssm_parameter" "ecr_url" {
+  name        = "/${var.environment}/ECR_URL"
+  description = "ECR repository URL for ${var.environment}."
+  type        = "SecureString"
+  value       = module.ecr.repository_url
+  tags        = var.tags
+}


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Made an output for the `repository_url` for the ECR module.
- Added an SSM parameter for this output.

## Why?

I am doing this because:

- We need the applications to be able to fetch this using the AWS CLI, so that we can amend the CI for each application to put images into the new environments.
