### PR TITLE
HOTT-3600: Create Backend Secret(s)

### DIFF
--- a/environments/common/README.md
+++ b/environments/common/README.md
@@ -1,0 +1,3 @@
+# Modules
+
+Common modules shared across environments.

--- a/environments/common/secret/.terraform.lock.hcl
+++ b/environments/common/secret/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.7.0"
+  hashes = [
+    "h1:aa0gGxD4NVirhzUUbEngnG2Ag6fAsPMjIsivd/f2QVM=",
+    "zh:03240d7fc041d5331db7fd5f2ca4fe031321d07d2a6ca27085c5020dae13f211",
+    "zh:0b5252b14c354636fe0348823195dd901b457de1a033015f4a7d11cfe998c766",
+    "zh:2bfb62325b0487be8d1850a964f09cca0d45148faec577459c2a24334ec9977b",
+    "zh:2f9e317ffc57d2b5117cfe8dc266f88aa139b760bc93d8adeed7ad533a78b5a3",
+    "zh:36512725c9d7c559927b98fead04be58494a3a997e5270b905a75a468e307427",
+    "zh:5483e696d3ea764f746d3fe439f7dcc49001c3c774122d7baa51ce01011f0075",
+    "zh:5967635cc14f969ea26622863a2e3f9d6a7ddd3e7d35a29a7275c5e10579ac8c",
+    "zh:7e63c94a64af5b7aeb36ea6e3719962f65a7c28074532c02549a67212d410bb8",
+    "zh:8a7d5f33b11a3f5c7281413b431fa85de149ed8493ec1eea73d50d2d80a475e6",
+    "zh:8e2ed2d986aaf590975a79a2f6b5e60e0dc7d804ab01a8c03ab181e41cfe9b0f",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9c7b8ca1b17489f16a6d0f1fc2aa9c130978ea74c9c861d8435410567a0a888f",
+    "zh:a54385896a70524063f0c5420be26ff6f88909bd8e6902dd3e922577b21fd546",
+    "zh:aecd3a8fb70b938b58d93459bfb311540fd6aaf981924bf34abd48f953b4be0d",
+    "zh:f3de076fa3402768d27af0187c6a677777b47691d1f0f84c9b259ff66e65953e",
+  ]
+}

--- a/environments/common/secret/README.md
+++ b/environments/common/secret/README.md
@@ -1,0 +1,42 @@
+# secret
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.6 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.7.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_secretsmanager_secret.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret_version.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | KMS Key ARN with which to encrypt the secret. | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | Name of the secret. | `string` | n/a | yes |
+| <a name="input_recovery_window"></a> [recovery\_window](#input\_recovery\_window) | Recovery window in days for the secret. | `string` | n/a | yes |
+| <a name="input_secret_string"></a> [secret\_string](#input\_secret\_string) | Value of the secret. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_secret_arn"></a> [secret\_arn](#output\_secret\_arn) | ARN of the secret to be used in IAM policies. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/environments/common/secret/main.tf
+++ b/environments/common/secret/main.tf
@@ -1,0 +1,10 @@
+resource "aws_secretsmanager_secret" "this" {
+  kms_key_id              = var.kms_key_arn
+  recovery_window_in_days = var.recovery_window
+  name                    = var.name
+}
+
+resource "aws_secretsmanager_secret_version" "this" {
+  secret_id     = aws_secretsmanager_secret.this.id
+  secret_string = var.secret_string
+}

--- a/environments/common/secret/outputs.tf
+++ b/environments/common/secret/outputs.tf
@@ -1,0 +1,4 @@
+output "secret_arn" {
+  description = "ARN of the secret to be used in IAM policies."
+  value       = aws_secretsmanager_secret.this.arn
+}

--- a/environments/common/secret/variables.tf
+++ b/environments/common/secret/variables.tf
@@ -1,0 +1,20 @@
+variable "secret_string" {
+  description = "Value of the secret."
+  type        = string
+  sensitive   = true
+}
+
+variable "name" {
+  description = "Name of the secret."
+  type        = string
+}
+
+variable "kms_key_arn" {
+  description = "KMS Key ARN with which to encrypt the secret."
+  type        = string
+}
+
+variable "recovery_window" {
+  description = "Recovery window in days for the secret."
+  type        = string
+}

--- a/environments/common/secret/versions.tf
+++ b/environments/common/secret/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.4.6"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4" # Don't upgrade to 5.x.x yet
+    }
+  }
+}

--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -45,9 +45,12 @@ No outputs.
 | <a name="module_acm"></a> [acm](#module\_acm) | ../../common/acm/ | n/a |
 | <a name="module_alb"></a> [alb](#module\_alb) | ../../common/application-load-balancer/ | n/a |
 | <a name="module_alb-security-group"></a> [alb-security-group](#module\_alb-security-group) | ../../common/security-group/ | n/a |
+| <a name="module_backend_secret_key_base"></a> [backend\_secret\_key\_base](#module\_backend\_secret\_key\_base) | ../../common/secret/ | n/a |
 | <a name="module_cloudwatch"></a> [cloudwatch](#module\_cloudwatch) | ../../common/cloudwatch/ | n/a |
 | <a name="module_ecr"></a> [ecr](#module\_ecr) | ../../common/ecr/ | n/a |
+| <a name="module_frontend_secret_key_base"></a> [frontend\_secret\_key\_base](#module\_frontend\_secret\_key\_base) | ../../common/secret/ | n/a |
 | <a name="module_logs"></a> [logs](#module\_logs) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v3.14.0 |
+| <a name="module_newrelic_license_key"></a> [newrelic\_license\_key](#module\_newrelic\_license\_key) | ../../common/secret/ | n/a |
 | <a name="module_opensearch"></a> [opensearch](#module\_opensearch) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/opensearch | aws/opensearch-v1.0.0 |
 | <a name="module_opensearch_packages_bucket"></a> [opensearch\_packages\_bucket](#module\_opensearch\_packages\_bucket) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v3.14.0 |
 | <a name="module_postgres"></a> [postgres](#module\_postgres) | ../../common/rds | n/a |
@@ -63,14 +66,8 @@ No outputs.
 | [aws_kms_alias.secretsmanager_kms_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_key.opensearch_kms_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_kms_key.secretsmanager_kms_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
-| [aws_secretsmanager_secret.backend_secret_key_base](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
-| [aws_secretsmanager_secret.frontend_secret_key_base](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
-| [aws_secretsmanager_secret.newrelic_license_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret.postgres_connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret.redis_connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
-| [aws_secretsmanager_secret_version.backend_secret_key_base_value](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
-| [aws_secretsmanager_secret_version.frontend_secret_key_base_value](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
-| [aws_secretsmanager_secret_version.newrelic_license_key_value](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_secretsmanager_secret_version.postgres_connection_string_value](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_secretsmanager_secret_version.redis_connection_string_value](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_ssm_parameter.ecr_url](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |

--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -63,10 +63,12 @@ No outputs.
 | [aws_kms_alias.secretsmanager_kms_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_key.opensearch_kms_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_kms_key.secretsmanager_kms_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_secretsmanager_secret.backend_secret_key_base](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret.frontend_secret_key_base](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret.newrelic_license_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret.postgres_connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret.redis_connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret_version.backend_secret_key_base_value](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_secretsmanager_secret_version.frontend_secret_key_base_value](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_secretsmanager_secret_version.newrelic_license_key_value](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_secretsmanager_secret_version.postgres_connection_string_value](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
@@ -81,6 +83,7 @@ No outputs.
 |------|-------------|------|---------|:--------:|
 | <a name="input_alb_name"></a> [alb\_name](#input\_alb\_name) | The name of the alb | `string` | `"trade-tariff-alb"` | no |
 | <a name="input_aws_account_id"></a> [aws\_account\_id](#input\_aws\_account\_id) | Development Account ID. | `string` | `"844815912454"` | no |
+| <a name="input_backend_secret_key_base"></a> [backend\_secret\_key\_base](#input\_backend\_secret\_key\_base) | Value of SECRET\_KEY\_BASE for the backend. | `string` | n/a | yes |
 | <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | Name of the test Domain | `string` | `"transformtariff.co.uk"` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Build environment | `string` | `"development"` | no |
 | <a name="input_frontend_secret_key_base"></a> [frontend\_secret\_key\_base](#input\_frontend\_secret\_key\_base) | Value of SECRET\_KEY\_BASE for the frontend. | `string` | n/a | yes |

--- a/environments/development/common/secrets.tf
+++ b/environments/development/common/secrets.tf
@@ -29,3 +29,19 @@ variable "newrelic_license_key" {
   type        = string
   sensitive   = true
 }
+
+resource "aws_secretsmanager_secret" "backend_secret_key_base" {
+  name       = "backend-secret-key-base"
+  kms_key_id = aws_kms_key.secretsmanager_kms_key.arn
+}
+
+resource "aws_secretsmanager_secret_version" "backend_secret_key_base_value" {
+  secret_id     = aws_secretsmanager_secret.backend_secret_key_base.id
+  secret_string = var.backend_secret_key_base
+}
+
+variable "backend_secret_key_base" {
+  description = "Value of SECRET_KEY_BASE for the backend."
+  type        = string
+  sensitive   = true
+}

--- a/environments/development/common/secrets.tf
+++ b/environments/development/common/secrets.tf
@@ -1,47 +1,23 @@
-resource "aws_secretsmanager_secret" "frontend_secret_key_base" {
-  name       = "frontend-secret-key-base"
-  kms_key_id = aws_kms_key.secretsmanager_kms_key.arn
+module "frontend_secret_key_base" {
+  source          = "../../common/secret/"
+  name            = "frontend-secret-key-base"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.frontend_secret_key_base
 }
 
-resource "aws_secretsmanager_secret_version" "frontend_secret_key_base_value" {
-  secret_id     = aws_secretsmanager_secret.frontend_secret_key_base.id
-  secret_string = var.frontend_secret_key_base
+module "backend_secret_key_base" {
+  source          = "../../common/secret/"
+  name            = "backend-secret-key-base"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.backend_secret_key_base
 }
 
-variable "frontend_secret_key_base" {
-  description = "Value of SECRET_KEY_BASE for the frontend."
-  type        = string
-  sensitive   = true
-}
-
-resource "aws_secretsmanager_secret" "newrelic_license_key" {
-  name       = "newrelic-license-key"
-  kms_key_id = aws_kms_key.secretsmanager_kms_key.arn
-}
-
-resource "aws_secretsmanager_secret_version" "newrelic_license_key_value" {
-  secret_id     = aws_secretsmanager_secret.newrelic_license_key.id
-  secret_string = var.newrelic_license_key
-}
-
-variable "newrelic_license_key" {
-  description = "License key for NewRelic."
-  type        = string
-  sensitive   = true
-}
-
-resource "aws_secretsmanager_secret" "backend_secret_key_base" {
-  name       = "backend-secret-key-base"
-  kms_key_id = aws_kms_key.secretsmanager_kms_key.arn
-}
-
-resource "aws_secretsmanager_secret_version" "backend_secret_key_base_value" {
-  secret_id     = aws_secretsmanager_secret.backend_secret_key_base.id
-  secret_string = var.backend_secret_key_base
-}
-
-variable "backend_secret_key_base" {
-  description = "Value of SECRET_KEY_BASE for the backend."
-  type        = string
-  sensitive   = true
+module "newrelic_license_key" {
+  source          = "../../common/secret/"
+  name            = "newrelic-license-key"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.newrelic_license_key
 }

--- a/environments/development/common/variables.tf
+++ b/environments/development/common/variables.tf
@@ -45,3 +45,21 @@ variable "s3_tags" {
     Billing     = "TRN.HMR11896"
   }
 }
+
+variable "newrelic_license_key" {
+  description = "License key for NewRelic."
+  type        = string
+  sensitive   = true
+}
+
+variable "backend_secret_key_base" {
+  description = "Value of SECRET_KEY_BASE for the backend."
+  type        = string
+  sensitive   = true
+}
+
+variable "frontend_secret_key_base" {
+  description = "Value of SECRET_KEY_BASE for the frontend."
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
# Pull Request

[HOTT-3600](https://transformuk.atlassian.net/browse/HOTT-3600)

## What?

I have:

- Created a basic module to simplify creating SecetsManager Secrets.
- Moved secret resources to use the module.
- Added the backend 'secret key base' secret.

## Why?

I am doing this because:

- The backend needs this secret but we want to keep it a secret rather than putting it into less secure service(s).