### PR TITLE
HOTT-3844: Split Backend Redis

### DIFF
--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -76,7 +76,6 @@ No outputs.
 | <a name="module_signon_devise_secret_key"></a> [signon\_devise\_secret\_key](#module\_signon\_devise\_secret\_key) | ../../common/secret/ | n/a |
 | <a name="module_signon_govuk_notify_api_key"></a> [signon\_govuk\_notify\_api\_key](#module\_signon\_govuk\_notify\_api\_key) | ../../common/secret/ | n/a |
 | <a name="module_signon_secret_key_base"></a> [signon\_secret\_key\_base](#module\_signon\_secret\_key\_base) | ../../common/secret/ | n/a |
-| <a name="module_waf"></a> [waf](#module\_waf) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/waf | aws/waf-v1.1.3 |
 | <a name="module_waf"></a> [waf](#module\_waf) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/waf | aws/waf-v1.2.1 |
 
 ## Resources

--- a/environments/development/common/redis.tf
+++ b/environments/development/common/redis.tf
@@ -1,7 +1,8 @@
 locals {
   redis = toset([
     "frontend",
-    "backend",
+    "backend-uk",
+    "backend-xi",
     "admin"
   ])
 }


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Removed the `backend` Redis replication group.
- Added `backend-uk` and `backend-xi` Redis replication groups. 

## Why?

I am doing this because:

- The backend service is split into two; UK and XI (Northern Ireland) services. These two services, whilst using the same application, have subtly different properties that require some separation of concerns. This means that we need a Redis pool for each of UK and XI services.

## Downstream Concerns

- We will need to update the backend service(s) to fetch the new Redis strings.