### PR TITLE
BAU: Fix RDS password, shorten deregistration delay

### DIFF
--- a/environments/common/application-load-balancer/alb.tf
+++ b/environments/common/application-load-balancer/alb.tf
@@ -16,12 +16,13 @@ resource "aws_lb" "application_load_balancer" {
 
 /* target group name cannot be longer than 32 chars */
 resource "aws_lb_target_group" "trade_tariff_target_groups" {
-  for_each    = local.services
-  name        = each.value.target_group_name
-  port        = var.application_port
-  protocol    = "HTTP"
-  target_type = "ip"
-  vpc_id      = var.vpc_id
+  for_each             = local.services
+  name                 = each.value.target_group_name
+  port                 = var.application_port
+  protocol             = "HTTP"
+  target_type          = "ip"
+  vpc_id               = var.vpc_id
+  deregistration_delay = 20
 
   health_check {
     enabled             = true

--- a/environments/common/rds/README.md
+++ b/environments/common/rds/README.md
@@ -35,7 +35,6 @@ No modules.
 | [random_string.master_username](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [random_string.prefix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [random_string.private_subnet_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
-| [aws_secretsmanager_secret_version.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 
 ## Inputs
 

--- a/environments/common/rds/data.tf
+++ b/environments/common/rds/data.tf
@@ -12,18 +12,13 @@ resource "random_string" "prefix" {
 resource "random_password" "master_password" {
   length           = 16
   special          = true
-  override_special = "_%@"
+  override_special = "_-"
 }
 
 resource "random_string" "private_subnet_suffix" {
   length  = 8
   special = false
   upper   = false
-}
-
-data "aws_secretsmanager_secret_version" "this" {
-  secret_id  = aws_db_instance.this.master_user_secret[0].secret_arn
-  depends_on = [aws_db_instance.this]
 }
 
 resource "aws_secretsmanager_secret" "this" {

--- a/environments/common/rds/locals.tf
+++ b/environments/common/rds/locals.tf
@@ -1,7 +1,7 @@
 locals {
   max_allocated_storage = var.max_allocated_storage <= var.allocated_storage || var.max_allocated_storage == null ? var.allocated_storage : var.max_allocated_storage
   master_username       = "${random_string.prefix.result}${random_string.master_username.result}"
-  master_password       = urlencode(jsondecode(data.aws_secretsmanager_secret_version.this.secret_string)["password"])
+  master_password       = random_password.master_password.result
 
   tags = merge(
     {

--- a/environments/common/rds/rds.tf
+++ b/environments/common/rds/rds.tf
@@ -23,7 +23,7 @@ resource "aws_db_instance" "this" {
   apply_immediately = false
 
   username                            = local.master_username
-  manage_master_user_password         = true
+  password                            = local.master_password
   iam_database_authentication_enabled = true
 
   performance_insights_enabled          = true


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Fix RDS password
- Shortened the deregistration delay on target groups

## Why?

I am doing this because:

- The RDS password configuration had too much complexity and was just broken for some reason :(
- We don't want to have to wait 300 seconds for apps to deregister.