### PR TITLE
HOTT-3669: Create Origin DNS

### DIFF
--- a/environments/common/acm/acm.tf
+++ b/environments/common/acm/acm.tf
@@ -3,6 +3,8 @@ resource "aws_acm_certificate" "acm_certificate" {
   domain_name       = var.domain_name
   validation_method = "DNS"
 
+  subject_alternative_names = ["*.${var.domain_name}"]
+
   lifecycle {
     create_before_destroy = true
   }
@@ -17,7 +19,6 @@ data "aws_route53_zone" "route53_zone" {
   name         = var.domain_name
   private_zone = false
 }
-
 
 /* create a record set for route53 for domain validation */
 resource "aws_route53_record" "route53_record" {
@@ -39,7 +40,6 @@ resource "aws_route53_record" "route53_record" {
 
 /*validate acm certificates */
 resource "aws_acm_certificate_validation" "validate_acm_certificates" {
-
   certificate_arn = aws_acm_certificate.acm_certificate.arn
 
   validation_record_fqdns = [for record in aws_route53_record.route53_record : record.fqdn]

--- a/environments/common/application-load-balancer/README.md
+++ b/environments/common/application-load-balancer/README.md
@@ -70,5 +70,8 @@ No modules.
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_dns_name"></a> [dns\_name](#output\_dns\_name) | DNS name of the load balancer. |
+| <a name="output_zone_id"></a> [zone\_id](#output\_zone\_id) | Zone ID of the load balancer. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/environments/common/application-load-balancer/outputs.tf
+++ b/environments/common/application-load-balancer/outputs.tf
@@ -1,0 +1,9 @@
+output "dns_name" {
+  description = "DNS name of the load balancer."
+  value       = aws_lb.application_load_balancer.dns_name
+}
+
+output "zone_id" {
+  description = "Zone ID of the load balancer."
+  value       = aws_lb.application_load_balancer.zone_id
+}

--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -43,6 +43,7 @@ No outputs.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_acm"></a> [acm](#module\_acm) | ../../common/acm/ | n/a |
+| <a name="module_acm_origin"></a> [acm\_origin](#module\_acm\_origin) | ../../common/acm | n/a |
 | <a name="module_admin_bearer_token"></a> [admin\_bearer\_token](#module\_admin\_bearer\_token) | ../../common/secret/ | n/a |
 | <a name="module_admin_oauth_id"></a> [admin\_oauth\_id](#module\_admin\_oauth\_id) | ../../common/secret/ | n/a |
 | <a name="module_admin_oauth_secret"></a> [admin\_oauth\_secret](#module\_admin\_oauth\_secret) | ../../common/secret/ | n/a |
@@ -82,11 +83,15 @@ No outputs.
 | [aws_kms_alias.secretsmanager_kms_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_key.opensearch_kms_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_kms_key.secretsmanager_kms_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_route53_record.origin_ns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.origin_root](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_zone.origin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
 | [aws_secretsmanager_secret.redis_connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret_version.redis_connection_string_value](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_ssm_parameter.ecr_url](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.opensearch_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 | [aws_secretsmanager_secret_version.postgres_master_user_details](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 | [terraform_remote_state.base](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 

--- a/environments/development/common/acm.tf
+++ b/environments/development/common/acm.tf
@@ -1,6 +1,11 @@
 module "acm" {
-  source = "../../common/acm/"
-
+  source      = "../../common/acm/"
   domain_name = var.domain_name
+  environment = var.environment
+}
+
+module "acm_origin" {
+  source      = "../../common/acm"
+  domain_name = "origin.${var.domain_name}"
   environment = var.environment
 }

--- a/environments/development/common/route53.tf
+++ b/environments/development/common/route53.tf
@@ -1,0 +1,32 @@
+locals {
+  origin_domain_name = "origin.${var.domain_name}"
+}
+
+data "aws_route53_zone" "this" {
+  name         = var.domain_name
+  private_zone = false
+}
+
+resource "aws_route53_zone" "origin" {
+  name = local.origin_domain_name
+}
+
+resource "aws_route53_record" "origin_ns" {
+  zone_id = data.aws_route53_zone.this.zone_id
+  name    = local.origin_domain_name
+  type    = "NS"
+  ttl     = "30"
+  records = aws_route53_zone.origin.name_servers
+}
+
+resource "aws_route53_record" "origin_root" {
+  zone_id = aws_route53_zone.origin.zone_id
+  name    = local.origin_domain_name
+  type    = "A"
+
+  alias {
+    name                   = module.alb.dns_name
+    zone_id                = module.alb.zone_id
+    evaluate_target_health = true
+  }
+}


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Added DNS record(s) for the origin (load balancer) to `origin.domain.tld`.

## Why?

I am doing this because:

- We can reach the apps without going through the CDN later on.