### PR TITLE
BAU: Allow HTTP traffic through to ECS from ALB

### DIFF
--- a/environments/common/security-group/README.md
+++ b/environments/common/security-group/README.md
@@ -31,9 +31,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_allowed_ingress_traffic"></a> [allowed\_ingress\_traffic](#input\_allowed\_ingress\_traffic) | Ingress traffic allowed | `string` | `"0.0.0.0/0"` | no |
 | <a name="input_aws_account_id"></a> [aws\_account\_id](#input\_aws\_account\_id) | Development Account ID. | `string` | `"844815912454"` | no |
-| <a name="input_cidr_block"></a> [cidr\_block](#input\_cidr\_block) | VPC Cidr Block | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | Built environment. | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | AWS region. Defaults to `eu-west-2`. | `string` | `"eu-west-2"` | no |
 

--- a/environments/common/security-group/security-group.tf
+++ b/environments/common/security-group/security-group.tf
@@ -1,26 +1,27 @@
 # application load balancer Security Group
 # This is to supress tfsec erroring allow all ingress traffic to the load balancer
 
-# tfsec:ignore:aws-ec2-no-public-ingress-sgr
 resource "aws_security_group" "alb_security_group" {
   name        = "trade-tariff-alb-security-group-${var.environment}"
   description = "Allow TLS inbound traffic"
   vpc_id      = data.terraform_remote_state.base.outputs.vpc_id
 
+  # tfsec:ignore:aws-ec2-no-public-ingress-sgr
   ingress {
-    description = "https access"
+    description = "HTTPS Ingress from CDN"
     from_port   = 443
     to_port     = 443
     protocol    = "tcp"
-    cidr_blocks = [var.allowed_ingress_traffic]
+    cidr_blocks = ["0.0.0.0/0"]
   }
 
+  # tfsec:ignore:aws-ec2-no-public-egress-sgr
   egress {
     description = "Allow All Egress From VPC"
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = [var.cidr_block]
+    cidr_blocks = ["0.0.0.0/0"]
   }
 
   tags = {
@@ -31,16 +32,22 @@ resource "aws_security_group" "alb_security_group" {
 /* Security group for the ecs application */
 resource "aws_security_group" "ecs_security_group" {
   name        = "trade-tariff-ecs-security-group-${var.environment}"
-  description = "Allow TLS ingress, all egress"
+  description = "Allow HTTP/S ingress, all egress"
   vpc_id      = data.terraform_remote_state.base.outputs.vpc_id
 
   # ingress traffic from alb
   ingress {
-    description     = "HTTPS Access From ALB"
-    from_port       = 443
-    to_port         = 8080
-    protocol        = "tcp"
-    security_groups = [aws_security_group.alb_security_group.id]
+    description = "HTTP Access from ALB"
+    from_port   = 80
+    to_port     = 8080
+    protocol    = "tcp"
+  }
+
+  ingress {
+    description = "HTTPS Access From ALB"
+    from_port   = 443
+    to_port     = 8080
+    protocol    = "tcp"
   }
 
   # We want egress out to the public internet here

--- a/environments/common/security-group/variables.tf
+++ b/environments/common/security-group/variables.tf
@@ -9,17 +9,6 @@ variable "region" {
   default     = "eu-west-2"
 }
 
-variable "allowed_ingress_traffic" {
-  description = "Ingress traffic allowed"
-  type        = string
-  default     = "0.0.0.0/0"
-}
-
-variable "cidr_block" {
-  description = "VPC Cidr Block"
-  type        = string
-}
-
 variable "aws_account_id" {
   description = "Development Account ID."
   type        = string


### PR DESCRIPTION
# Pull Request

[ci skip] because I don't want this to apply over the other open PRs

## What?

I have:

- Added an ingress rule on the ECS security group to allow HTTP traffic on 80 from the load balancer through to 8080 on ECS.
- Removed VPC CIDR block variable.
 
## Why?

I am doing this because:

- We want HTTP traffic to be reach the applications from the load balancer, because the applications health checks are done by the load balancer - and can only be done over a non-TLS connection. This is the simplest way of digging ourselves out of that hole instead of making the applications terminate TLS.
- The egress rule that had the VPC CIDR block specified was wrong and needs to look like the below to work like the `ALLOW ALL` that we want it to:

```hcl
egress {
  from_port        = 0
  to_port          = 0
  protocol         = "-1"
  cidr_blocks      = ["0.0.0.0/0"]
}
```



