### PR TITLE
HOTT-3143: Fix OpenSearch/bucket creation

### DIFF
--- a/environments/development/common/cloudwatch.tf
+++ b/environments/development/common/cloudwatch.tf
@@ -14,6 +14,9 @@ module "logs" {
   bucket = "trade-tariff-logs-${local.account_id}"
   acl    = "log-delivery-write"
 
+  control_object_ownership = true
+  object_ownership         = "ObjectWriter"
+
   server_side_encryption_configuration = {
     rule = {
       apply_server_side_encryption_by_default = {

--- a/environments/development/common/opensearch.tf
+++ b/environments/development/common/opensearch.tf
@@ -32,6 +32,9 @@ module "opensearch_packages_bucket" {
     }
   }
 
+  control_object_ownership = true
+  object_ownership         = "ObjectWriter"
+
   logging = {
     target_bucket = module.logs.s3_bucket_id
     target_prefix = "log/"
@@ -55,6 +58,9 @@ module "search_configuration_bucket" {
       }
     }
   }
+
+  control_object_ownership = true
+  object_ownership         = "ObjectWriter"
 
   logging = {
     target_bucket = module.logs.s3_bucket_id

--- a/environments/development/common/opensearch.tf
+++ b/environments/development/common/opensearch.tf
@@ -75,7 +75,8 @@ module "opensearch" {
   instance_type           = "t3.small.search" # small one for dev :)
   ebs_volume_size         = 80
 
-  create_master_user = true
-  encrypt_kms_key_id = aws_kms_key.opensearch_kms_key.key_id
-  ssm_secret_name    = "/${var.environment}/ELASTICSEARCH_URL"
+  create_service_role = true
+  create_master_user  = true
+  encrypt_kms_key_id  = aws_kms_key.opensearch_kms_key.key_id
+  ssm_secret_name     = "/${var.environment}/ELASTICSEARCH_URL"
 }


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Fixed bucket ACL creation failure
- Create OpenSearch service role

## Why?

I am doing this because:

- We need the service-linked IAM role so that we can create the OpenSearch domain
- The buckets won't allow ACLs because of a change made to S3, the module
documentation isn't actually that good here and doesn't point this out,
but we need to specify the object ownership: https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/pull/226