### PR TITLE
HOTT-3733: Create MySQL RDS Instance for Signon

### DIFF
--- a/environments/common/rds/README.md
+++ b/environments/common/rds/README.md
@@ -29,8 +29,13 @@ No modules.
 | [aws_db_instance.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance) | resource |
 | [aws_db_subnet_group.rds_private_subnet](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_subnet_group) | resource |
 | [aws_kms_key.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_secretsmanager_secret.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret_version.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
+| [random_password.master_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [random_string.master_username](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [random_string.prefix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
+| [random_string.private_subnet_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
+| [aws_secretsmanager_secret_version.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 
 ## Inputs
 
@@ -49,6 +54,7 @@ No modules.
 | <a name="input_name"></a> [name](#input\_name) | Name of the database. | `string` | n/a | yes |
 | <a name="input_performance_insights_retention_period"></a> [performance\_insights\_retention\_period](#input\_performance\_insights\_retention\_period) | Amount of time, in days, (minimum 7, maximum 731, or any multiple of 31) to retain performance insights data. | `number` | `31` | no |
 | <a name="input_private_subnet_ids"></a> [private\_subnet\_ids](#input\_private\_subnet\_ids) | A list of private subnet IDs | `list(string)` | n/a | yes |
+| <a name="input_secret_kms_key_arn"></a> [secret\_kms\_key\_arn](#input\_secret\_kms\_key\_arn) | ARN of the KMS Key to use to encrypt the connection string secret. | `string` | n/a | yes |
 | <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | A list of security group IDs to associate with this RDS instance. | `list(string)` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Map of tags to apply to all taggable resources. | `map(string)` | `{}` | no |
 

--- a/environments/common/rds/data.tf
+++ b/environments/common/rds/data.tf
@@ -1,0 +1,41 @@
+resource "random_string" "master_username" {
+  length  = 7
+  special = false
+}
+
+resource "random_string" "prefix" {
+  length  = 1
+  special = false
+  numeric = false
+}
+
+resource "random_password" "master_password" {
+  length           = 16
+  special          = true
+  override_special = "_%@"
+}
+
+resource "random_string" "private_subnet_suffix" {
+  length  = 8
+  special = false
+}
+
+data "aws_secretsmanager_secret_version" "this" {
+  secret_id  = aws_db_instance.this.master_user_secret[0].secret_arn
+  depends_on = [aws_db_instance.this]
+}
+
+resource "aws_secretsmanager_secret" "this" {
+  name                    = "${lower(var.name)}-connection-string"
+  kms_key_id              = var.secret_kms_key_arn
+  recovery_window_in_days = 7
+}
+
+resource "aws_secretsmanager_secret_version" "this" {
+  secret_id     = aws_secretsmanager_secret.this.id
+  secret_string = "${var.engine}://${local.master_username}:${local.master_password}@${aws_db_instance.this.endpoint}/${var.name}"
+}
+
+locals {
+  master_password = urlencode(jsondecode(data.aws_secretsmanager_secret_version.this.secret_string)["password"])
+}

--- a/environments/common/rds/data.tf
+++ b/environments/common/rds/data.tf
@@ -18,6 +18,7 @@ resource "random_password" "master_password" {
 resource "random_string" "private_subnet_suffix" {
   length  = 8
   special = false
+  upper   = false
 }
 
 data "aws_secretsmanager_secret_version" "this" {

--- a/environments/common/rds/data.tf
+++ b/environments/common/rds/data.tf
@@ -35,7 +35,3 @@ resource "aws_secretsmanager_secret_version" "this" {
   secret_id     = aws_secretsmanager_secret.this.id
   secret_string = "${var.engine}://${local.master_username}:${local.master_password}@${aws_db_instance.this.endpoint}/${var.name}"
 }
-
-locals {
-  master_password = urlencode(jsondecode(data.aws_secretsmanager_secret_version.this.secret_string)["password"])
-}

--- a/environments/common/rds/locals.tf
+++ b/environments/common/rds/locals.tf
@@ -1,6 +1,7 @@
 locals {
-  master_username       = "${random_string.prefix.result}${random_string.master_username.result}"
   max_allocated_storage = var.max_allocated_storage <= var.allocated_storage || var.max_allocated_storage == null ? var.allocated_storage : var.max_allocated_storage
+  master_username       = "${random_string.prefix.result}${random_string.master_username.result}"
+  master_password       = urlencode(jsondecode(data.aws_secretsmanager_secret_version.this.secret_string)["password"])
 
   tags = merge(
     {

--- a/environments/common/rds/rds.tf
+++ b/environments/common/rds/rds.tf
@@ -35,30 +35,15 @@ resource "aws_db_instance" "this" {
   tags = local.tags
 }
 
+resource "aws_db_subnet_group" "rds_private_subnet" {
+  name       = "subnet-group-${random_string.private_subnet_suffix.result}"
+  subnet_ids = var.private_subnet_ids
+  tags       = local.tags
+}
+
 resource "aws_kms_key" "this" {
   description         = "KMS key for the ${var.name} RDS instance on ${var.environment}."
   key_usage           = "ENCRYPT_DECRYPT"
   enable_key_rotation = true
   tags                = local.tags
-}
-
-resource "random_string" "master_username" {
-  length  = 7
-  special = false
-}
-
-resource "random_string" "prefix" {
-  length  = 1
-  special = false
-  numeric = false
-}
-
-# rds private subnet
-resource "aws_db_subnet_group" "rds_private_subnet" {
-  name       = "rds-subnet-group-${var.environment}"
-  subnet_ids = var.private_subnet_ids
-
-  tags = {
-    Name = "RDS Private Subnet Group ${var.environment}"
-  }
 }

--- a/environments/common/rds/variables.tf
+++ b/environments/common/rds/variables.tf
@@ -79,3 +79,8 @@ variable "private_subnet_ids" {
   description = "A list of private subnet IDs"
   type        = list(string)
 }
+
+variable "secret_kms_key_arn" {
+  description = "ARN of the KMS Key to use to encrypt the connection string secret."
+  type        = string
+}

--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -50,7 +50,6 @@ No outputs.
 | <a name="module_admin_secret_key_base"></a> [admin\_secret\_key\_base](#module\_admin\_secret\_key\_base) | ../../common/secret/ | n/a |
 | <a name="module_alb"></a> [alb](#module\_alb) | ../../common/application-load-balancer/ | n/a |
 | <a name="module_alb-security-group"></a> [alb-security-group](#module\_alb-security-group) | ../../common/security-group/ | n/a |
-| <a name="module_backend_database_connection_string"></a> [backend\_database\_connection\_string](#module\_backend\_database\_connection\_string) | ../../common/secret/ | n/a |
 | <a name="module_backend_oauth_id"></a> [backend\_oauth\_id](#module\_backend\_oauth\_id) | ../../common/secret/ | n/a |
 | <a name="module_backend_oauth_secret"></a> [backend\_oauth\_secret](#module\_backend\_oauth\_secret) | ../../common/secret/ | n/a |
 | <a name="module_backend_secret_key_base"></a> [backend\_secret\_key\_base](#module\_backend\_secret\_key\_base) | ../../common/secret/ | n/a |
@@ -65,6 +64,7 @@ No outputs.
 | <a name="module_ecr"></a> [ecr](#module\_ecr) | ../../common/ecr/ | n/a |
 | <a name="module_frontend_secret_key_base"></a> [frontend\_secret\_key\_base](#module\_frontend\_secret\_key\_base) | ../../common/secret/ | n/a |
 | <a name="module_logs"></a> [logs](#module\_logs) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v3.14.0 |
+| <a name="module_mysql"></a> [mysql](#module\_mysql) | ../../common/rds | n/a |
 | <a name="module_newrelic_license_key"></a> [newrelic\_license\_key](#module\_newrelic\_license\_key) | ../../common/secret/ | n/a |
 | <a name="module_opensearch"></a> [opensearch](#module\_opensearch) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/opensearch | aws/opensearch-v1.1.0 |
 | <a name="module_opensearch_packages_bucket"></a> [opensearch\_packages\_bucket](#module\_opensearch\_packages\_bucket) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v3.14.0 |
@@ -100,7 +100,6 @@ No outputs.
 | [aws_cloudfront_cache_policy.caching_disabled](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudfront_cache_policy) | data source |
 | [aws_iam_policy_document.opensearch_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
-| [aws_secretsmanager_secret_version.postgres_master_user_details](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 | [terraform_remote_state.base](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 
 ## Inputs

--- a/environments/development/common/rds.tf
+++ b/environments/development/common/rds.tf
@@ -2,7 +2,7 @@ module "postgres" {
   source = "../../common/rds"
 
   environment    = var.environment
-  name           = local.database_name
+  name           = "TradeTariffPostgres${title(var.environment)}"
   engine         = "postgres"
   engine_version = "13.11"
 
@@ -18,25 +18,36 @@ module "postgres" {
   max_allocated_storage = 40
   security_group_ids    = [module.alb-security-group.be_to_rds_security_group_id]
 
+  secret_kms_key_arn = aws_kms_key.secretsmanager_kms_key.arn
+
   depends_on = [
     module.alb-security-group
   ]
 }
 
-data "aws_secretsmanager_secret_version" "postgres_master_user_details" {
-  secret_id = module.postgres.master_user_secret
-}
+module "mysql" {
+  source = "../../common/rds"
 
-locals {
-  postgres_username = urlencode(jsondecode(data.aws_secretsmanager_secret_version.postgres_master_user_details.secret_string)["username"])
-  postgres_password = urlencode(jsondecode(data.aws_secretsmanager_secret_version.postgres_master_user_details.secret_string)["password"])
-  database_name     = "TradeTariffPostgres${title(var.environment)}"
-}
+  environment    = var.environment
+  name           = "TradeTariffMySQL${title(var.environment)}"
+  engine         = "mysql"
+  engine_version = "8.0"
 
-module "backend_database_connection_string" {
-  source          = "../../common/secret/"
-  name            = "backend-database-connection-string"
-  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window = 7
-  secret_string   = "postgres://${local.postgres_username}:${local.postgres_password}@${module.postgres.db_endpoint}/${local.database_name}"
+  deletion_protection = false # in dev
+
+  # smallest that supports encryption at rest and postgres 13.11
+  instance_type      = "db.t3.micro"
+  backup_window      = "22:00-23:00"
+  maintenance_window = "Fri:23:00-Sat:01:00"
+  private_subnet_ids = data.terraform_remote_state.base.outputs.private_subnet_ids
+
+  allocated_storage     = 20
+  max_allocated_storage = 40
+  security_group_ids    = [module.alb-security-group.be_to_rds_security_group_id]
+
+  secret_kms_key_arn = aws_kms_key.secretsmanager_kms_key.arn
+
+  depends_on = [
+    module.alb-security-group
+  ]
 }

--- a/environments/development/common/rds.tf
+++ b/environments/development/common/rds.tf
@@ -35,8 +35,7 @@ module "mysql" {
 
   deletion_protection = false # in dev
 
-  # smallest that supports encryption at rest and postgres 13.11
-  instance_type      = "db.t3.micro"
+  instance_type      = "db.t3.medium"
   backup_window      = "22:00-23:00"
   maintenance_window = "Fri:23:00-Sat:01:00"
   private_subnet_ids = data.terraform_remote_state.base.outputs.private_subnet_ids


### PR DESCRIPTION
[ci skip] because the changes are quite big.

# Pull Request

## What?

I have:

- This PR makes significant change to the RDS module, in that it takes the connection string secret generation away from having to be created downstream. It does this by using a data source to fetch the secret created by RDS and extracting the password and parsing the inputs to build a connection string.
- I have also changed the name of the subnet group as it would otherwise clash with the new MySQL instance.


## Why?

I am doing this because:

- The Signon service requires a small MySQL database, separate from the Postgres instance used by the backends.
- We need a connection string when we build out the RDS instances, so having the module handle this internally is a more useful abstraction.