### PR TITLE
BAU: Add origin wildcard DNS record

### DIFF
--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -90,6 +90,7 @@ No outputs.
 | [aws_kms_key.secretsmanager_kms_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_route53_record.origin_ns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.origin_root](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.origin_wildcard](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_zone.origin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
 | [aws_secretsmanager_secret.redis_connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret_version.redis_connection_string_value](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |

--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -59,7 +59,7 @@ No outputs.
 | <a name="module_backend_sync_host"></a> [backend\_sync\_host](#module\_backend\_sync\_host) | ../../common/secret/ | n/a |
 | <a name="module_backend_sync_password"></a> [backend\_sync\_password](#module\_backend\_sync\_password) | ../../common/secret/ | n/a |
 | <a name="module_backend_sync_username"></a> [backend\_sync\_username](#module\_backend\_sync\_username) | ../../common/secret/ | n/a |
-| <a name="module_cdn"></a> [cdn](#module\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.1.1 |
+| <a name="module_cdn"></a> [cdn](#module\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.2.1 |
 | <a name="module_cloudwatch"></a> [cloudwatch](#module\_cloudwatch) | ../../common/cloudwatch/ | n/a |
 | <a name="module_duty_calculator_secret_key_base"></a> [duty\_calculator\_secret\_key\_base](#module\_duty\_calculator\_secret\_key\_base) | ../../common/secret/ | n/a |
 | <a name="module_ecr"></a> [ecr](#module\_ecr) | ../../common/ecr/ | n/a |
@@ -91,6 +91,7 @@ No outputs.
 | [aws_route53_record.origin_ns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.origin_root](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.origin_wildcard](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.subdomains](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_zone.origin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
 | [aws_secretsmanager_secret.redis_connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret_version.redis_connection_string_value](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |

--- a/environments/development/common/cloudfront.tf
+++ b/environments/development/common/cloudfront.tf
@@ -3,7 +3,7 @@ data "aws_cloudfront_cache_policy" "caching_disabled" {
 }
 
 module "cdn" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront?ref=aws/cloudfront-v1.1.1"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront?ref=aws/cloudfront-v1.2.1"
 
   aliases         = [var.domain_name]
   create_alias    = true

--- a/environments/development/common/route53.tf
+++ b/environments/development/common/route53.tf
@@ -21,3 +21,15 @@ resource "aws_route53_record" "origin_root" {
     evaluate_target_health = true
   }
 }
+
+resource "aws_route53_record" "origin_wildcard" {
+  zone_id = aws_route53_zone.origin.zone_id
+  name    = "*.${local.origin_domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = module.alb.dns_name
+    zone_id                = module.alb.zone_id
+    evaluate_target_health = true
+  }
+}

--- a/environments/development/common/route53.tf
+++ b/environments/development/common/route53.tf
@@ -33,3 +33,16 @@ resource "aws_route53_record" "origin_wildcard" {
     evaluate_target_health = true
   }
 }
+
+resource "aws_route53_record" "subdomains" {
+  for_each = toset(["admin", "signon"])
+  zone_id  = data.aws_route53_zone.this.zone_id
+  name     = "${each.value}.${var.domain_name}"
+  type     = "A"
+
+  alias {
+    name                   = module.cdn.aws_cloudfront_distribution_domain_name
+    zone_id                = module.cdn.aws_cloudfront_distribution_hosted_zone_id
+    evaluate_target_health = true
+  }
+}


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Added an A record for the wildcarded origin subdomain.
- Added Route 53 A records for the required subdomains.

## Why?

I am doing this because:

- Since we have two services that will be using host based routing, admin and signon, we'll want the origin to be accessible for them.
- We want to be able to hit these services at their respective paths, so we'll need A records.