### PR TITLE
Hott 2803 - Set api docs cloudfront origin to s3 bucket

### DIFF
--- a/environments/development/common/cloudfront.tf
+++ b/environments/development/common/cloudfront.tf
@@ -133,7 +133,7 @@ module "api_cdn" {
 
   origin = {
     api = {
-      domain_name = "api.${local.origin_domain_name}"
+      domain_name = aws_s3_bucket.this["api-docs"].bucket_regional_domain_name
       custom_origin_config = {
         http_port              = 80
         https_port             = 443


### PR DESCRIPTION
Jira link

[HOTT-2803](https://transformuk.atlassian.net/browse/HOTT-2803)

## What?

I have:

- Set api docs cloudfront origin to s3 bucket

