### PR TITLE
BAU: Simplify target groups

### DIFF
--- a/environments/common/application-load-balancer/alb.tf
+++ b/environments/common/application-load-balancer/alb.tf
@@ -16,8 +16,8 @@ resource "aws_lb" "application_load_balancer" {
 
 /* target group name cannot be longer than 32 chars */
 resource "aws_lb_target_group" "trade_tariff_target_groups" {
-  for_each             = local.blue_green
-  name                 = replace(each.value.target_group_name, "_", "-")
+  for_each             = local.services
+  name                 = replace(each.key, "_", "-")
   port                 = var.application_port
   protocol             = "HTTP"
   target_type          = "ip"
@@ -71,7 +71,7 @@ resource "aws_lb_listener" "trade_tariff_listeners" {
 }
 
 resource "aws_lb_listener_rule" "this" {
-  for_each     = local.blue_green
+  for_each     = local.services
   listener_arn = aws_lb_listener.trade_tariff_listeners.arn
 
   action {
@@ -80,7 +80,7 @@ resource "aws_lb_listener_rule" "this" {
   }
 
   dynamic "condition" {
-    for_each = lookup(local.blue_green[each.key], "host", null) != null ? [true] : []
+    for_each = lookup(local.services[each.key], "host", null) != null ? [true] : []
     content {
       host_header {
         values = each.value.host
@@ -89,7 +89,7 @@ resource "aws_lb_listener_rule" "this" {
   }
 
   dynamic "condition" {
-    for_each = lookup(local.blue_green[each.key], "paths", null) != null ? [true] : []
+    for_each = lookup(local.services[each.key], "paths", null) != null ? [true] : []
     content {
       path_pattern {
         values = each.value.paths

--- a/environments/common/application-load-balancer/locals.tf
+++ b/environments/common/application-load-balancer/locals.tf
@@ -1,68 +1,38 @@
 locals {
-  environment = "development"
   services = {
     admin = {
-      target_group_name = "trade-tariff-ad-tg-${local.environment}"
-      host              = ["admin.*"]
-      healthcheck_path  = "/healthcheckz"
+      host             = ["admin.*"]
+      healthcheck_path = "/healthcheckz"
     }
 
     signon = {
-      target_group_name = "trade-tariff-so-tg-${local.environment}"
-      host              = ["signon.*"]
-      healthcheck_path  = "/healthcheck/live"
+      host             = ["signon.*"]
+      healthcheck_path = "/healthcheck/live"
     }
 
     backend_uk = {
-      target_group_name = "backend-uk-tg-${local.environment}"
-      paths             = ["/uk/api/beta/*"]
-      healthcheck_path  = "/healthcheckz"
+      paths            = ["/uk/api/beta/*"]
+      healthcheck_path = "/healthcheckz"
     }
 
     backend_xi = {
-      target_group_name = "backend-xi-tg-${local.environment}"
-      paths             = ["/xi/api/beta/*"]
-      healthcheck_path  = "/healthcheckz"
+      paths            = ["/xi/api/beta/*"]
+      healthcheck_path = "/healthcheckz"
     }
 
     duty_calculator = {
-      target_group_name = "trade-tariff-dc-tg-${local.environment}"
-      paths             = ["/duty-calculator/*"]
-      healthcheck_path  = "/healthcheckz"
+      paths            = ["/duty-calculator/*"]
+      healthcheck_path = "/healthcheckz"
     }
 
     search_query_parser = {
-      target_group_name = "trade-tariff-sqp-tg-${local.environment}"
-      paths             = ["/api/search/*"]
-      healthcheck_path  = "/healthcheckz"
+      paths            = ["/api/search/*"]
+      healthcheck_path = "/healthcheckz"
     }
 
     frontend = {
-      target_group_name = "trade-tariff-fe-tg-${local.environment}"
-      paths             = ["/*"]
-      healthcheck_path  = "/healthcheckz"
+      paths            = ["/*"]
+      healthcheck_path = "/healthcheckz"
     }
   }
-
-
-  blue = {
-    for k, v in local.services : "${k}_blue" => {
-      target_group_name = "${k}_blue"
-      host              = try(v.host, null)
-      paths             = try(v.paths, null)
-      healthcheck_path  = v.healthcheck_path
-    }
-  }
-
-  green = {
-    for k, v in local.services : "${k}_green" => {
-      target_group_name = "${k}_green"
-      host              = try(v.host, null)
-      paths             = try(v.paths, null)
-      healthcheck_path  = v.healthcheck_path
-    }
-  }
-
-  # TODO: remove original target groups once blue and green are in use in all apps.
-  blue_green = merge(local.services, local.blue, local.green)
 }


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Simplified target group names
- Removed blue/green target groups

## Why?

I am doing this because:

- We no longer need the duplicated TGs
- The target group names don't need to be complex