### PR TITLE
HOTT-2801: Keep www for Production

### DIFF
--- a/environments/production/common/cloudfront.tf
+++ b/environments/production/common/cloudfront.tf
@@ -5,7 +5,7 @@ data "aws_cloudfront_cache_policy" "caching_disabled" {
 module "cdn" {
   source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront?ref=aws/cloudfront-v1.2.1"
 
-  aliases         = [var.domain_name, "signon.${var.domain_name}", "admin.${var.domain_name}"]
+  aliases         = [var.domain_name, "signon.${var.domain_name}", "admin.${var.domain_name}", "www.${var.domain_name}"]
   create_alias    = true
   route53_zone_id = data.aws_route53_zone.this.id
   comment         = "${title(var.environment)} CDN"


### PR DESCRIPTION
# Pull Request

[HOTT-2801](https://transformuk.atlassian.net/browse/HOTT-2801)

## What?

I have:

- Added `www` alias for the CDN.

## Why?

I am doing this because:

- The current production environment requires it, so we'll want to keep it around.