### PR TITLE
HOTT-2803 - Create API Docs infrastructure on staging and production environments

### DIFF
--- a/environments/production/common/README.md
+++ b/environments/production/common/README.md
@@ -27,6 +27,7 @@
 | <a name="module_admin_secret_key_base"></a> [admin\_secret\_key\_base](#module\_admin\_secret\_key\_base) | ../../common/secret/ | n/a |
 | <a name="module_alb"></a> [alb](#module\_alb) | ../../common/application-load-balancer/ | n/a |
 | <a name="module_alb-security-group"></a> [alb-security-group](#module\_alb-security-group) | ../../common/security-group/ | n/a |
+| <a name="module_api_cdn"></a> [api\_cdn](#module\_api\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.2.1 |
 | <a name="module_backend_oauth_id"></a> [backend\_oauth\_id](#module\_backend\_oauth\_id) | ../../common/secret/ | n/a |
 | <a name="module_backend_oauth_secret"></a> [backend\_oauth\_secret](#module\_backend\_oauth\_secret) | ../../common/secret/ | n/a |
 | <a name="module_backend_secret_key_base"></a> [backend\_secret\_key\_base](#module\_backend\_secret\_key\_base) | ../../common/secret/ | n/a |

--- a/environments/production/common/cloudfront.tf
+++ b/environments/production/common/cloudfront.tf
@@ -110,3 +110,75 @@ resource "aws_cloudfront_origin_request_policy" "forward_all_qsa" {
     query_string_behavior = "all"
   }
 }
+
+# API Docs Cloudfront
+module "api_cdn" {
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront?ref=aws/cloudfront-v1.2.1"
+
+  aliases         = ["api.${var.domain_name}"]
+  create_alias    = true
+  route53_zone_id = data.aws_route53_zone.this.id
+  comment         = "API Docs ${title(var.environment)} CDN"
+
+  enabled         = true
+  is_ipv6_enabled = true
+  price_class     = "PriceClass_100"
+
+  web_acl_id = module.waf.web_acl_id
+
+  logging_config = {
+    bucket = module.logs.s3_bucket_bucket_domain_name
+    prefix = "cloudfront/${var.environment}"
+  }
+
+  origin = {
+    api = {
+      domain_name = "api.${local.origin_domain_name}"
+      custom_origin_config = {
+        http_port              = 80
+        https_port             = 443
+        origin_protocol_policy = "https-only"
+        origin_ssl_protocols   = ["TLSv1.2"]
+      }
+    }
+  }
+
+  cache_behavior = {
+    default = {
+      target_origin_id       = "api"
+      viewer_protocol_policy = "redirect-to-https"
+
+      cache_policy_id          = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id = aws_cloudfront_origin_request_policy.forward_all_qsa.id
+
+      min_ttl     = 0
+      default_ttl = 0
+      max_ttl     = 0
+
+      compress = false
+
+      allowed_methods = [
+        "GET",
+        "HEAD",
+        "OPTIONS",
+        "PUT",
+        "POST",
+        "PATCH",
+        "DELETE"
+      ]
+
+      cached_methods = [
+        "GET",
+        "HEAD"
+      ]
+    },
+  }
+
+  viewer_certificate = {
+    ssl_support_method  = "sni-only"
+    acm_certificate_arn = module.acm.validated_certificate_arn
+    depends_on = [
+      module.acm.validated_certificate_arn
+    ]
+  }
+}

--- a/environments/production/common/s3.tf
+++ b/environments/production/common/s3.tf
@@ -3,6 +3,7 @@ locals {
     persistence       = "trade-tariff-persistence-${local.account_id}"
     pdf               = "trade-tariff-pdf-${local.account_id}"
     lambda-deployment = "trade-tariff-lambda-deployment-${local.account_id}"
+    api-docs          = "trade-tariff-api-docs-${local.account_id}"
   }
 }
 

--- a/environments/staging/common/README.md
+++ b/environments/staging/common/README.md
@@ -27,6 +27,7 @@
 | <a name="module_admin_secret_key_base"></a> [admin\_secret\_key\_base](#module\_admin\_secret\_key\_base) | ../../common/secret/ | n/a |
 | <a name="module_alb"></a> [alb](#module\_alb) | ../../common/application-load-balancer/ | n/a |
 | <a name="module_alb-security-group"></a> [alb-security-group](#module\_alb-security-group) | ../../common/security-group/ | n/a |
+| <a name="module_api_cdn"></a> [api\_cdn](#module\_api\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.2.1 |
 | <a name="module_backend_oauth_id"></a> [backend\_oauth\_id](#module\_backend\_oauth\_id) | ../../common/secret/ | n/a |
 | <a name="module_backend_oauth_secret"></a> [backend\_oauth\_secret](#module\_backend\_oauth\_secret) | ../../common/secret/ | n/a |
 | <a name="module_backend_secret_key_base"></a> [backend\_secret\_key\_base](#module\_backend\_secret\_key\_base) | ../../common/secret/ | n/a |

--- a/environments/staging/common/cloudfront.tf
+++ b/environments/staging/common/cloudfront.tf
@@ -110,3 +110,75 @@ resource "aws_cloudfront_origin_request_policy" "forward_all_qsa" {
     query_string_behavior = "all"
   }
 }
+
+# API Docs Cloudfront
+module "api_cdn" {
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront?ref=aws/cloudfront-v1.2.1"
+
+  aliases         = ["api.${var.domain_name}"]
+  create_alias    = true
+  route53_zone_id = data.aws_route53_zone.this.id
+  comment         = "API Docs ${title(var.environment)} CDN"
+
+  enabled         = true
+  is_ipv6_enabled = true
+  price_class     = "PriceClass_100"
+
+  web_acl_id = module.waf.web_acl_id
+
+  logging_config = {
+    bucket = module.logs.s3_bucket_bucket_domain_name
+    prefix = "cloudfront/${var.environment}"
+  }
+
+  origin = {
+    api = {
+      domain_name = "api.${local.origin_domain_name}"
+      custom_origin_config = {
+        http_port              = 80
+        https_port             = 443
+        origin_protocol_policy = "https-only"
+        origin_ssl_protocols   = ["TLSv1.2"]
+      }
+    }
+  }
+
+  cache_behavior = {
+    default = {
+      target_origin_id       = "api"
+      viewer_protocol_policy = "redirect-to-https"
+
+      cache_policy_id          = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id = aws_cloudfront_origin_request_policy.forward_all_qsa.id
+
+      min_ttl     = 0
+      default_ttl = 0
+      max_ttl     = 0
+
+      compress = false
+
+      allowed_methods = [
+        "GET",
+        "HEAD",
+        "OPTIONS",
+        "PUT",
+        "POST",
+        "PATCH",
+        "DELETE"
+      ]
+
+      cached_methods = [
+        "GET",
+        "HEAD"
+      ]
+    },
+  }
+
+  viewer_certificate = {
+    ssl_support_method  = "sni-only"
+    acm_certificate_arn = module.acm.validated_certificate_arn
+    depends_on = [
+      module.acm.validated_certificate_arn
+    ]
+  }
+}

--- a/environments/staging/common/s3.tf
+++ b/environments/staging/common/s3.tf
@@ -3,6 +3,7 @@ locals {
     persistence       = "trade-tariff-persistence-${local.account_id}"
     pdf               = "trade-tariff-pdf-${local.account_id}"
     lambda-deployment = "trade-tariff-lambda-deployment-${local.account_id}"
+    api-docs          = "trade-tariff-api-docs-${local.account_id}"
   }
 }
 


### PR DESCRIPTION
Jira link

[HOTT-2803](https://transformuk.atlassian.net/browse/HOTT-2803)

## What?

I have:

- Added API Docs infrastructure - cloudfront, s3 bucket on staging and production environments.
