### PR TITLE
BAU: Allow HTTP traffic on 80 in from Internet

### DIFF
--- a/environments/common/security-group/security-group.tf
+++ b/environments/common/security-group/security-group.tf
@@ -8,7 +8,16 @@ resource "aws_security_group" "alb_security_group" {
 
   # tfsec:ignore:aws-ec2-no-public-ingress-sgr
   ingress {
-    description = "HTTPS Ingress from CDN"
+    description = "HTTP Ingress from Internet"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # tfsec:ignore:aws-ec2-no-public-ingress-sgr
+  ingress {
+    description = "HTTPS Ingress from Internet"
     from_port   = 443
     to_port     = 443
     protocol    = "tcp"


### PR DESCRIPTION
[ci skip]

## What?

I have:

- Added an `ingress` block on our security group to allow traffic on port 80.

## Why?

I am doing this because:

- For our listener rule on 80 to work in redirecting traffic to 443, we need to allow the traffic in from 80 so we can deal with it at the listener.
