### PR TITLE
BAU: Set up healthcheck path dynamically

### DIFF
--- a/environments/common/application-load-balancer/alb.tf
+++ b/environments/common/application-load-balancer/alb.tf
@@ -26,7 +26,7 @@ resource "aws_lb_target_group" "trade_tariff_target_groups" {
   health_check {
     enabled             = true
     interval            = 60
-    path                = "/healthcheckz"
+    path                = each.value.healthcheck_path
     port                = "traffic-port"
     healthy_threshold   = 3
     unhealthy_threshold = 3

--- a/environments/common/application-load-balancer/locals.tf
+++ b/environments/common/application-load-balancer/locals.tf
@@ -4,36 +4,42 @@ locals {
       target_group_name = "trade-tariff-ad-tg-${var.environment}"
       priority          = 10
       host              = ["admin.*"]
+      healthcheck_path  = "/healthcheckz"
     }
 
     signon = {
       target_group_name = "trade-tariff-so-tg-${var.environment}"
       priority          = 20
       host              = ["signon.*"]
+      healthcheck_path  = "/healthcheck/live"
     }
 
     backend_uk = {
       target_group_name = "backend-uk-tg-${var.environment}"
       priority          = 30
       paths             = ["/uk/api/beta/*"]
+      healthcheck_path  = "/healthcheckz"
     }
 
     backend_xi = {
       target_group_name = "backend-xi-tg-${var.environment}"
       priority          = 35
       paths             = ["/xi/api/beta/*"]
+      healthcheck_path  = "/healthcheckz"
     }
 
     duty_calculator = {
       target_group_name = "trade-tariff-dc-tg-${var.environment}"
       priority          = 40
       paths             = ["/duty-calculator/*"]
+      healthcheck_path  = "/healthcheckz"
     }
 
     search_query_parser = {
       target_group_name = "trade-tariff-sqp-tg-${var.environment}"
       priority          = 50
       paths             = ["/api/search/*"]
+      healthcheck_path  = "/healthcheckz"
     }
 
     # frontend is a fallback, so must have the highest priority
@@ -41,6 +47,7 @@ locals {
       target_group_name = "trade-tariff-fe-tg-${var.environment}"
       priority          = 100
       paths             = ["/*"]
+      healthcheck_path  = "/healthcheckz"
     }
   }
 }


### PR DESCRIPTION
[ci skip]

# Pull Request

## What?

I have:

- Added `healthcheck_path` to the locals for the services.
- Changed the `path` of the `health_check` block to use this string from the locals.

## Why?

I am doing this because:

- The signon service exposes it's healthcheck on `/healthcheck/live`. As we don't fork this, but simply pull `alphagov/signon` and apply basic `sed`/`echo` text patches, we can't edit to add our standard `/healthcheckz` path. In this case, we want to change the path of the health check we're doing through the target group.