### PR TITLE
BAU: Reconfigure VPC to use a single NAT gateway

### DIFF
--- a/environments/development/base/README.md
+++ b/environments/development/base/README.md
@@ -27,10 +27,6 @@ No resources.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_availability_zone"></a> [availability\_zone](#input\_availability\_zone) | A list of AWS availability zones | `list(string)` | <pre>[<br>  "eu-west-2a",<br>  "eu-west-2b",<br>  "eu-west-2c"<br>]</pre> | no |
-| <a name="input_cidr_block"></a> [cidr\_block](#input\_cidr\_block) | n/a | `string` | `"10.0.0.0/16"` | no |
-| <a name="input_enable_dns_hostnames"></a> [enable\_dns\_hostnames](#input\_enable\_dns\_hostnames) | n/a | `string` | `"true"` | no |
-| <a name="input_enable_nat_gateway"></a> [enable\_nat\_gateway](#input\_enable\_nat\_gateway) | n/a | `string` | `"true"` | no |
-| <a name="input_enable_vpn_gateway"></a> [enable\_vpn\_gateway](#input\_enable\_vpn\_gateway) | n/a | `string` | `"true"` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Deployment environment. | `string` | `"development"` | no |
 | <a name="input_private_subnets"></a> [private\_subnets](#input\_private\_subnets) | A list of private subnets inside the VPC | `list(string)` | <pre>[<br>  "10.0.1.0/24",<br>  "10.0.2.0/24",<br>  "10.0.3.0/24"<br>]</pre> | no |
 | <a name="input_public_subnets"></a> [public\_subnets](#input\_public\_subnets) | A list of public subnets inside the VPC | `list(string)` | <pre>[<br>  "10.0.101.0/24",<br>  "10.0.102.0/24",<br>  "10.0.103.0/24"<br>]</pre> | no |

--- a/environments/development/base/variables.tf
+++ b/environments/development/base/variables.tf
@@ -4,11 +4,6 @@ variable "environment" {
   default     = "development"
 }
 
-variable "cidr_block" {
-  type    = string
-  default = "10.0.0.0/16"
-}
-
 variable "private_subnets" {
   description = "A list of private subnets inside the VPC"
   type        = list(string)
@@ -38,19 +33,4 @@ variable "availability_zone" {
 variable "region" {
   type    = string
   default = "eu-west-2"
-}
-
-variable "enable_nat_gateway" {
-  type    = string
-  default = "true"
-}
-
-variable "enable_vpn_gateway" {
-  type    = string
-  default = "true"
-}
-
-variable "enable_dns_hostnames" {
-  type    = string
-  default = "true"
 }

--- a/environments/development/base/vpc.tf
+++ b/environments/development/base/vpc.tf
@@ -3,15 +3,16 @@ module "vpc" {
   source = "github.com/trade-tariff/terraform-aws-vpc?ref=0ea859dd659701e6e8dda61e61c47629eeda5ba3"
 
   name = "trade_tariff_development_vpc"
-  cidr = var.cidr_block
+  cidr = "10.0.0.0/16"
 
   azs             = var.availability_zone
   private_subnets = var.private_subnets
   public_subnets  = var.public_subnets
 
-  enable_nat_gateway   = var.enable_nat_gateway
-  enable_vpn_gateway   = var.enable_vpn_gateway
-  enable_dns_hostnames = var.enable_dns_hostnames
+  enable_nat_gateway   = true
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+  single_nat_gateway   = true
 
   tags = {
     Terraform   = "true"


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Enabled `single_nat_gateway`.
- Removed VPN gateway. 
- Simplified the variables as there's some that are just being set with defaults so not needed.

## Why?

I am doing this because:

- We want a single NAT gateway in this configuration. 

