### PR TITLE
HOTT-3852 - Add base, common and applications folder and terragrunt config for staging and production

### DIFF
--- a/environments/production/applications/terragrunt.hcl
+++ b/environments/production/applications/terragrunt.hcl
@@ -1,0 +1,15 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  extra_arguments "init_args" {
+    commands = [
+      "init"
+    ]
+
+    arguments = [
+      "-upgrade",
+    ]
+  }
+}

--- a/environments/production/base/terragrunt.hcl
+++ b/environments/production/base/terragrunt.hcl
@@ -1,0 +1,15 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  extra_arguments "init_args" {
+    commands = [
+      "init"
+    ]
+
+    arguments = [
+      "-upgrade",
+    ]
+  }
+}

--- a/environments/staging/applications/terragrunt.hcl
+++ b/environments/staging/applications/terragrunt.hcl
@@ -1,0 +1,15 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  extra_arguments "init_args" {
+    commands = [
+      "init"
+    ]
+
+    arguments = [
+      "-upgrade",
+    ]
+  }
+}

--- a/environments/staging/base/terragrunt.hcl
+++ b/environments/staging/base/terragrunt.hcl
@@ -1,0 +1,15 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  extra_arguments "init_args" {
+    commands = [
+      "init"
+    ]
+
+    arguments = [
+      "-upgrade",
+    ]
+  }
+}

--- a/environments/staging/common/terragrunt.hcl
+++ b/environments/staging/common/terragrunt.hcl
@@ -1,0 +1,15 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  extra_arguments "init_args" {
+    commands = [
+      "init"
+    ]
+
+    arguments = [
+      "-upgrade",
+    ]
+  }
+}


### PR DESCRIPTION


## What?

I have:

- Added base, common and applications folders and terragrunt config for staging and production

## Why?

I am doing this because:

- Deploying services to staging and production for the first time
