### PR TITLE
BAU: Another Pass on Listener Rules

### DIFF
--- a/environments/common/application-load-balancer/alb.tf
+++ b/environments/common/application-load-balancer/alb.tf
@@ -65,16 +65,16 @@ resource "aws_lb_listener_rule" "this" {
   }
 
   dynamic "condition" {
-    for_each = each.value.host != null ? [true] : []
+    for_each = lookup(local.services[each.key], "host", null) != null ? [true] : []
     content {
       host_header {
-        values = condition.value.host
+        values = each.value.host
       }
     }
   }
 
   dynamic "condition" {
-    for_each = each.value.paths != null ? [true] : []
+    for_each = lookup(local.services[each.key], "paths", null) != null ? [true] : []
     content {
       path_pattern {
         values = each.value.paths

--- a/environments/common/application-load-balancer/alb.tf
+++ b/environments/common/application-load-balancer/alb.tf
@@ -48,8 +48,8 @@ resource "aws_lb_listener" "trade_tariff_listeners" {
     type = "fixed-response"
     fixed_response {
       content_type = "text/plain"
-      message_body = "OK"
-      status_code  = "200"
+      message_body = "Not Found"
+      status_code  = "404"
     }
   }
 }

--- a/environments/common/application-load-balancer/alb.tf
+++ b/environments/common/application-load-balancer/alb.tf
@@ -43,9 +43,14 @@ resource "aws_lb_listener" "trade_tariff_listeners" {
   ssl_policy        = "ELBSecurityPolicy-TLS-1-2-2017-01"
   certificate_arn   = var.certificate_arn
 
+  # our rules will take over
   default_action {
-    type             = "forward"
-    target_group_arn = aws_lb_target_group.trade_tariff_target_groups["frontend"].arn
+    type = "fixed-response"
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "OK"
+      status_code  = "200"
+    }
   }
 }
 
@@ -59,9 +64,21 @@ resource "aws_lb_listener_rule" "this" {
     target_group_arn = aws_lb_target_group.trade_tariff_target_groups[each.key].arn
   }
 
-  condition {
-    path_pattern {
-      values = each.value.paths
+  dynamic "condition" {
+    for_each = each.value.host != null ? [true] : []
+    content {
+      host_header {
+        values = condition.value.host
+      }
+    }
+  }
+
+  dynamic "condition" {
+    for_each = each.value.paths != null ? [true] : []
+    content {
+      path_pattern {
+        values = each.value.paths
+      }
     }
   }
 }

--- a/environments/common/application-load-balancer/locals.tf
+++ b/environments/common/application-load-balancer/locals.tf
@@ -2,43 +2,45 @@ locals {
   services = {
     admin = {
       target_group_name = "trade-tariff-ad-tg-${var.environment}"
-      priority          = 50
-      paths             = ["/admin/*"] # TODO: confirm routes
-    }
-
-    backend = {
-      target_group_name = "trade-tariff-be-tg-${var.environment}"
       priority          = 10
-      paths = [
-        "/chapters/*",
-        "/search/*",
-        "/xi/search/*"
-      ]
-    }
-
-    duty_calculator = {
-      target_group_name = "trade-tariff-dc-tg-${var.environment}"
-      priority          = 20
-      paths             = ["/duty-calculator/*"]
-    }
-
-    frontend = {
-      target_group_name = "trade-tariff-fe-tg-${var.environment}"
-      priority          = 100
-      paths             = ["/"]
-    }
-
-
-    search_query_parser = {
-      target_group_name = "trade-tariff-sqp-tg-${var.environment}"
-      priority          = 30
-      paths             = ["/api/search/*"]
+      host              = ["admin.*"]
     }
 
     signon = {
       target_group_name = "trade-tariff-so-tg-${var.environment}"
+      priority          = 20
+      host              = ["signon.*"]
+    }
+
+    backend_uk = {
+      target_group_name = "backend-uk-tg-${var.environment}"
+      priority          = 30
+      paths             = ["/uk/api/beta/*"]
+    }
+
+    backend_xi = {
+      target_group_name = "backend-xi-tg-${var.environment}"
+      priority          = 35
+      paths             = ["/xi/api/beta/*"]
+    }
+
+    duty_calculator = {
+      target_group_name = "trade-tariff-dc-tg-${var.environment}"
       priority          = 40
-      paths             = ["/signin-required", "/users/*"]
+      paths             = ["/duty-calculator/*"]
+    }
+
+    search_query_parser = {
+      target_group_name = "trade-tariff-sqp-tg-${var.environment}"
+      priority          = 50
+      paths             = ["/api/search/*"]
+    }
+
+    # frontend is a fallback, so must have the highest priority
+    frontend = {
+      target_group_name = "trade-tariff-fe-tg-${var.environment}"
+      priority          = 100
+      paths             = ["/*"]
     }
   }
 }


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Removed listener's default action of forwarding to frontend target groups.
- Added `dynamic` `condition` blocks to the listener rules to create the conditions dependant on the service mappings.
- Updated the mappings to each service.
- Split the backend target groups out between UK and XI.
- Adjusted the rule priorities.


## Why?

I am doing this because:

- Some of the apps use host-based routing rules, so we'll need to create the listener conditions based on the service map and whether `paths` or `host` is specified for each service.

- Removed the default action to go to the frontend target group as it's not needed; we have a catch-all rule with the lowest priority. We could, alternatively, _not_ have the frontend rule, but it needs a target group - it's being created such that we're explicit about it and _not_ relying on default behaviours (for clarity).

- Although I believe the only priority that matters is the frontend - it should have the least priority {a larger number} because everything else uses distinct paths - I'd rather set some vaguely arbitrary priority numbers here.