### PR TITLE
HOTT-3851: Create Redis cluster for Signon tool

### DIFF
--- a/environments/development/common/redis.tf
+++ b/environments/development/common/redis.tf
@@ -3,7 +3,8 @@ locals {
     "frontend",
     "backend-uk",
     "backend-xi",
-    "admin"
+    "admin",
+    "signon"
   ])
 }
 


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Added `signon` to the list of Redis clusters to create.

## Why?

I am doing this because:

- The signon tool needs its own Redis cluster.