### PR TITLE
HOTT-3669: Fix Hosted Zone IDs

### DIFF
--- a/environments/common/acm/README.md
+++ b/environments/common/acm/README.md
@@ -40,6 +40,6 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_certificate_arn"></a> [certificate\_arn](#output\_certificate\_arn) | n/a |
 | <a name="output_domain_name"></a> [domain\_name](#output\_domain\_name) | n/a |
+| <a name="output_validated_certificate_arn"></a> [validated\_certificate\_arn](#output\_validated\_certificate\_arn) | Validated certificate ARN for use with other resources. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/environments/common/acm/README.md
+++ b/environments/common/acm/README.md
@@ -25,7 +25,6 @@ No modules.
 | [aws_acm_certificate.acm_certificate](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate) | resource |
 | [aws_acm_certificate_validation.validate_acm_certificates](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/acm_certificate_validation) | resource |
 | [aws_route53_record.route53_record](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_zone.route53_zone](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 
 ## Inputs
 
@@ -33,6 +32,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | Name of the test domain | `string` | `"transformtrade.co.uk"` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | A map of tags to add to all resources | `string` | n/a | yes |
+| <a name="input_hosted_zone_id"></a> [hosted\_zone\_id](#input\_hosted\_zone\_id) | ID of the hosted zone. | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | AWS region. Defaults to `eu-west-2`. | `string` | `"eu-west-2"` | no |
 | <a name="input_validation_timeout"></a> [validation\_timeout](#input\_validation\_timeout) | How long to wait for a certificate to be issued, default max 45m | `string` | `null` | no |
 

--- a/environments/common/acm/acm.tf
+++ b/environments/common/acm/acm.tf
@@ -14,12 +14,6 @@ resource "aws_acm_certificate" "acm_certificate" {
   }
 }
 
-/* get details about a route 53 hosted zone */
-data "aws_route53_zone" "route53_zone" {
-  name         = var.domain_name
-  private_zone = false
-}
-
 /* create a record set for route53 for domain validation */
 resource "aws_route53_record" "route53_record" {
   for_each = {
@@ -35,7 +29,7 @@ resource "aws_route53_record" "route53_record" {
   records         = [each.value.record]
   ttl             = 60
   type            = each.value.type
-  zone_id         = data.aws_route53_zone.route53_zone.zone_id
+  zone_id         = var.hosted_zone_id
 }
 
 /*validate acm certificates */

--- a/environments/common/acm/output.tf
+++ b/environments/common/acm/output.tf
@@ -2,6 +2,7 @@ output "domain_name" {
   value = var.domain_name
 }
 
-output "certificate_arn" {
-  value = aws_acm_certificate.acm_certificate.arn
+output "validated_certificate_arn" {
+  description = "Validated certificate ARN for use with other resources."
+  value       = aws_acm_certificate_validation.validate_acm_certificates.certificate_arn
 }

--- a/environments/common/acm/variables.tf
+++ b/environments/common/acm/variables.tf
@@ -20,3 +20,8 @@ variable "domain_name" {
   type        = string
   default     = "transformtrade.co.uk"
 }
+
+variable "hosted_zone_id" {
+  description = "ID of the hosted zone."
+  type        = string
+}

--- a/environments/development/common/acm.tf
+++ b/environments/development/common/acm.tf
@@ -1,11 +1,13 @@
 module "acm" {
-  source      = "../../common/acm/"
-  domain_name = var.domain_name
-  environment = var.environment
+  source         = "../../common/acm/"
+  domain_name    = var.domain_name
+  environment    = var.environment
+  hosted_zone_id = data.aws_route53_zone.this.zone_id
 }
 
 module "acm_origin" {
-  source      = "../../common/acm"
-  domain_name = "origin.${var.domain_name}"
-  environment = var.environment
+  source         = "../../common/acm"
+  domain_name    = "origin.${var.domain_name}"
+  environment    = var.environment
+  hosted_zone_id = aws_route53_zone.origin.zone_id
 }

--- a/environments/development/common/alb.tf
+++ b/environments/development/common/alb.tf
@@ -3,7 +3,7 @@ module "alb" {
   alb_name              = var.alb_name
   alb_security_group_id = module.alb-security-group.alb_security_group_id
   public_subnet_id      = data.terraform_remote_state.base.outputs.public_subnet_id
-  certificate_arn       = module.acm.certificate_arn
+  certificate_arn       = module.acm.validated_certificate_arn
   environment           = var.environment
   vpc_id                = data.terraform_remote_state.base.outputs.vpc_id
 }


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Removed the zone lookup from the ACM module
- Added a `hosted_zone_id` input variable in the module

## Why?

I am doing this because:

- We need the zone outside of the ACM module, so let's input the zone ID instead of looking up a zone, as this will fail when we pass in something that doesn't have a zone.