### PR TITLE
BAU: Enable Postgres Autoscaling

### DIFF
--- a/environments/common/rds/README.md
+++ b/environments/common/rds/README.md
@@ -44,7 +44,7 @@ No modules.
 | <a name="input_environment"></a> [environment](#input\_environment) | Deployment environment. | `string` | n/a | yes |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type for the database. See https://aws.amazon.com/rds/instance-types/ | `string` | n/a | yes |
 | <a name="input_maintenance_window"></a> [maintenance\_window](#input\_maintenance\_window) | The time window (in UTC) to perform maintenance in. Syntax: `ddd:hh24:mi-ddd:hh24:mi`, eg: `Mon:00:00-Mon:01:30`. | `string` | n/a | yes |
-| <a name="input_max_allocated_storage"></a> [max\_allocated\_storage](#input\_max\_allocated\_storage) | Maximum allocated storage for the instance. Defaults to 5 (no autoscaling). | `number` | `5` | no |
+| <a name="input_max_allocated_storage"></a> [max\_allocated\_storage](#input\_max\_allocated\_storage) | Maximum allocated storage for the instance. Defaults to `null` (no autoscaling). | `number` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the database. | `string` | n/a | yes |
 | <a name="input_performance_insights_retention_period"></a> [performance\_insights\_retention\_period](#input\_performance\_insights\_retention\_period) | Amount of time, in days, (minimum 7, maximum 731, or any multiple of 31) to retain performance insights data. | `number` | `31` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS region. Defaults to `eu-west-2`. | `string` | `"eu-west-2"` | no |

--- a/environments/common/rds/README.md
+++ b/environments/common/rds/README.md
@@ -44,6 +44,7 @@ No modules.
 | <a name="input_environment"></a> [environment](#input\_environment) | Deployment environment. | `string` | n/a | yes |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type for the database. See https://aws.amazon.com/rds/instance-types/ | `string` | n/a | yes |
 | <a name="input_maintenance_window"></a> [maintenance\_window](#input\_maintenance\_window) | The time window (in UTC) to perform maintenance in. Syntax: `ddd:hh24:mi-ddd:hh24:mi`, eg: `Mon:00:00-Mon:01:30`. | `string` | n/a | yes |
+| <a name="input_max_allocated_storage"></a> [max\_allocated\_storage](#input\_max\_allocated\_storage) | Maximum allocated storage for the instance. Defaults to 5 (no autoscaling). | `number` | `5` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the database. | `string` | n/a | yes |
 | <a name="input_performance_insights_retention_period"></a> [performance\_insights\_retention\_period](#input\_performance\_insights\_retention\_period) | Amount of time, in days, (minimum 7, maximum 731, or any multiple of 31) to retain performance insights data. | `number` | `31` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS region. Defaults to `eu-west-2`. | `string` | `"eu-west-2"` | no |

--- a/environments/common/rds/locals.tf
+++ b/environments/common/rds/locals.tf
@@ -1,5 +1,6 @@
 locals {
-  master_username = "${random_string.prefix.result}${random_string.master_username.result}"
+  master_username       = "${random_string.prefix.result}${random_string.master_username.result}"
+  max_allocated_storage = var.max_allocated_storage <= var.allocated_storage || var.max_allocated_storage == null ? var.allocated_storage : var.max_allocated_storage
 
   tags = merge(
     {

--- a/environments/common/rds/rds.tf
+++ b/environments/common/rds/rds.tf
@@ -1,10 +1,12 @@
 resource "aws_db_instance" "this" {
-  db_name           = var.name
-  engine            = var.engine
-  engine_version    = var.engine_version
-  instance_class    = var.instance_type
-  allocated_storage = var.allocated_storage
-  storage_encrypted = true
+  db_name        = var.name
+  engine         = var.engine
+  engine_version = var.engine_version
+  instance_class = var.instance_type
+
+  allocated_storage     = var.allocated_storage
+  max_allocated_storage = var.max_allocated_storage
+  storage_encrypted     = true
 
   #tfsec:ignore:aws-rds-enable-deletion-protection
   deletion_protection     = var.deletion_protection

--- a/environments/common/rds/rds.tf
+++ b/environments/common/rds/rds.tf
@@ -5,7 +5,7 @@ resource "aws_db_instance" "this" {
   instance_class = var.instance_type
 
   allocated_storage     = var.allocated_storage
-  max_allocated_storage = var.max_allocated_storage
+  max_allocated_storage = local.max_allocated_storage
   storage_encrypted     = true
 
   #tfsec:ignore:aws-rds-enable-deletion-protection

--- a/environments/common/rds/variables.tf
+++ b/environments/common/rds/variables.tf
@@ -15,6 +15,12 @@ variable "allocated_storage" {
   default     = 5
 }
 
+variable "max_allocated_storage" {
+  description = "Maximum allocated storage for the instance. Defaults to 5 (no autoscaling)."
+  type        = number
+  default     = 5
+}
+
 variable "instance_type" {
   description = "Instance type for the database. See https://aws.amazon.com/rds/instance-types/"
   type        = string

--- a/environments/common/rds/variables.tf
+++ b/environments/common/rds/variables.tf
@@ -16,9 +16,9 @@ variable "allocated_storage" {
 }
 
 variable "max_allocated_storage" {
-  description = "Maximum allocated storage for the instance. Defaults to 5 (no autoscaling)."
+  description = "Maximum allocated storage for the instance. Defaults to `null` (no autoscaling)."
   type        = number
-  default     = 5
+  default     = null
 }
 
 variable "instance_type" {

--- a/environments/development/common/rds.tf
+++ b/environments/development/common/rds.tf
@@ -12,6 +12,9 @@ module "postgres" {
   backup_window      = "22:00-23:00"
   maintenance_window = "Fri:23:00-Sat:01:00"
 
+  allocated_storage     = 10
+  max_allocated_storage = 20
+
   region      = var.region
   environment = var.environment
 }


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Added `max_allocated_storage` to the RDS module.
- Set the allocated storage to a minimum of 10GB, and given a 2x scale factor up to a maximum of 20GB.

## Why?

I am doing this because:

- When doing an initial dump and restore we found that the database size was over 7GB uncompressed, so the initial 5GB allocation was not enough.