### PR TITLE
BAU: Redirect HTTP to HTTPS

### DIFF
--- a/environments/common/application-load-balancer/README.md
+++ b/environments/common/application-load-balancer/README.md
@@ -46,6 +46,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_lb.application_load_balancer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
+| [aws_lb_listener.redirect_http](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
 | [aws_lb_listener.trade_tariff_listeners](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
 | [aws_lb_listener_rule.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener_rule) | resource |
 | [aws_lb_target_group.trade_tariff_target_groups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |

--- a/environments/common/application-load-balancer/alb.tf
+++ b/environments/common/application-load-balancer/alb.tf
@@ -36,6 +36,21 @@ resource "aws_lb_target_group" "trade_tariff_target_groups" {
   }
 }
 
+resource "aws_lb_listener" "redirect_http" {
+  load_balancer_arn = aws_lb.application_load_balancer.arn
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
 resource "aws_lb_listener" "trade_tariff_listeners" {
   load_balancer_arn = aws_lb.application_load_balancer.arn
   port              = var.listening_port


### PR DESCRIPTION
## What?

I have:

- Added a HTTP listener on port 80 that redirects to the HTTPS listener on 443.

## Why?

I am doing this because:

- We should redirect HTTP on 80 to HTTPS on 443.