### PR TITLE
BAU: Create all remaining Target Groups

### DIFF
--- a/environments/common/application-load-balancer/README.md
+++ b/environments/common/application-load-balancer/README.md
@@ -47,8 +47,7 @@ No modules.
 |------|------|
 | [aws_lb.application_load_balancer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
 | [aws_lb_listener.trade_tariff_listeners](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
-| [aws_lb_listener_rule.trade_tariff_backend_listeners_rules](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener_rule) | resource |
-| [aws_lb_listener_rule.trade_tariff_duty_cal_listeners_rules](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener_rule) | resource |
+| [aws_lb_listener_rule.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener_rule) | resource |
 | [aws_lb_target_group.trade_tariff_target_groups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
 
 ## Inputs

--- a/environments/common/application-load-balancer/alb.tf
+++ b/environments/common/application-load-balancer/alb.tf
@@ -45,7 +45,7 @@ resource "aws_lb_listener" "trade_tariff_listeners" {
 
   default_action {
     type             = "forward"
-    target_group_arn = aws_lb_target_group.trade_tariff_target_groups["trade-tariff-fe-tg-${var.environment}"].arn
+    target_group_arn = aws_lb_target_group.trade_tariff_target_groups["frontend"].arn
   }
 }
 

--- a/environments/common/application-load-balancer/alb.tf
+++ b/environments/common/application-load-balancer/alb.tf
@@ -56,7 +56,7 @@ resource "aws_lb_listener_rule" "this" {
 
   action {
     type             = "forward"
-    target_group_arn = aws_lb_target_group.trade_tariff_target_groups[each.value.target_group_name].arn
+    target_group_arn = aws_lb_target_group.trade_tariff_target_groups[each.key].arn
   }
 
   condition {

--- a/environments/common/application-load-balancer/alb.tf
+++ b/environments/common/application-load-balancer/alb.tf
@@ -16,16 +16,8 @@ resource "aws_lb" "application_load_balancer" {
 
 /* target group name cannot be longer than 32 chars */
 resource "aws_lb_target_group" "trade_tariff_target_groups" {
-  for_each = toset([
-    "trade-tariff-fe-tg-${var.environment}",
-    "trade-tariff-be-tg-${var.environment}",
-    "trade-tariff-dc-tg-${var.environment}",
-    "trade-tariff-sqp-tg-${var.environment}",
-    "trade-tariff-ad-tg-${var.environment}",
-    "trade-tariff-so-tg-${var.environment}"
-  ])
-
-  name        = each.value
+  for_each    = local.services
+  name        = each.value.target_group_name
   port        = var.application_port
   protocol    = "HTTP"
   target_type = "ip"
@@ -44,7 +36,6 @@ resource "aws_lb_target_group" "trade_tariff_target_groups" {
   }
 }
 
-/* target group name cannot be longer than 30 char */
 resource "aws_lb_listener" "trade_tariff_listeners" {
   load_balancer_arn = aws_lb.application_load_balancer.arn
   port              = var.listening_port
@@ -58,35 +49,19 @@ resource "aws_lb_listener" "trade_tariff_listeners" {
   }
 }
 
-resource "aws_lb_listener_rule" "trade_tariff_backend_listeners_rules" {
+resource "aws_lb_listener_rule" "this" {
+  for_each     = local.services
   listener_arn = aws_lb_listener.trade_tariff_listeners.arn
+  priority     = each.value.priority
 
   action {
     type             = "forward"
-    target_group_arn = aws_lb_target_group.trade_tariff_target_groups["trade-tariff-be-tg-${var.environment}"].arn
+    target_group_arn = aws_lb_target_group.trade_tariff_target_groups[each.value.target_group_name].arn
   }
 
-  ## have to ideal for now
   condition {
     path_pattern {
-      values = ["/backend/*"]
-    }
-  }
-}
-
-resource "aws_lb_listener_rule" "trade_tariff_duty_cal_listeners_rules" {
-  listener_arn = aws_lb_listener.trade_tariff_listeners.arn
-  priority     = 100
-
-  action {
-    type             = "forward"
-    target_group_arn = aws_lb_target_group.trade_tariff_target_groups["trade-tariff-dc-tg-${var.environment}"].arn
-  }
-
-  ## have to ideal for now
-  condition {
-    path_pattern {
-      values = ["/duty-calulator/*"]
+      values = each.value.paths
     }
   }
 }

--- a/environments/common/application-load-balancer/locals.tf
+++ b/environments/common/application-load-balancer/locals.tf
@@ -1,0 +1,44 @@
+locals {
+  services = {
+    admin = {
+      target_group_name = "trade-tariff-ad-tg-${var.environment}"
+      priority          = 50
+      paths             = ["/admin/*"] # TODO: confirm routes
+    }
+
+    backend = {
+      target_group_name = "trade-tariff-be-tg-${var.environment}"
+      priority          = 10
+      paths = [
+        "/chapters/*",
+        "/search/*",
+        "/xi/search/*"
+      ]
+    }
+
+    duty_calculator = {
+      target_group_name = "trade-tariff-dc-tg-${var.environment}"
+      priority          = 20
+      paths             = ["/duty-calculator/*"]
+    }
+
+    frontend = {
+      target_group_name = "trade-tariff-fe-tg-${var.environment}"
+      priority          = 100
+      paths             = ["/"]
+    }
+
+
+    search_query_parser = {
+      target_group_name = "trade-tariff-sqp-tg-${var.environment}"
+      priority          = 30
+      paths             = ["/api/search/*"]
+    }
+
+    signon = {
+      target_group_name = "trade-tariff-so-tg-${var.environment}"
+      priority          = 40
+      paths             = ["/signin-required", "/users/*"]
+    }
+  }
+}


### PR DESCRIPTION
## What?

I have:

- Moved the list of services out into a local, with a map for each service, that contains its target group name, the priority of the rule, and the paths for the rule.
- Removed the target group rule resources and created a new one that builds rules using the `for_each`.

## Why?

I am doing this because:

- We need the rest of the target groups at this stage so we can deploy the remaining applications easily.
- This makes editing the rules easier in the future if we need to add more paths.
