### PR TITLE
BAU: Add missing CDN aliases

### DIFF
--- a/environments/development/common/cloudfront.tf
+++ b/environments/development/common/cloudfront.tf
@@ -5,7 +5,7 @@ data "aws_cloudfront_cache_policy" "caching_disabled" {
 module "cdn" {
   source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront?ref=aws/cloudfront-v1.2.1"
 
-  aliases         = [var.domain_name]
+  aliases         = [var.domain_name, "signon.${var.domain_name}", "admin.${var.domain_name}"]
   create_alias    = true
   route53_zone_id = data.aws_route53_zone.this.id
   comment         = "${title(var.environment)} CDN"

--- a/environments/development/common/route53.tf
+++ b/environments/development/common/route53.tf
@@ -33,16 +33,3 @@ resource "aws_route53_record" "origin_wildcard" {
     evaluate_target_health = true
   }
 }
-
-resource "aws_route53_record" "subdomains" {
-  for_each = toset(["admin", "signon"])
-  zone_id  = data.aws_route53_zone.this.zone_id
-  name     = "${each.value}.${var.domain_name}"
-  type     = "A"
-
-  alias {
-    name                   = module.cdn.aws_cloudfront_distribution_domain_name
-    zone_id                = module.cdn.aws_cloudfront_distribution_hosted_zone_id
-    evaluate_target_health = true
-  }
-}

--- a/environments/production/common/cloudfront.tf
+++ b/environments/production/common/cloudfront.tf
@@ -5,7 +5,7 @@ data "aws_cloudfront_cache_policy" "caching_disabled" {
 module "cdn" {
   source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront?ref=aws/cloudfront-v1.2.1"
 
-  aliases         = [var.domain_name]
+  aliases         = [var.domain_name, "signon.${var.domain_name}", "admin.${var.domain_name}"]
   create_alias    = true
   route53_zone_id = data.aws_route53_zone.this.id
   comment         = "${title(var.environment)} CDN"

--- a/environments/production/common/route53.tf
+++ b/environments/production/common/route53.tf
@@ -33,16 +33,3 @@ resource "aws_route53_record" "origin_wildcard" {
     evaluate_target_health = true
   }
 }
-
-resource "aws_route53_record" "subdomains" {
-  for_each = toset(["admin", "signon"])
-  zone_id  = data.aws_route53_zone.this.zone_id
-  name     = "${each.value}.${var.domain_name}"
-  type     = "A"
-
-  alias {
-    name                   = module.cdn.aws_cloudfront_distribution_domain_name
-    zone_id                = module.cdn.aws_cloudfront_distribution_hosted_zone_id
-    evaluate_target_health = true
-  }
-}

--- a/environments/staging/common/README.md
+++ b/environments/staging/common/README.md
@@ -83,7 +83,6 @@
 | [aws_route53_record.origin_ns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.origin_root](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.origin_wildcard](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.subdomains](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_zone.origin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
 | [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_public_access_block.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |

--- a/environments/staging/common/cloudfront.tf
+++ b/environments/staging/common/cloudfront.tf
@@ -5,7 +5,7 @@ data "aws_cloudfront_cache_policy" "caching_disabled" {
 module "cdn" {
   source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront?ref=aws/cloudfront-v1.2.1"
 
-  aliases         = [var.domain_name]
+  aliases         = [var.domain_name, "signon.${var.domain_name}", "admin.${var.domain_name}"]
   create_alias    = true
   route53_zone_id = data.aws_route53_zone.this.id
   comment         = "${title(var.environment)} CDN"

--- a/environments/staging/common/route53.tf
+++ b/environments/staging/common/route53.tf
@@ -33,16 +33,3 @@ resource "aws_route53_record" "origin_wildcard" {
     evaluate_target_health = true
   }
 }
-
-resource "aws_route53_record" "subdomains" {
-  for_each = toset(["admin", "signon"])
-  zone_id  = data.aws_route53_zone.this.zone_id
-  name     = "${each.value}.${var.domain_name}"
-  type     = "A"
-
-  alias {
-    name                   = module.cdn.aws_cloudfront_distribution_domain_name
-    zone_id                = module.cdn.aws_cloudfront_distribution_hosted_zone_id
-    evaluate_target_health = true
-  }
-}


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Added `signon` and `admin` subdomain aliases for the CDN.

## Why?

I am doing this because:

- We need the CDN to have these configured so they can point at the origin correctly.