### PR TITLE
HOTT-3136: Adds serverless ci users and policies

### DIFF
--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -85,11 +85,12 @@ No outputs.
 | [aws_cloudwatch_log_group.redis_engine_lg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.redis_slow_lg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_elasticache_subnet_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_subnet_group) | resource |
-| [aws_iam_policy.ci-lambda-deployment-policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.ci_lambda_deployment_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.opensearch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_user.opensearch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
-| [aws_iam_user.serverless-lambda-ci](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
+| [aws_iam_user.serverless_lambda_ci](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_iam_user_policy_attachment.opensearch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
+| [aws_iam_user_policy_attachment.serverless_lambda_ci_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
 | [aws_kms_alias.opensearch_kms_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_alias.s3_kms_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_alias.secretsmanager_kms_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |

--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -85,8 +85,10 @@ No outputs.
 | [aws_cloudwatch_log_group.redis_engine_lg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.redis_slow_lg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_elasticache_subnet_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_subnet_group) | resource |
+| [aws_iam_policy.ci-lambda-deployment-policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.opensearch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_user.opensearch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
+| [aws_iam_user.serverless-lambda-ci](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_iam_user_policy_attachment.opensearch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
 | [aws_kms_alias.opensearch_kms_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_alias.s3_kms_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |

--- a/environments/development/common/iam.tf
+++ b/environments/development/common/iam.tf
@@ -1,13 +1,13 @@
-resource "aws_iam_user" "serverless-lambda-ci" {
+resource "aws_iam_user" "serverless_lambda_ci" {
   name = "serverless-lambda-ci"
 }
 
-resource "aws_iam_user_policy_attachment" "serverless-lambda-ci-attachment" {
-  user       = aws_iam_user.serverless-lambda-ci.name
-  policy_arn = aws_iam_policy.ci-lambda-deployment-policy.arn
+resource "aws_iam_user_policy_attachment" "serverless_lambda_ci_attachment" {
+  user       = aws_iam_user.serverless_lambda_ci.name
+  policy_arn = aws_iam_policy.ci_lambda_deployment_policy.arn
 }
 
-resource "aws_iam_policy" "ci-lambda-deployment-policy" {
+resource "aws_iam_policy" "ci_lambda_deployment_policy" {
   name        = "ci-lambda-deployment-policy"
   description = "Policy for CircleCI deployments of serverless applications"
 

--- a/environments/development/common/iam.tf
+++ b/environments/development/common/iam.tf
@@ -1,0 +1,81 @@
+resource "aws_iam_user" "serverless-lambda-ci" {
+  name = "serverless-lambda-ci"
+}
+
+resource "aws_iam_user_policy_attachment" "serverless-lambda-ci-attachment" {
+  user       = aws_iam_user.serverless-lambda-ci.name
+  policy_arn = aws_iam_policy.ci-lambda-deployment-policy.arn
+}
+
+resource "aws_iam_policy" "ci-lambda-deployment-policy" {
+  name        = "ci-lambda-deployment-policy"
+  description = "Policy for CircleCI deployments of serverless applications"
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "s3:ListBucket",
+          "s3:PutObject",
+          "s3:GetObject"
+        ],
+        Resource = [
+          "arn:aws:s3:::${aws_s3_bucket.this["lambda-deployment"].id}",
+          "arn:aws:s3:::${aws_s3_bucket.this["lambda-deployment"].id}/*"
+        ]
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "cloudformation:DescribeStacks",
+          "cloudformation:DescribeStackEvents",
+          "cloudformation:DescribeStackResource",
+          "cloudformation:CreateStack",
+          "cloudformation:UpdateStack",
+          "cloudformation:ValidateTemplate"
+        ],
+        Resource = "*"
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "lambda:GetFunction",
+          "lambda:ListFunctions",
+          "lambda:CreateFunction",
+          "lambda:UpdateFunctionCode",
+          "lambda:UpdateFunctionConfiguration",
+          "lambda:InvokeFunction"
+        ],
+        Resource = "*"
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "iam:CreateRole",
+          "iam:PutRolePolicy",
+          "iam:PassRole"
+        ],
+        Resource = "*"
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:DescribeLogGroups",
+          "logs:DescribeLogStreams"
+        ],
+        Resource = "*"
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "events:PutRule",
+          "events:PutTargets"
+        ],
+        Resource = "*"
+      }
+    ]
+  })
+}


### PR DESCRIPTION
# Jira link

https://transformuk.atlassian.net/browse/HOTT-3136

## What?

We plan to reuse the same circle ci context for the development, staging and production
deployment workflows in the new world of serverless lambda functions.

The serverless function will manage the execution role of the specific lambda function as well as its deployment
and updates.

In terraform we need to create the shared s3 buckets (done elsewhere) and the users that will
orchestrate the deployment of each of the lambda functions in each of the accounts.

I have:

- [x] Added serverless deployment user and policy for development
- [ ] Added serverless deployment user and policy for staging
- [ ] Added serverless deployment user and policy for production

## Why?

I am doing this because:

- This is required for us to be able to orchestrate deployments under different circle ci contexts for the serverless functions
