### PR TITLE
bau-ecr-mutable - Revert image_tag_mutability to MUTABLE

### DIFF
--- a/environments/common/ecr/ecr.tf
+++ b/environments/common/ecr/ecr.tf
@@ -9,9 +9,10 @@ resource "aws_kms_alias" "this" {
 }
 
 resource "aws_ecr_repository" "this" {
-  for_each             = toset(local.applications)
-  name                 = "tariff-${each.key}-${var.environment}"
-  image_tag_mutability = "IMMUTABLE"
+  for_each = toset(local.applications)
+  name     = "tariff-${each.key}-${var.environment}"
+  #tfsec:ignore:aws-ecr-enforce-immutable-repository
+  image_tag_mutability = "MUTABLE"
   force_delete         = false
   tags                 = var.tags
 


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Reverted image_tag_mutability to MUTABLE temporarity until we update the build job to query repo to check if the tag already exists 

