### PR TITLE
BAU: Separate secrets for uk and xi workers

### DIFF
--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -44,7 +44,6 @@ No outputs.
 |------|--------|---------|
 | <a name="module_acm"></a> [acm](#module\_acm) | ../../common/acm/ | n/a |
 | <a name="module_acm_origin"></a> [acm\_origin](#module\_acm\_origin) | ../../common/acm | n/a |
-| <a name="module_acm_origin_api"></a> [acm\_origin\_api](#module\_acm\_origin\_api) | ../../common/acm | n/a |
 | <a name="module_admin_bearer_token"></a> [admin\_bearer\_token](#module\_admin\_bearer\_token) | ../../common/secret/ | n/a |
 | <a name="module_admin_oauth_id"></a> [admin\_oauth\_id](#module\_admin\_oauth\_id) | ../../common/secret/ | n/a |
 | <a name="module_admin_oauth_secret"></a> [admin\_oauth\_secret](#module\_admin\_oauth\_secret) | ../../common/secret/ | n/a |
@@ -57,9 +56,12 @@ No outputs.
 | <a name="module_backend_secret_key_base"></a> [backend\_secret\_key\_base](#module\_backend\_secret\_key\_base) | ../../common/secret/ | n/a |
 | <a name="module_backend_sentry_dsn"></a> [backend\_sentry\_dsn](#module\_backend\_sentry\_dsn) | ../../common/secret/ | n/a |
 | <a name="module_backend_sync_email"></a> [backend\_sync\_email](#module\_backend\_sync\_email) | ../../common/secret/ | n/a |
-| <a name="module_backend_sync_host"></a> [backend\_sync\_host](#module\_backend\_sync\_host) | ../../common/secret/ | n/a |
-| <a name="module_backend_sync_password"></a> [backend\_sync\_password](#module\_backend\_sync\_password) | ../../common/secret/ | n/a |
-| <a name="module_backend_sync_username"></a> [backend\_sync\_username](#module\_backend\_sync\_username) | ../../common/secret/ | n/a |
+| <a name="module_backend_uk_sync_host"></a> [backend\_uk\_sync\_host](#module\_backend\_uk\_sync\_host) | ../../common/secret/ | n/a |
+| <a name="module_backend_uk_sync_password"></a> [backend\_uk\_sync\_password](#module\_backend\_uk\_sync\_password) | ../../common/secret/ | n/a |
+| <a name="module_backend_uk_sync_username"></a> [backend\_uk\_sync\_username](#module\_backend\_uk\_sync\_username) | ../../common/secret/ | n/a |
+| <a name="module_backend_xi_sync_host"></a> [backend\_xi\_sync\_host](#module\_backend\_xi\_sync\_host) | ../../common/secret/ | n/a |
+| <a name="module_backend_xi_sync_password"></a> [backend\_xi\_sync\_password](#module\_backend\_xi\_sync\_password) | ../../common/secret/ | n/a |
+| <a name="module_backend_xi_sync_username"></a> [backend\_xi\_sync\_username](#module\_backend\_xi\_sync\_username) | ../../common/secret/ | n/a |
 | <a name="module_cdn"></a> [cdn](#module\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.2.1 |
 | <a name="module_cloudwatch"></a> [cloudwatch](#module\_cloudwatch) | ../../common/cloudwatch/ | n/a |
 | <a name="module_duty_calculator_secret_key_base"></a> [duty\_calculator\_secret\_key\_base](#module\_duty\_calculator\_secret\_key\_base) | ../../common/secret/ | n/a |
@@ -145,9 +147,12 @@ No outputs.
 | <a name="input_tariff_backend_oauth_secret"></a> [tariff\_backend\_oauth\_secret](#input\_tariff\_backend\_oauth\_secret) | Value of Tariff Backend OAuth secret. | `string` | n/a | yes |
 | <a name="input_tariff_backend_sentry_dsn"></a> [tariff\_backend\_sentry\_dsn](#input\_tariff\_backend\_sentry\_dsn) | Value of Backend Sentry DSN. | `string` | n/a | yes |
 | <a name="input_tariff_backend_sync_email"></a> [tariff\_backend\_sync\_email](#input\_tariff\_backend\_sync\_email) | Value of Tariff Sync email. | `string` | n/a | yes |
-| <a name="input_tariff_backend_sync_host"></a> [tariff\_backend\_sync\_host](#input\_tariff\_backend\_sync\_host) | Value of Tariff Sync host. Used to fetch CDS files | `string` | n/a | yes |
-| <a name="input_tariff_backend_sync_password"></a> [tariff\_backend\_sync\_password](#input\_tariff\_backend\_sync\_password) | Value of Tariff Sync password. | `string` | n/a | yes |
-| <a name="input_tariff_backend_sync_username"></a> [tariff\_backend\_sync\_username](#input\_tariff\_backend\_sync\_username) | Value of Tariff Sync username. | `string` | n/a | yes |
+| <a name="input_tariff_backend_uk_sync_host"></a> [tariff\_backend\_uk\_sync\_host](#input\_tariff\_backend\_uk\_sync\_host) | Value of Tariff Sync host. | `string` | n/a | yes |
+| <a name="input_tariff_backend_uk_sync_password"></a> [tariff\_backend\_uk\_sync\_password](#input\_tariff\_backend\_uk\_sync\_password) | Value of Tariff Sync password. | `string` | n/a | yes |
+| <a name="input_tariff_backend_uk_sync_username"></a> [tariff\_backend\_uk\_sync\_username](#input\_tariff\_backend\_uk\_sync\_username) | Value of Tariff Sync username. | `string` | n/a | yes |
+| <a name="input_tariff_backend_xi_sync_host"></a> [tariff\_backend\_xi\_sync\_host](#input\_tariff\_backend\_xi\_sync\_host) | Value of Tariff Sync host. | `string` | n/a | yes |
+| <a name="input_tariff_backend_xi_sync_password"></a> [tariff\_backend\_xi\_sync\_password](#input\_tariff\_backend\_xi\_sync\_password) | Value of Tariff Sync password. | `string` | n/a | yes |
+| <a name="input_tariff_backend_xi_sync_username"></a> [tariff\_backend\_xi\_sync\_username](#input\_tariff\_backend\_xi\_sync\_username) | Value of Tariff Sync username. | `string` | n/a | yes |
 | <a name="input_waf_rpm_limit"></a> [waf\_rpm\_limit](#input\_waf\_rpm\_limit) | Request per minute limit for the WAF. | `number` | `100` | no |
 
 ## Outputs

--- a/environments/development/common/secrets.tf
+++ b/environments/development/common/secrets.tf
@@ -78,28 +78,52 @@ module "backend_sync_email" {
   secret_string   = var.tariff_backend_sync_email
 }
 
-module "backend_sync_host" {
+module "backend_xi_sync_host" {
   source          = "../../common/secret/"
-  name            = "backend-sync-host"
+  name            = "backend-xi-sync-host"
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
   recovery_window = 7
-  secret_string   = var.tariff_backend_sync_host
+  secret_string   = var.tariff_backend_xi_sync_host
 }
 
-module "backend_sync_password" {
+module "backend_xi_sync_password" {
   source          = "../../common/secret/"
-  name            = "backend-sync-password"
+  name            = "backend-xi-sync-password"
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
   recovery_window = 7
-  secret_string   = var.tariff_backend_sync_password
+  secret_string   = var.tariff_backend_xi_sync_password
 }
 
-module "backend_sync_username" {
+module "backend_xi_sync_username" {
   source          = "../../common/secret/"
-  name            = "backend-sync-username"
+  name            = "backend-xi-sync-username"
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
   recovery_window = 7
-  secret_string   = var.tariff_backend_sync_username
+  secret_string   = var.tariff_backend_xi_sync_username
+}
+
+module "backend_uk_sync_host" {
+  source          = "../../common/secret/"
+  name            = "backend-uk-sync-host"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.tariff_backend_uk_sync_host
+}
+
+module "backend_uk_sync_password" {
+  source          = "../../common/secret/"
+  name            = "backend-uk-sync-password"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.tariff_backend_uk_sync_password
+}
+
+module "backend_uk_sync_username" {
+  source          = "../../common/secret/"
+  name            = "backend-uk-sync-username"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.tariff_backend_uk_sync_username
 }
 
 module "backend_oauth_id" {

--- a/environments/development/common/variables.tf
+++ b/environments/development/common/variables.tf
@@ -112,19 +112,37 @@ variable "admin_bearer_token" {
   sensitive   = true
 }
 
-variable "tariff_backend_sync_host" {
-  description = "Value of Tariff Sync host. Used to fetch CDS files"
+variable "tariff_backend_uk_sync_host" {
+  description = "Value of Tariff Sync host."
   type        = string
   sensitive   = true
 }
 
-variable "tariff_backend_sync_password" {
+variable "tariff_backend_uk_sync_password" {
   description = "Value of Tariff Sync password."
   type        = string
   sensitive   = true
 }
 
-variable "tariff_backend_sync_username" {
+variable "tariff_backend_uk_sync_username" {
+  description = "Value of Tariff Sync username."
+  type        = string
+  sensitive   = true
+}
+
+variable "tariff_backend_xi_sync_host" {
+  description = "Value of Tariff Sync host."
+  type        = string
+  sensitive   = true
+}
+
+variable "tariff_backend_xi_sync_password" {
+  description = "Value of Tariff Sync password."
+  type        = string
+  sensitive   = true
+}
+
+variable "tariff_backend_xi_sync_username" {
   description = "Value of Tariff Sync username."
   type        = string
   sensitive   = true

--- a/environments/production/common/README.md
+++ b/environments/production/common/README.md
@@ -32,9 +32,12 @@
 | <a name="module_backend_secret_key_base"></a> [backend\_secret\_key\_base](#module\_backend\_secret\_key\_base) | ../../common/secret/ | n/a |
 | <a name="module_backend_sentry_dsn"></a> [backend\_sentry\_dsn](#module\_backend\_sentry\_dsn) | ../../common/secret/ | n/a |
 | <a name="module_backend_sync_email"></a> [backend\_sync\_email](#module\_backend\_sync\_email) | ../../common/secret/ | n/a |
-| <a name="module_backend_sync_host"></a> [backend\_sync\_host](#module\_backend\_sync\_host) | ../../common/secret/ | n/a |
-| <a name="module_backend_sync_password"></a> [backend\_sync\_password](#module\_backend\_sync\_password) | ../../common/secret/ | n/a |
-| <a name="module_backend_sync_username"></a> [backend\_sync\_username](#module\_backend\_sync\_username) | ../../common/secret/ | n/a |
+| <a name="module_backend_uk_sync_host"></a> [backend\_uk\_sync\_host](#module\_backend\_uk\_sync\_host) | ../../common/secret/ | n/a |
+| <a name="module_backend_uk_sync_password"></a> [backend\_uk\_sync\_password](#module\_backend\_uk\_sync\_password) | ../../common/secret/ | n/a |
+| <a name="module_backend_uk_sync_username"></a> [backend\_uk\_sync\_username](#module\_backend\_uk\_sync\_username) | ../../common/secret/ | n/a |
+| <a name="module_backend_xi_sync_host"></a> [backend\_xi\_sync\_host](#module\_backend\_xi\_sync\_host) | ../../common/secret/ | n/a |
+| <a name="module_backend_xi_sync_password"></a> [backend\_xi\_sync\_password](#module\_backend\_xi\_sync\_password) | ../../common/secret/ | n/a |
+| <a name="module_backend_xi_sync_username"></a> [backend\_xi\_sync\_username](#module\_backend\_xi\_sync\_username) | ../../common/secret/ | n/a |
 | <a name="module_cdn"></a> [cdn](#module\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.2.1 |
 | <a name="module_cloudwatch"></a> [cloudwatch](#module\_cloudwatch) | ../../common/cloudwatch/ | n/a |
 | <a name="module_duty_calculator_secret_key_base"></a> [duty\_calculator\_secret\_key\_base](#module\_duty\_calculator\_secret\_key\_base) | ../../common/secret/ | n/a |
@@ -110,9 +113,12 @@
 | <a name="input_tariff_backend_oauth_secret"></a> [tariff\_backend\_oauth\_secret](#input\_tariff\_backend\_oauth\_secret) | Value of Tariff Backend OAuth secret. | `string` | n/a | yes |
 | <a name="input_tariff_backend_sentry_dsn"></a> [tariff\_backend\_sentry\_dsn](#input\_tariff\_backend\_sentry\_dsn) | Value of Backend Sentry DSN. | `string` | n/a | yes |
 | <a name="input_tariff_backend_sync_email"></a> [tariff\_backend\_sync\_email](#input\_tariff\_backend\_sync\_email) | Value of Tariff Sync email. | `string` | n/a | yes |
-| <a name="input_tariff_backend_sync_host"></a> [tariff\_backend\_sync\_host](#input\_tariff\_backend\_sync\_host) | Value of Tariff Sync host. Used to fetch CDS files | `string` | n/a | yes |
-| <a name="input_tariff_backend_sync_password"></a> [tariff\_backend\_sync\_password](#input\_tariff\_backend\_sync\_password) | Value of Tariff Sync password. | `string` | n/a | yes |
-| <a name="input_tariff_backend_sync_username"></a> [tariff\_backend\_sync\_username](#input\_tariff\_backend\_sync\_username) | Value of Tariff Sync username. | `string` | n/a | yes |
+| <a name="input_tariff_backend_uk_sync_host"></a> [tariff\_backend\_uk\_sync\_host](#input\_tariff\_backend\_uk\_sync\_host) | Value of Tariff Sync host. | `string` | n/a | yes |
+| <a name="input_tariff_backend_uk_sync_password"></a> [tariff\_backend\_uk\_sync\_password](#input\_tariff\_backend\_uk\_sync\_password) | Value of Tariff Sync password. | `string` | n/a | yes |
+| <a name="input_tariff_backend_uk_sync_username"></a> [tariff\_backend\_uk\_sync\_username](#input\_tariff\_backend\_uk\_sync\_username) | Value of Tariff Sync username. | `string` | n/a | yes |
+| <a name="input_tariff_backend_xi_sync_host"></a> [tariff\_backend\_xi\_sync\_host](#input\_tariff\_backend\_xi\_sync\_host) | Value of Tariff Sync host. | `string` | n/a | yes |
+| <a name="input_tariff_backend_xi_sync_password"></a> [tariff\_backend\_xi\_sync\_password](#input\_tariff\_backend\_xi\_sync\_password) | Value of Tariff Sync password. | `string` | n/a | yes |
+| <a name="input_tariff_backend_xi_sync_username"></a> [tariff\_backend\_xi\_sync\_username](#input\_tariff\_backend\_xi\_sync\_username) | Value of Tariff Sync username. | `string` | n/a | yes |
 | <a name="input_waf_rpm_limit"></a> [waf\_rpm\_limit](#input\_waf\_rpm\_limit) | Request per minute limit for the WAF. | `number` | `5000` | no |
 
 ## Outputs

--- a/environments/production/common/secrets.tf
+++ b/environments/production/common/secrets.tf
@@ -78,29 +78,54 @@ module "backend_sync_email" {
   secret_string   = var.tariff_backend_sync_email
 }
 
-module "backend_sync_host" {
+module "backend_xi_sync_host" {
   source          = "../../common/secret/"
-  name            = "backend-sync-host"
+  name            = "backend-xi-sync-host"
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
   recovery_window = 7
-  secret_string   = var.tariff_backend_sync_host
+  secret_string   = var.tariff_backend_xi_sync_host
 }
 
-module "backend_sync_password" {
+module "backend_xi_sync_password" {
   source          = "../../common/secret/"
-  name            = "backend-sync-password"
+  name            = "backend-xi-sync-password"
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
   recovery_window = 7
-  secret_string   = var.tariff_backend_sync_password
+  secret_string   = var.tariff_backend_xi_sync_password
 }
 
-module "backend_sync_username" {
+module "backend_xi_sync_username" {
   source          = "../../common/secret/"
-  name            = "backend-sync-username"
+  name            = "backend-xi-sync-username"
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
   recovery_window = 7
-  secret_string   = var.tariff_backend_sync_username
+  secret_string   = var.tariff_backend_xi_sync_username
 }
+
+module "backend_uk_sync_host" {
+  source          = "../../common/secret/"
+  name            = "backend-uk-sync-host"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.tariff_backend_uk_sync_host
+}
+
+module "backend_uk_sync_password" {
+  source          = "../../common/secret/"
+  name            = "backend-uk-sync-password"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.tariff_backend_uk_sync_password
+}
+
+module "backend_uk_sync_username" {
+  source          = "../../common/secret/"
+  name            = "backend-uk-sync-username"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.tariff_backend_uk_sync_username
+}
+
 
 module "backend_oauth_id" {
   source          = "../../common/secret/"

--- a/environments/production/common/variables.tf
+++ b/environments/production/common/variables.tf
@@ -106,19 +106,37 @@ variable "admin_bearer_token" {
   sensitive   = true
 }
 
-variable "tariff_backend_sync_host" {
-  description = "Value of Tariff Sync host. Used to fetch CDS files"
+variable "tariff_backend_uk_sync_host" {
+  description = "Value of Tariff Sync host."
   type        = string
   sensitive   = true
 }
 
-variable "tariff_backend_sync_password" {
+variable "tariff_backend_uk_sync_password" {
   description = "Value of Tariff Sync password."
   type        = string
   sensitive   = true
 }
 
-variable "tariff_backend_sync_username" {
+variable "tariff_backend_uk_sync_username" {
+  description = "Value of Tariff Sync username."
+  type        = string
+  sensitive   = true
+}
+
+variable "tariff_backend_xi_sync_host" {
+  description = "Value of Tariff Sync host."
+  type        = string
+  sensitive   = true
+}
+
+variable "tariff_backend_xi_sync_password" {
+  description = "Value of Tariff Sync password."
+  type        = string
+  sensitive   = true
+}
+
+variable "tariff_backend_xi_sync_username" {
   description = "Value of Tariff Sync username."
   type        = string
   sensitive   = true

--- a/environments/staging/common/README.md
+++ b/environments/staging/common/README.md
@@ -32,9 +32,12 @@
 | <a name="module_backend_secret_key_base"></a> [backend\_secret\_key\_base](#module\_backend\_secret\_key\_base) | ../../common/secret/ | n/a |
 | <a name="module_backend_sentry_dsn"></a> [backend\_sentry\_dsn](#module\_backend\_sentry\_dsn) | ../../common/secret/ | n/a |
 | <a name="module_backend_sync_email"></a> [backend\_sync\_email](#module\_backend\_sync\_email) | ../../common/secret/ | n/a |
-| <a name="module_backend_sync_host"></a> [backend\_sync\_host](#module\_backend\_sync\_host) | ../../common/secret/ | n/a |
-| <a name="module_backend_sync_password"></a> [backend\_sync\_password](#module\_backend\_sync\_password) | ../../common/secret/ | n/a |
-| <a name="module_backend_sync_username"></a> [backend\_sync\_username](#module\_backend\_sync\_username) | ../../common/secret/ | n/a |
+| <a name="module_backend_uk_sync_host"></a> [backend\_uk\_sync\_host](#module\_backend\_uk\_sync\_host) | ../../common/secret/ | n/a |
+| <a name="module_backend_uk_sync_password"></a> [backend\_uk\_sync\_password](#module\_backend\_uk\_sync\_password) | ../../common/secret/ | n/a |
+| <a name="module_backend_uk_sync_username"></a> [backend\_uk\_sync\_username](#module\_backend\_uk\_sync\_username) | ../../common/secret/ | n/a |
+| <a name="module_backend_xi_sync_host"></a> [backend\_xi\_sync\_host](#module\_backend\_xi\_sync\_host) | ../../common/secret/ | n/a |
+| <a name="module_backend_xi_sync_password"></a> [backend\_xi\_sync\_password](#module\_backend\_xi\_sync\_password) | ../../common/secret/ | n/a |
+| <a name="module_backend_xi_sync_username"></a> [backend\_xi\_sync\_username](#module\_backend\_xi\_sync\_username) | ../../common/secret/ | n/a |
 | <a name="module_cdn"></a> [cdn](#module\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.2.1 |
 | <a name="module_cloudwatch"></a> [cloudwatch](#module\_cloudwatch) | ../../common/cloudwatch/ | n/a |
 | <a name="module_duty_calculator_secret_key_base"></a> [duty\_calculator\_secret\_key\_base](#module\_duty\_calculator\_secret\_key\_base) | ../../common/secret/ | n/a |
@@ -116,9 +119,12 @@
 | <a name="input_tariff_backend_oauth_secret"></a> [tariff\_backend\_oauth\_secret](#input\_tariff\_backend\_oauth\_secret) | Value of Tariff Backend OAuth secret. | `string` | n/a | yes |
 | <a name="input_tariff_backend_sentry_dsn"></a> [tariff\_backend\_sentry\_dsn](#input\_tariff\_backend\_sentry\_dsn) | Value of Backend Sentry DSN. | `string` | n/a | yes |
 | <a name="input_tariff_backend_sync_email"></a> [tariff\_backend\_sync\_email](#input\_tariff\_backend\_sync\_email) | Value of Tariff Sync email. | `string` | n/a | yes |
-| <a name="input_tariff_backend_sync_host"></a> [tariff\_backend\_sync\_host](#input\_tariff\_backend\_sync\_host) | Value of Tariff Sync host. Used to fetch CDS files | `string` | n/a | yes |
-| <a name="input_tariff_backend_sync_password"></a> [tariff\_backend\_sync\_password](#input\_tariff\_backend\_sync\_password) | Value of Tariff Sync password. | `string` | n/a | yes |
-| <a name="input_tariff_backend_sync_username"></a> [tariff\_backend\_sync\_username](#input\_tariff\_backend\_sync\_username) | Value of Tariff Sync username. | `string` | n/a | yes |
+| <a name="input_tariff_backend_uk_sync_host"></a> [tariff\_backend\_uk\_sync\_host](#input\_tariff\_backend\_uk\_sync\_host) | Value of Tariff Sync host. | `string` | n/a | yes |
+| <a name="input_tariff_backend_uk_sync_password"></a> [tariff\_backend\_uk\_sync\_password](#input\_tariff\_backend\_uk\_sync\_password) | Value of Tariff Sync password. | `string` | n/a | yes |
+| <a name="input_tariff_backend_uk_sync_username"></a> [tariff\_backend\_uk\_sync\_username](#input\_tariff\_backend\_uk\_sync\_username) | Value of Tariff Sync username. | `string` | n/a | yes |
+| <a name="input_tariff_backend_xi_sync_host"></a> [tariff\_backend\_xi\_sync\_host](#input\_tariff\_backend\_xi\_sync\_host) | Value of Tariff Sync host. | `string` | n/a | yes |
+| <a name="input_tariff_backend_xi_sync_password"></a> [tariff\_backend\_xi\_sync\_password](#input\_tariff\_backend\_xi\_sync\_password) | Value of Tariff Sync password. | `string` | n/a | yes |
+| <a name="input_tariff_backend_xi_sync_username"></a> [tariff\_backend\_xi\_sync\_username](#input\_tariff\_backend\_xi\_sync\_username) | Value of Tariff Sync username. | `string` | n/a | yes |
 | <a name="input_waf_rpm_limit"></a> [waf\_rpm\_limit](#input\_waf\_rpm\_limit) | Request per minute limit for the WAF. | `number` | `500` | no |
 
 ## Outputs

--- a/environments/staging/common/secrets.tf
+++ b/environments/staging/common/secrets.tf
@@ -78,28 +78,52 @@ module "backend_sync_email" {
   secret_string   = var.tariff_backend_sync_email
 }
 
-module "backend_sync_host" {
+module "backend_xi_sync_host" {
   source          = "../../common/secret/"
-  name            = "backend-sync-host"
+  name            = "backend-xi-sync-host"
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
   recovery_window = 7
-  secret_string   = var.tariff_backend_sync_host
+  secret_string   = var.tariff_backend_xi_sync_host
 }
 
-module "backend_sync_password" {
+module "backend_xi_sync_password" {
   source          = "../../common/secret/"
-  name            = "backend-sync-password"
+  name            = "backend-xi-sync-password"
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
   recovery_window = 7
-  secret_string   = var.tariff_backend_sync_password
+  secret_string   = var.tariff_backend_xi_sync_password
 }
 
-module "backend_sync_username" {
+module "backend_xi_sync_username" {
   source          = "../../common/secret/"
-  name            = "backend-sync-username"
+  name            = "backend-xi-sync-username"
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
   recovery_window = 7
-  secret_string   = var.tariff_backend_sync_username
+  secret_string   = var.tariff_backend_xi_sync_username
+}
+
+module "backend_uk_sync_host" {
+  source          = "../../common/secret/"
+  name            = "backend-uk-sync-host"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.tariff_backend_uk_sync_host
+}
+
+module "backend_uk_sync_password" {
+  source          = "../../common/secret/"
+  name            = "backend-uk-sync-password"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.tariff_backend_uk_sync_password
+}
+
+module "backend_uk_sync_username" {
+  source          = "../../common/secret/"
+  name            = "backend-uk-sync-username"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.tariff_backend_uk_sync_username
 }
 
 module "backend_oauth_id" {

--- a/environments/staging/common/variables.tf
+++ b/environments/staging/common/variables.tf
@@ -112,19 +112,37 @@ variable "admin_bearer_token" {
   sensitive   = true
 }
 
-variable "tariff_backend_sync_host" {
-  description = "Value of Tariff Sync host. Used to fetch CDS files"
+variable "tariff_backend_uk_sync_host" {
+  description = "Value of Tariff Sync host."
   type        = string
   sensitive   = true
 }
 
-variable "tariff_backend_sync_password" {
+variable "tariff_backend_uk_sync_password" {
   description = "Value of Tariff Sync password."
   type        = string
   sensitive   = true
 }
 
-variable "tariff_backend_sync_username" {
+variable "tariff_backend_uk_sync_username" {
+  description = "Value of Tariff Sync username."
+  type        = string
+  sensitive   = true
+}
+
+variable "tariff_backend_xi_sync_host" {
+  description = "Value of Tariff Sync host."
+  type        = string
+  sensitive   = true
+}
+
+variable "tariff_backend_xi_sync_password" {
+  description = "Value of Tariff Sync password."
+  type        = string
+  sensitive   = true
+}
+
+variable "tariff_backend_xi_sync_username" {
   description = "Value of Tariff Sync username."
   type        = string
   sensitive   = true


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Added separate secrets for the uk and xi sync jobs

## Why?

I am doing this because:

- This is necessary but also delineates clearly between the two worker environments
