### PR TITLE
BAU: Decrease deregistration delay on targets

### DIFF
--- a/environments/common/application-load-balancer/alb.tf
+++ b/environments/common/application-load-balancer/alb.tf
@@ -28,6 +28,9 @@ resource "aws_lb_target_group" "trade_tariff_target_groups" {
   target_type = "ip"
   vpc_id      = var.vpc_id
 
+  deregistration_delay   = 60
+  connection_termination = true
+
   health_check {
     enabled             = true
     interval            = "10"


### PR DESCRIPTION


# Pull Request

## What?

_I have:_

- Set the deregistration delay of the target groups to 60 seconds.
- Turned on connection termination for the target groups once the delay is complete.

## Why?

_I am doing this because:_

- The default deregistration delay is 300 seconds, which is causing the draining of ECS services to take a long time. This makes the maximum time 60 seconds and terminates connections after that time is over. This puts the services into unused which allows ECS to terminate them.
- _"we don't generally have clients that keep connections alive for more than the duration of the request and requests that take more than 60s are rare and super problematic"_ - @willfish 
