### PR TITLE
BAU: Create ECR repository for each image

### DIFF
--- a/environments/common/ecr/README.md
+++ b/environments/common/ecr/README.md
@@ -22,8 +22,8 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_ecr_repository.trade_tariff_ecr_repo](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
-| [aws_kms_key.ecr_kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_ecr_repository.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
+| [aws_kms_key.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 
 ## Inputs
 
@@ -37,5 +37,5 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_repository_url"></a> [repository\_url](#output\_repository\_url) | ECR repository URL |
+| <a name="output_repository_urls"></a> [repository\_urls](#output\_repository\_urls) | Map of ECR repository URLs, sorted by service. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/environments/common/ecr/README.md
+++ b/environments/common/ecr/README.md
@@ -23,6 +23,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_ecr_repository.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository) | resource |
+| [aws_kms_alias.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_key.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 
 ## Inputs

--- a/environments/common/ecr/ecr.tf
+++ b/environments/common/ecr/ecr.tf
@@ -3,13 +3,9 @@ resource "aws_kms_key" "this" {
   enable_key_rotation = true
 }
 
-locals {
-  applications = [
-    "frontend",
-    "backend",
-    "duty-calculator",
-    "admin"
-  ]
+resource "aws_kms_alias" "this" {
+  name          = "alias/ecr-kms-key"
+  target_key_id = aws_kms_key.this.key_id
 }
 
 # tfsec:ignore:aws-ecr-enforce-immutable-repository

--- a/environments/common/ecr/locals.tf
+++ b/environments/common/ecr/locals.tf
@@ -1,0 +1,8 @@
+locals {
+  applications = [
+    "frontend",
+    "backend",
+    "duty-calculator",
+    "admin"
+  ]
+}

--- a/environments/common/ecr/locals.tf
+++ b/environments/common/ecr/locals.tf
@@ -1,8 +1,9 @@
 locals {
   applications = [
-    "frontend",
+    "admin",
     "backend",
     "duty-calculator",
-    "admin"
+    "frontend",
+    "search-query-parser",
   ]
 }

--- a/environments/development/common/ecr.tf
+++ b/environments/development/common/ecr.tf
@@ -5,9 +5,10 @@ module "ecr" {
 }
 
 resource "aws_ssm_parameter" "ecr_url" {
-  name        = "/${var.environment}/ECR_URL"
-  description = "ECR repository URL for ${var.environment}."
+  for_each    = module.ecr.repository_urls
+  name        = "/${var.environment}/${upper(each.key)}_ECR_URL"
+  description = "${title(each.key)} ECR repository URL for ${var.environment}."
   type        = "SecureString"
-  value       = module.ecr.repository_url
+  value       = each.value
   tags        = var.tags
 }

--- a/environments/development/common/ecr.tf
+++ b/environments/development/common/ecr.tf
@@ -6,7 +6,7 @@ module "ecr" {
 
 resource "aws_ssm_parameter" "ecr_url" {
   for_each    = module.ecr.repository_urls
-  name        = "/${var.environment}/${upper(each.key)}_ECR_URL"
+  name        = "/${var.environment}/${replace(upper(each.key), "-", "_")}_ECR_URL"
   description = "${title(each.key)} ECR repository URL for ${var.environment}."
   type        = "SecureString"
   value       = each.value


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Changed the ECR module to create a repository for each of the applications;
  - `admin`
  - `backend`
  - `duty-calculator`
  - `frontend`
  - `search-query-parser`

## Why?

I am doing this because:

- After working on [HOTT-3513](https://github.com/trade-tariff/trade-tariff-frontend/pull/1503), I have come to the realisation that we do need a repository for each separate image. This is why I am getting the error 'EOF' from docker push commands.


### Other notes

- Whilst here, I've also changed resource names to `this`; they are in a module and there is only one of each resource type, so do not need special names, as they'll be referenced by the module call in each environment they are used in - this also conforms to Anton's best practices.
