### PR TITLE
BAU: Rename development VPC to align with standard

### DIFF
--- a/environments/development/base/vpc.tf
+++ b/environments/development/base/vpc.tf
@@ -2,7 +2,7 @@
 module "vpc" {
   source = "github.com/trade-tariff/terraform-aws-vpc?ref=0ea859dd659701e6e8dda61e61c47629eeda5ba3"
 
-  name = "trade_tariff_development_vpc"
+  name = "trade-tariff-${var.environment}-vpc"
   cidr = "10.0.0.0/16"
 
   azs             = var.availability_zone


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Renamed the `development` VPC to use hyphens instead of underscores.
 
## Why?

I am doing this because:

- We should be consistent with our naming scheme across environments.