### PR TITLE
BAU: Add Secrets for Admin Tool

### DIFF
--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -43,6 +43,10 @@ No outputs.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_acm"></a> [acm](#module\_acm) | ../../common/acm/ | n/a |
+| <a name="module_admin_bearer_token"></a> [admin\_bearer\_token](#module\_admin\_bearer\_token) | ../../common/secret/ | n/a |
+| <a name="module_admin_oauth_id"></a> [admin\_oauth\_id](#module\_admin\_oauth\_id) | ../../common/secret/ | n/a |
+| <a name="module_admin_oauth_secret"></a> [admin\_oauth\_secret](#module\_admin\_oauth\_secret) | ../../common/secret/ | n/a |
+| <a name="module_admin_secret_key_base"></a> [admin\_secret\_key\_base](#module\_admin\_secret\_key\_base) | ../../common/secret/ | n/a |
 | <a name="module_alb"></a> [alb](#module\_alb) | ../../common/application-load-balancer/ | n/a |
 | <a name="module_alb-security-group"></a> [alb-security-group](#module\_alb-security-group) | ../../common/security-group/ | n/a |
 | <a name="module_backend_secret_key_base"></a> [backend\_secret\_key\_base](#module\_backend\_secret\_key\_base) | ../../common/secret/ | n/a |
@@ -83,6 +87,10 @@ No outputs.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_admin_bearer_token"></a> [admin\_bearer\_token](#input\_admin\_bearer\_token) | Value of BEARER\_TOKEN for the admin tool. | `string` | n/a | yes |
+| <a name="input_admin_oauth_id"></a> [admin\_oauth\_id](#input\_admin\_oauth\_id) | Value of TARIFF\_ADMIN\_OAUTH\_ID for the admin tool. | `string` | n/a | yes |
+| <a name="input_admin_oauth_secret"></a> [admin\_oauth\_secret](#input\_admin\_oauth\_secret) | Value of TARIFF\_ADMIN\_OAUTH\_SECRET for the admin tool. | `string` | n/a | yes |
+| <a name="input_admin_secret_key_base"></a> [admin\_secret\_key\_base](#input\_admin\_secret\_key\_base) | Value of SECRET\_KEY\_BASE for the admin tool. | `string` | n/a | yes |
 | <a name="input_alb_name"></a> [alb\_name](#input\_alb\_name) | The name of the alb | `string` | `"trade-tariff-alb"` | no |
 | <a name="input_aws_account_id"></a> [aws\_account\_id](#input\_aws\_account\_id) | Development Account ID. | `string` | `"844815912454"` | no |
 | <a name="input_backend_secret_key_base"></a> [backend\_secret\_key\_base](#input\_backend\_secret\_key\_base) | Value of SECRET\_KEY\_BASE for the backend. | `string` | n/a | yes |

--- a/environments/development/common/secrets.tf
+++ b/environments/development/common/secrets.tf
@@ -29,3 +29,35 @@ module "newrelic_license_key" {
   recovery_window = 7
   secret_string   = var.newrelic_license_key
 }
+
+module "admin_secret_key_base" {
+  source          = "../../common/secret/"
+  name            = "admin-secret-key-base"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.admin_secret_key_base
+}
+
+module "admin_oauth_id" {
+  source          = "../../common/secret/"
+  name            = "admin-oauth-id"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.admin_oauth_id
+}
+
+module "admin_oauth_secret" {
+  source          = "../../common/secret/"
+  name            = "admin-oauth-secret"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.admin_oauth_secret
+}
+
+module "admin_bearer_token" {
+  source          = "../../common/secret/"
+  name            = "admin-bearer-token"
+  kms_key_arn     = aws_kms_key.opensearch_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.admin_bearer_token
+}

--- a/environments/development/common/variables.tf
+++ b/environments/development/common/variables.tf
@@ -69,3 +69,27 @@ variable "duty_calculator_secret_key_base" {
   type        = string
   sensitive   = true
 }
+
+variable "admin_secret_key_base" {
+  description = "Value of SECRET_KEY_BASE for the admin tool."
+  type        = string
+  sensitive   = true
+}
+
+variable "admin_oauth_id" {
+  description = "Value of TARIFF_ADMIN_OAUTH_ID for the admin tool."
+  type        = string
+  sensitive   = true
+}
+
+variable "admin_oauth_secret" {
+  description = "Value of TARIFF_ADMIN_OAUTH_SECRET for the admin tool."
+  type        = string
+  sensitive   = true
+}
+
+variable "admin_bearer_token" {
+  description = "Value of BEARER_TOKEN for the admin tool."
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
[ci skip] so as to not clobber other branches

# Pull Request

## What?

I have:

- Added the secrets for the Admin tool.

## Why?

I am doing this because:

- I'll need to be able to reference these secrets when creating the admin service.