### PR TITLE
HOTT-3670: Add CloudFront (and WAF)

### DIFF
--- a/environments/common/acm/README.md
+++ b/environments/common/acm/README.md
@@ -31,9 +31,8 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | Name of the test domain | `string` | `"transformtrade.co.uk"` | no |
-| <a name="input_environment"></a> [environment](#input\_environment) | A map of tags to add to all resources | `string` | n/a | yes |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name. | `string` | n/a | yes |
 | <a name="input_hosted_zone_id"></a> [hosted\_zone\_id](#input\_hosted\_zone\_id) | ID of the hosted zone. | `string` | n/a | yes |
-| <a name="input_region"></a> [region](#input\_region) | AWS region. Defaults to `eu-west-2`. | `string` | `"eu-west-2"` | no |
 | <a name="input_validation_timeout"></a> [validation\_timeout](#input\_validation\_timeout) | How long to wait for a certificate to be issued, default max 45m | `string` | `null` | no |
 
 ## Outputs

--- a/environments/common/acm/variables.tf
+++ b/environments/common/acm/variables.tf
@@ -1,5 +1,5 @@
 variable "environment" {
-  description = "A map of tags to add to all resources"
+  description = "Environment name."
   type        = string
 }
 
@@ -7,12 +7,6 @@ variable "validation_timeout" {
   description = "How long to wait for a certificate to be issued, default max 45m"
   type        = string
   default     = null
-}
-
-variable "region" {
-  description = "AWS region. Defaults to `eu-west-2`."
-  type        = string
-  default     = "eu-west-2"
 }
 
 variable "domain_name" {

--- a/environments/common/acm/versions.tf
+++ b/environments/common/acm/versions.tf
@@ -7,7 +7,3 @@ terraform {
     }
   }
 }
-
-provider "aws" {
-  region = var.region
-}

--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -59,7 +59,7 @@ No outputs.
 | <a name="module_backend_sync_host"></a> [backend\_sync\_host](#module\_backend\_sync\_host) | ../../common/secret/ | n/a |
 | <a name="module_backend_sync_password"></a> [backend\_sync\_password](#module\_backend\_sync\_password) | ../../common/secret/ | n/a |
 | <a name="module_backend_sync_username"></a> [backend\_sync\_username](#module\_backend\_sync\_username) | ../../common/secret/ | n/a |
-| <a name="module_cdn"></a> [cdn](#module\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.0.1 |
+| <a name="module_cdn"></a> [cdn](#module\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.1.0 |
 | <a name="module_cloudwatch"></a> [cloudwatch](#module\_cloudwatch) | ../../common/cloudwatch/ | n/a |
 | <a name="module_duty_calculator_secret_key_base"></a> [duty\_calculator\_secret\_key\_base](#module\_duty\_calculator\_secret\_key\_base) | ../../common/secret/ | n/a |
 | <a name="module_ecr"></a> [ecr](#module\_ecr) | ../../common/ecr/ | n/a |

--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -59,7 +59,7 @@ No outputs.
 | <a name="module_backend_sync_host"></a> [backend\_sync\_host](#module\_backend\_sync\_host) | ../../common/secret/ | n/a |
 | <a name="module_backend_sync_password"></a> [backend\_sync\_password](#module\_backend\_sync\_password) | ../../common/secret/ | n/a |
 | <a name="module_backend_sync_username"></a> [backend\_sync\_username](#module\_backend\_sync\_username) | ../../common/secret/ | n/a |
-| <a name="module_cdn"></a> [cdn](#module\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.1.0 |
+| <a name="module_cdn"></a> [cdn](#module\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.1.1 |
 | <a name="module_cloudwatch"></a> [cloudwatch](#module\_cloudwatch) | ../../common/cloudwatch/ | n/a |
 | <a name="module_duty_calculator_secret_key_base"></a> [duty\_calculator\_secret\_key\_base](#module\_duty\_calculator\_secret\_key\_base) | ../../common/secret/ | n/a |
 | <a name="module_ecr"></a> [ecr](#module\_ecr) | ../../common/ecr/ | n/a |

--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -59,6 +59,7 @@ No outputs.
 | <a name="module_backend_sync_host"></a> [backend\_sync\_host](#module\_backend\_sync\_host) | ../../common/secret/ | n/a |
 | <a name="module_backend_sync_password"></a> [backend\_sync\_password](#module\_backend\_sync\_password) | ../../common/secret/ | n/a |
 | <a name="module_backend_sync_username"></a> [backend\_sync\_username](#module\_backend\_sync\_username) | ../../common/secret/ | n/a |
+| <a name="module_cdn"></a> [cdn](#module\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.0.1 |
 | <a name="module_cloudwatch"></a> [cloudwatch](#module\_cloudwatch) | ../../common/cloudwatch/ | n/a |
 | <a name="module_duty_calculator_secret_key_base"></a> [duty\_calculator\_secret\_key\_base](#module\_duty\_calculator\_secret\_key\_base) | ../../common/secret/ | n/a |
 | <a name="module_ecr"></a> [ecr](#module\_ecr) | ../../common/ecr/ | n/a |
@@ -71,11 +72,14 @@ No outputs.
 | <a name="module_redis"></a> [redis](#module\_redis) | ../../common/elasticache/ | n/a |
 | <a name="module_s3"></a> [s3](#module\_s3) | ../../common/s3 | n/a |
 | <a name="module_search_configuration_bucket"></a> [search\_configuration\_bucket](#module\_search\_configuration\_bucket) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v3.14.0 |
+| <a name="module_waf"></a> [waf](#module\_waf) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/waf | aws/waf-v1.1.3 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
+| [aws_cloudfront_cache_policy.cache_all_qsa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_cache_policy) | resource |
+| [aws_cloudfront_origin_request_policy.forward_all_qsa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_request_policy) | resource |
 | [aws_elasticache_subnet_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_subnet_group) | resource |
 | [aws_iam_policy.opensearch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_user.opensearch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
@@ -91,6 +95,7 @@ No outputs.
 | [aws_secretsmanager_secret_version.redis_connection_string_value](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_ssm_parameter.ecr_url](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_cloudfront_cache_policy.caching_disabled](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudfront_cache_policy) | data source |
 | [aws_iam_policy_document.opensearch_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 | [aws_secretsmanager_secret_version.postgres_master_user_details](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
@@ -122,6 +127,7 @@ No outputs.
 | <a name="input_tariff_backend_sync_host"></a> [tariff\_backend\_sync\_host](#input\_tariff\_backend\_sync\_host) | Value of Tariff Sync host. | `string` | n/a | yes |
 | <a name="input_tariff_backend_sync_password"></a> [tariff\_backend\_sync\_password](#input\_tariff\_backend\_sync\_password) | Value of Tariff Sync password. | `string` | n/a | yes |
 | <a name="input_tariff_backend_sync_username"></a> [tariff\_backend\_sync\_username](#input\_tariff\_backend\_sync\_username) | Value of Tariff Sync username. | `string` | n/a | yes |
+| <a name="input_waf_rpm_limit"></a> [waf\_rpm\_limit](#input\_waf\_rpm\_limit) | Request per minute limit for the WAF. | `number` | `100` | no |
 
 ## Outputs
 

--- a/environments/development/common/acm.tf
+++ b/environments/development/common/acm.tf
@@ -3,6 +3,10 @@ module "acm" {
   domain_name    = var.domain_name
   environment    = var.environment
   hosted_zone_id = data.aws_route53_zone.this.zone_id
+
+  providers = {
+    aws = aws.us_east_1
+  }
 }
 
 module "acm_origin" {

--- a/environments/development/common/alb.tf
+++ b/environments/development/common/alb.tf
@@ -3,7 +3,7 @@ module "alb" {
   alb_name              = var.alb_name
   alb_security_group_id = module.alb-security-group.alb_security_group_id
   public_subnet_id      = data.terraform_remote_state.base.outputs.public_subnet_ids
-  certificate_arn       = module.acm.validated_certificate_arn
+  certificate_arn       = module.acm_origin.validated_certificate_arn
   environment           = var.environment
   vpc_id                = data.terraform_remote_state.base.outputs.vpc_id
 }

--- a/environments/development/common/cloudfront.tf
+++ b/environments/development/common/cloudfront.tf
@@ -3,7 +3,7 @@ data "aws_cloudfront_cache_policy" "caching_disabled" {
 }
 
 module "cdn" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront?ref=aws/cloudfront-v1.1.0"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront?ref=aws/cloudfront-v1.1.1"
 
   aliases         = [var.domain_name]
   create_alias    = true

--- a/environments/development/common/cloudfront.tf
+++ b/environments/development/common/cloudfront.tf
@@ -1,0 +1,111 @@
+data "aws_cloudfront_cache_policy" "caching_disabled" {
+  name = "Managed-CachingDisabled"
+}
+
+module "cdn" {
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront?ref=aws/cloudfront-v1.0.1"
+
+  aliases         = [var.domain_name]
+  route53_zone_id = data.aws_route53_zone.this.id
+  comment         = "${title(var.environment)} CDN"
+
+  enabled         = true
+  is_ipv6_enabled = true
+  price_class     = "PriceClass_100"
+
+  web_acl_id = module.waf.web_acl_id
+
+  logging_config = {
+    bucket = module.logs.s3_bucket_bucket_domain_name
+    prefix = "cloudfront/${var.environment}"
+  }
+
+  origin = {
+    frontend = {
+      domain_name = local.origin_domain_name
+      custom_origin_config = {
+        http_port              = 80
+        https_port             = 443
+        origin_protocol_policy = "https-only"
+        origin_ssl_protocols   = ["TLSv1.2"]
+      }
+    }
+  }
+
+  cache_behavior = {
+    default = {
+      target_origin_id       = "frontend"
+      viewer_protocol_policy = "redirect-to-https"
+
+      cache_policy_id          = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id = aws_cloudfront_origin_request_policy.forward_all_qsa.id
+
+      min_ttl     = 0
+      default_ttl = 0
+      max_ttl     = 0
+
+      compress = false
+
+      allowed_methods = [
+        "GET",
+        "HEAD",
+        "OPTIONS",
+        "PUT",
+        "POST",
+        "PATCH",
+        "DELETE"
+      ]
+
+      cached_methods = [
+        "GET",
+        "HEAD"
+      ]
+    },
+  }
+
+  viewer_certificate = {
+    ssl_support_method  = "sni-only"
+    acm_certificate_arn = module.acm.validated_certificate_arn
+    depends_on = [
+      module.acm.validated_certificate_arn
+    ]
+  }
+}
+
+resource "aws_cloudfront_cache_policy" "cache_all_qsa" {
+  name        = "Cache-All-QSA-${var.environment}"
+  comment     = "Cache all QSA (managed by Terraform)"
+  default_ttl = 86400
+  max_ttl     = 31536000
+  min_ttl     = 1
+
+  parameters_in_cache_key_and_forwarded_to_origin {
+    cookies_config {
+      cookie_behavior = "none"
+    }
+
+    headers_config {
+      header_behavior = "none"
+    }
+
+    query_strings_config {
+      query_string_behavior = "all"
+    }
+  }
+}
+
+resource "aws_cloudfront_origin_request_policy" "forward_all_qsa" {
+  name    = "Forward-All-QSA-${var.environment}"
+  comment = "Forward all QSA (managed by Terraform)"
+  cookies_config {
+    cookie_behavior = "all"
+  }
+
+  headers_config {
+    header_behavior = "allViewer"
+  }
+
+  query_strings_config {
+    query_string_behavior = "all"
+  }
+}

--- a/environments/development/common/cloudfront.tf
+++ b/environments/development/common/cloudfront.tf
@@ -3,9 +3,10 @@ data "aws_cloudfront_cache_policy" "caching_disabled" {
 }
 
 module "cdn" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront?ref=aws/cloudfront-v1.0.1"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront?ref=aws/cloudfront-v1.1.0"
 
   aliases         = [var.domain_name]
+  create_alias    = true
   route53_zone_id = data.aws_route53_zone.this.id
   comment         = "${title(var.environment)} CDN"
 

--- a/environments/development/common/locals.tf
+++ b/environments/development/common/locals.tf
@@ -1,5 +1,11 @@
+locals {
+  account_id         = data.aws_caller_identity.current.account_id
+  origin_domain_name = "origin.${var.domain_name}"
+}
+
 data "aws_caller_identity" "current" {}
 
-locals {
-  account_id = data.aws_caller_identity.current.account_id
+data "aws_route53_zone" "this" {
+  name         = var.domain_name
+  private_zone = false
 }

--- a/environments/development/common/route53.tf
+++ b/environments/development/common/route53.tf
@@ -1,12 +1,3 @@
-locals {
-  origin_domain_name = "origin.${var.domain_name}"
-}
-
-data "aws_route53_zone" "this" {
-  name         = var.domain_name
-  private_zone = false
-}
-
 resource "aws_route53_zone" "origin" {
   name = local.origin_domain_name
 }

--- a/environments/development/common/variables.tf
+++ b/environments/development/common/variables.tf
@@ -135,3 +135,9 @@ variable "tariff_backend_oauth_secret" {
   type        = string
   sensitive   = true
 }
+
+variable "waf_rpm_limit" {
+  description = "Request per minute limit for the WAF."
+  type        = number
+  default     = 100
+}

--- a/environments/development/common/versions.tf
+++ b/environments/development/common/versions.tf
@@ -11,3 +11,8 @@ terraform {
 provider "aws" {
   region = var.region
 }
+
+provider "aws" {
+  region = "us-east-1"
+  alias  = "us_east_1"
+}

--- a/environments/development/common/waf.tf
+++ b/environments/development/common/waf.tf
@@ -1,0 +1,20 @@
+module "waf" {
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/waf?ref=aws/waf-v1.1.3"
+
+  name  = "tariff-waf-${var.environment}"
+  scope = "CLOUDFRONT"
+  ip_rate_based_rule = {
+    name      = "ratelimiting"
+    priority  = 1
+    rpm_limit = var.waf_rpm_limit
+    action    = "block"
+    custom_response = {
+      response_code = 429
+      body_key      = "rate-limit-exceeded"
+      response_header = {
+        name  = "X-Rate-Limit"
+        value = "1"
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Added the CDN
- Added the WAF to protect the CDN

## Why?

I am doing this because:

- We have the origin, but we now need the CDN route so we have a protected and cacheable endpoint.