### PR TITLE
HOTT-3515: Add AWS Secrets Manager Secrets

### DIFF
--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -54,6 +54,12 @@ No outputs.
 
 | Name | Type |
 |------|------|
+| [aws_kms_alias.secretsmanager_kms_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
+| [aws_kms_key.secretsmanager_kms_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_secretsmanager_secret.postgres_connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret.redis_connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret_version.postgres_connection_string_value](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
+| [aws_secretsmanager_secret_version.redis_connection_string_value](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_ssm_parameter.ecr_url](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [terraform_remote_state.base](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 

--- a/environments/development/common/kms.tf
+++ b/environments/development/common/kms.tf
@@ -1,0 +1,11 @@
+resource "aws_kms_key" "secretsmanager_kms_key" {
+  description             = "KMS key for encrypting Secrets Manager secrets."
+  deletion_window_in_days = 10
+  key_usage               = "ENCRYPT_DECRYPT"
+  enable_key_rotation     = true
+}
+
+resource "aws_kms_alias" "secretsmanager_kms_alias" {
+  name          = "alias/secretsmanager-key"
+  target_key_id = aws_kms_key.secretsmanager_kms_key.key_id
+}

--- a/environments/development/common/rds.tf
+++ b/environments/development/common/rds.tf
@@ -15,3 +15,13 @@ module "postgres" {
   region      = var.region
   environment = var.environment
 }
+
+resource "aws_secretsmanager_secret" "postgres_connection_string" {
+  name       = "postgres-connection-string"
+  kms_key_id = aws_kms_key.secretsmanager_kms_key.arn
+}
+
+resource "aws_secretsmanager_secret_version" "postgres_connection_string_value" {
+  secret_id     = aws_secretsmanager_secret.postgres_connection_string.id
+  secret_string = module.postgres.db_endpoint
+}

--- a/environments/development/common/redis.tf
+++ b/environments/development/common/redis.tf
@@ -17,3 +17,13 @@ module "redis" {
   maintenance_window = "sun:00:00-sun:03:00"
   snapshot_window    = "04:00-06:00"
 }
+
+resource "aws_secretsmanager_secret" "redis_connection_string" {
+  name       = "redis-connection-string"
+  kms_key_id = aws_kms_key.secretsmanager_kms_key.arn
+}
+
+resource "aws_secretsmanager_secret_version" "redis_connection_string_value" {
+  secret_id     = aws_secretsmanager_secret.redis_connection_string.id
+  secret_string = module.redis.endpoint
+}


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Added `aws_secretsmanager_secret`s for the Redis and Postgres connection strings.
- Added a KMS key to encrypt these secrets, with an alias.

## Why?

I am doing this because:

- The ElastiCache Cluster and Postgres instance provide connection strings that will need to be given to the applications, so we should create these as AWS SecretsManager secrets that we can decrypt and pass to the application-level Terraform. ECS can fetch these values if passed to the secrets config.