### PR TITLE
BAU: Use the correct key for secrets

### DIFF
--- a/environments/development/common/secrets.tf
+++ b/environments/development/common/secrets.tf
@@ -57,7 +57,7 @@ module "admin_oauth_secret" {
 module "admin_bearer_token" {
   source          = "../../common/secret/"
   name            = "admin-bearer-token"
-  kms_key_arn     = aws_kms_key.opensearch_kms_key.arn
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
   recovery_window = 7
   secret_string   = var.admin_bearer_token
 }


### PR DESCRIPTION
I have:

- Changed the key used to encrypt the `admin_bearer_token` secret.

I am doing this because:

- For some reason it was using the opensearch key, which is wrong. This meant the admin service couldn't start as it doesn't have access to that key.