### PR TITLE
BAU: Create Multiple Redis Instances

### DIFF
--- a/environments/common/elasticache/README.md
+++ b/environments/common/elasticache/README.md
@@ -39,7 +39,6 @@ No modules.
 | <a name="input_maintenance_window"></a> [maintenance\_window](#input\_maintenance\_window) | The weekly time range for maintenance periods on the cluster. Format: `ddd:hh22:mi-ddd:hh23:mi` (UTC). Minimum period must be 60 minutes. For example, `sun:05:00-sun:06:00`. | `string` | n/a | yes |
 | <a name="input_parameter_group"></a> [parameter\_group](#input\_parameter\_group) | Parameter group for replication group. For example, `default.redis3.2.cluster.on`. | `string` | n/a | yes |
 | <a name="input_redis_version"></a> [redis\_version](#input\_redis\_version) | Engine version to use. | `string` | n/a | yes |
-| <a name="input_region"></a> [region](#input\_region) | AWS region to use. | `string` | n/a | yes |
 | <a name="input_replicas"></a> [replicas](#input\_replicas) | Number of replicas to create, between 0 (none) and 5. Defaults to `0`. | `number` | `0` | no |
 | <a name="input_security_group_names"></a> [security\_group\_names](#input\_security\_group\_names) | List of security group names to associate with the group. | `list(string)` | `null` | no |
 | <a name="input_shards"></a> [shards](#input\_shards) | Number of node groups (shards) for this group. Defaults to `1`. | `number` | `1` | no |

--- a/environments/common/elasticache/README.md
+++ b/environments/common/elasticache/README.md
@@ -51,4 +51,6 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_endpoint"></a> [endpoint](#output\_endpoint) | Configuration endpoint of the replication group. |
+| <a name="output_kms_key_arn"></a> [kms\_key\_arn](#output\_kms\_key\_arn) | ARN of the KMS key used. |
+| <a name="output_kms_key_id"></a> [kms\_key\_id](#output\_kms\_key\_id) | Key ID of the KMS key used. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/environments/common/elasticache/elasticache.tf
+++ b/environments/common/elasticache/elasticache.tf
@@ -49,7 +49,7 @@ resource "aws_elasticache_replication_group" "this" {
 }
 
 resource "aws_kms_key" "this" {
-  description         = "KMS key for Redis on ${var.environment}."
+  description         = "KMS key for ${var.group_name}"
   key_usage           = "ENCRYPT_DECRYPT"
   enable_key_rotation = true
 }

--- a/environments/common/elasticache/outputs.tf
+++ b/environments/common/elasticache/outputs.tf
@@ -2,3 +2,13 @@ output "endpoint" {
   description = "Configuration endpoint of the replication group."
   value       = aws_elasticache_replication_group.this.configuration_endpoint_address
 }
+
+output "kms_key_arn" {
+  description = "ARN of the KMS key used."
+  value       = aws_kms_key.this.arn
+}
+
+output "kms_key_id" {
+  description = "Key ID of the KMS key used."
+  value       = aws_kms_key.this.key_id
+}

--- a/environments/common/elasticache/variables.tf
+++ b/environments/common/elasticache/variables.tf
@@ -19,11 +19,6 @@ variable "environment" {
   type        = string
 }
 
-variable "region" {
-  description = "AWS region to use."
-  type        = string
-}
-
 variable "instance_type" {
   description = "Instance type, i.e. `cache.t3.small`."
   type        = string

--- a/environments/common/elasticache/versions.tf
+++ b/environments/common/elasticache/versions.tf
@@ -7,7 +7,3 @@ terraform {
     }
   }
 }
-
-provider "aws" {
-  region = var.region
-}

--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -67,8 +67,6 @@ No outputs.
 | <a name="module_opensearch_packages_bucket"></a> [opensearch\_packages\_bucket](#module\_opensearch\_packages\_bucket) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v3.14.0 |
 | <a name="module_postgres"></a> [postgres](#module\_postgres) | ../../common/rds | n/a |
 | <a name="module_redis"></a> [redis](#module\_redis) | ../../common/elasticache/ | n/a |
-| <a name="module_redis_admin"></a> [redis\_admin](#module\_redis\_admin) | ../../common/elasticache/ | n/a |
-| <a name="module_redis_backend"></a> [redis\_backend](#module\_redis\_backend) | ../../common/elasticache/ | n/a |
 | <a name="module_s3"></a> [s3](#module\_s3) | ../../common/s3 | n/a |
 | <a name="module_search_configuration_bucket"></a> [search\_configuration\_bucket](#module\_search\_configuration\_bucket) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v3.14.0 |
 

--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -67,6 +67,8 @@ No outputs.
 | <a name="module_opensearch_packages_bucket"></a> [opensearch\_packages\_bucket](#module\_opensearch\_packages\_bucket) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v3.14.0 |
 | <a name="module_postgres"></a> [postgres](#module\_postgres) | ../../common/rds | n/a |
 | <a name="module_redis"></a> [redis](#module\_redis) | ../../common/elasticache/ | n/a |
+| <a name="module_redis_admin"></a> [redis\_admin](#module\_redis\_admin) | ../../common/elasticache/ | n/a |
+| <a name="module_redis_backend"></a> [redis\_backend](#module\_redis\_backend) | ../../common/elasticache/ | n/a |
 | <a name="module_s3"></a> [s3](#module\_s3) | ../../common/s3 | n/a |
 | <a name="module_search_configuration_bucket"></a> [search\_configuration\_bucket](#module\_search\_configuration\_bucket) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v3.14.0 |
 

--- a/environments/development/common/redis.tf
+++ b/environments/development/common/redis.tf
@@ -1,69 +1,37 @@
+locals {
+  redis = toset([
+    "frontend",
+    "backend",
+    "admin"
+  ])
+}
+
 module "redis" {
-  source = "../../common/elasticache/"
+  source   = "../../common/elasticache/"
+  for_each = local.redis
+
+  group_name           = "redis-${each.key}-${var.environment}"
+  redis_version        = "5.0.6"
+  instance_type        = "cache.t3.micro"
+  parameter_group      = "default.redis5.0.cluster.on"
+  cloudwatch_log_group = module.cloudwatch.log_group_name
+  shards               = 2
+  replicas             = 1
+
+  maintenance_window = "sun:04:00-sun:05:00"
+  snapshot_window    = "02:00-04:00"
 
   environment = var.environment
-  region      = var.region
-
-  cloudwatch_log_group = module.cloudwatch.log_group_name
-
-  group_name      = "redis-frontend-${var.environment}"
-  redis_version   = "5.0.6"
-  instance_type   = "cache.t3.micro"
-  parameter_group = "default.redis5.0.cluster.on"
-
-  shards   = 2
-  replicas = 1
-
-  maintenance_window = "sun:00:00-sun:03:00"
-  snapshot_window    = "04:00-06:00"
 }
 
 resource "aws_secretsmanager_secret" "redis_connection_string" {
-  name       = "redis-connection-string"
+  for_each   = local.redis
+  name       = "redis-${each.key}-connection-string"
   kms_key_id = aws_kms_key.secretsmanager_kms_key.arn
 }
 
 resource "aws_secretsmanager_secret_version" "redis_connection_string_value" {
-  secret_id     = aws_secretsmanager_secret.redis_connection_string.id
-  secret_string = module.redis.endpoint
-}
-
-module "redis_admin" {
-  source = "../../common/elasticache/"
-
-  environment = var.environment
-  region      = var.region
-
-  cloudwatch_log_group = module.cloudwatch.log_group_name
-
-  group_name      = "redis-admin-${var.environment}"
-  redis_version   = "5.0.6"
-  instance_type   = "cache.t3.micro"
-  parameter_group = "default.redis5.0.cluster.on"
-
-  shards   = 2
-  replicas = 1
-
-  maintenance_window = "sun:00:00-sun:03:00"
-  snapshot_window    = "04:00-06:00"
-}
-
-module "redis_backend" {
-  source = "../../common/elasticache/"
-
-  environment = var.environment
-  region      = var.region
-
-  cloudwatch_log_group = module.cloudwatch.log_group_name
-
-  group_name      = "redis-backend-${var.environment}"
-  redis_version   = "5.0.6"
-  instance_type   = "cache.t3.micro"
-  parameter_group = "default.redis5.0.cluster.on"
-
-  shards   = 2
-  replicas = 1
-
-  maintenance_window = "sun:00:00-sun:03:00"
-  snapshot_window    = "04:00-06:00"
+  for_each      = local.redis
+  secret_id     = aws_secretsmanager_secret.redis_connection_string[each.key].id
+  secret_string = module.redis[each.key].endpoint
 }

--- a/environments/development/common/redis.tf
+++ b/environments/development/common/redis.tf
@@ -6,7 +6,7 @@ module "redis" {
 
   cloudwatch_log_group = module.cloudwatch.log_group_name
 
-  group_name      = "tariff-redis-${var.environment}"
+  group_name      = "redis-frontend-${var.environment}"
   redis_version   = "5.0.6"
   instance_type   = "cache.t3.micro"
   parameter_group = "default.redis5.0.cluster.on"
@@ -26,4 +26,44 @@ resource "aws_secretsmanager_secret" "redis_connection_string" {
 resource "aws_secretsmanager_secret_version" "redis_connection_string_value" {
   secret_id     = aws_secretsmanager_secret.redis_connection_string.id
   secret_string = module.redis.endpoint
+}
+
+module "redis_admin" {
+  source = "../../common/elasticache/"
+
+  environment = var.environment
+  region      = var.region
+
+  cloudwatch_log_group = module.cloudwatch.log_group_name
+
+  group_name      = "redis-admin-${var.environment}"
+  redis_version   = "5.0.6"
+  instance_type   = "cache.t3.micro"
+  parameter_group = "default.redis5.0.cluster.on"
+
+  shards   = 2
+  replicas = 1
+
+  maintenance_window = "sun:00:00-sun:03:00"
+  snapshot_window    = "04:00-06:00"
+}
+
+module "redis_backend" {
+  source = "../../common/elasticache/"
+
+  environment = var.environment
+  region      = var.region
+
+  cloudwatch_log_group = module.cloudwatch.log_group_name
+
+  group_name      = "redis-backend-${var.environment}"
+  redis_version   = "5.0.6"
+  instance_type   = "cache.t3.micro"
+  parameter_group = "default.redis5.0.cluster.on"
+
+  shards   = 2
+  replicas = 1
+
+  maintenance_window = "sun:00:00-sun:03:00"
+  snapshot_window    = "04:00-06:00"
 }


### PR DESCRIPTION
[ci skip] so as to not clobber the other PR I have open.

## What?

I have:

- Added more Redis.
- Switched to `for_each`ing the secrets as we'll have multiple Redis connection strings.

## Why?

I am doing this because:

- We need multiple Redis instances (Redii?) as the services don't all use the same one. The frontend, backend(s) and the admin tool each expect their _own_ Redis to be available.

## Downstream Considerations

- Anywhere we are using the Redis connection string `redis-connection-string`, we'll have to update this to use the correct string for the specific instance we want.