### PR TITLE
BAU: Allow egress out from ECS

### DIFF
--- a/environments/common/security-group/security-group.tf
+++ b/environments/common/security-group/security-group.tf
@@ -1,6 +1,7 @@
-/* application load balancer Security Group */
-/* This is to supress tfsec erroring allow all ingress traffic to the load balancer */
-#  tfsec:ignore:aws-ec2-no-public-ingress-sgr
+# application load balancer Security Group
+# This is to supress tfsec erroring allow all ingress traffic to the load balancer
+
+# tfsec:ignore:aws-ec2-no-public-ingress-sgr
 resource "aws_security_group" "alb_security_group" {
   name        = "trade-tariff-alb-security-group-${var.environment}"
   description = "Allow TLS inbound traffic"
@@ -29,25 +30,27 @@ resource "aws_security_group" "alb_security_group" {
 
 /* Security group for the ecs application */
 resource "aws_security_group" "ecs_security_group" {
-  name        = "trade-tariff-allipcation-security-group-${var.environment}"
-  description = "Allow TLS inbound traffic"
+  name        = "trade-tariff-ecs-security-group-${var.environment}"
+  description = "Allow TLS ingress, all egress"
   vpc_id      = data.terraform_remote_state.base.outputs.vpc_id
 
-  # ingres traffic from alb
+  # ingress traffic from alb
   ingress {
-    description     = "Https Access From Alb"
+    description     = "HTTPS Access From ALB"
     from_port       = 443
     to_port         = 8080
     protocol        = "tcp"
     security_groups = [aws_security_group.alb_security_group.id]
   }
 
+  # We want egress out to the public internet here
+  # tfsec:ignore:aws-ec2-no-public-egress-sgr
   egress {
-    description = "Allow All Egress From VPC"
+    description = "Allow All Egress"
     from_port   = 0
     to_port     = 0
-    protocol    = -1
-    cidr_blocks = [var.cidr_block]
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
   }
 
   tags = {


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Given the ECS security group egress the correct CIDR block to allow all egress traffic.

## Why?

I am doing this because:

- We need public egress here so that the ECS tasks can reach ECR and pull the container images they need to start.