### PR TITLE
HOTT-3884: Create lock tables for service TF

### DIFF
--- a/environments/development/applications/README.md
+++ b/environments/development/applications/README.md
@@ -25,6 +25,7 @@
 
 | Name | Type |
 |------|------|
+| [aws_dynamodb_table.lock](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
 | [aws_kms_key.log_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_service_discovery_private_dns_namespace.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/service_discovery_private_dns_namespace) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |

--- a/environments/development/applications/dynamodb.tf
+++ b/environments/development/applications/dynamodb.tf
@@ -1,0 +1,15 @@
+#tfsec:ignore:aws-dynamodb-enable-recovery
+#tfsec:ignore:aws-dynamodb-enable-at-rest-encryption
+#tfsec:ignore:aws-dynamodb-table-customer-key
+resource "aws_dynamodb_table" "lock" {
+  for_each = toset(local.applications)
+
+  name         = "${each.key}-lock-${local.account_id}"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+}

--- a/environments/development/applications/locals.tf
+++ b/environments/development/applications/locals.tf
@@ -1,3 +1,11 @@
 locals {
   account_id = data.aws_caller_identity.current.account_id
+  applications = [
+    "admin",
+    "backend",
+    "duty-calculator",
+    "frontend",
+    "search-query-parser",
+    "signon"
+  ]
 }

--- a/environments/staging/applications/README.md
+++ b/environments/staging/applications/README.md
@@ -25,6 +25,7 @@
 
 | Name | Type |
 |------|------|
+| [aws_dynamodb_table.lock](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
 | [aws_kms_key.log_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_service_discovery_private_dns_namespace.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/service_discovery_private_dns_namespace) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |

--- a/environments/staging/applications/dynamodb.tf
+++ b/environments/staging/applications/dynamodb.tf
@@ -1,0 +1,15 @@
+#tfsec:ignore:aws-dynamodb-enable-recovery
+#tfsec:ignore:aws-dynamodb-enable-at-rest-encryption
+#tfsec:ignore:aws-dynamodb-table-customer-key
+resource "aws_dynamodb_table" "lock" {
+  for_each = toset(local.applications)
+
+  name         = "${each.key}-lock-${local.account_id}"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+}

--- a/environments/staging/applications/locals.tf
+++ b/environments/staging/applications/locals.tf
@@ -1,3 +1,11 @@
 locals {
   account_id = data.aws_caller_identity.current.account_id
+  applications = [
+    "admin",
+    "backend",
+    "duty-calculator",
+    "frontend",
+    "search-query-parser",
+    "signon"
+  ]
 }


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Added DynamoDB lock tables for all applications.

## Why?

I am doing this because:

- We need to enable Terraform state locking on the services as CI jobs may run in parallel across feature branches. This could cause state corruption, so we want to have locking in place to prevent this.