### PR TITLE
HOTT-4081 - aws cloudwatch alarm alerts to slack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,10 +13,7 @@ only-main: &only-main
 executors:
   default:
     docker:
-      - image: 382373577178.dkr.ecr.eu-west-2.amazonaws.com/terraform-1.5.5-python3:latest
-        aws_auth:
-          aws_access_key_id: $AWS_ACCESS_KEY_ID
-          aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
+      - image: hashicorp/terraform:1.5.5
     resource_class: small
     working_directory: "/tmp/terraform"
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,9 +13,13 @@ only-main: &only-main
 executors:
   default:
     docker:
-      - image: hashicorp/terraform:1.5.5
+      - image: 382373577178.dkr.ecr.eu-west-2.amazonaws.com/terraform-1.5.5-python3:latest
+        aws_auth:
+          aws_access_key_id: $AWS_ACCESS_KEY_ID
+          aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
     resource_class: small
     working_directory: "/tmp/terraform"
+    context: trade-tariff-terraform-aws-production
     environment:
       TF_INPUT: 0
       TF_IN_AUTOMATION: 1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,6 @@ executors:
           aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
     resource_class: small
     working_directory: "/tmp/terraform"
-    context: trade-tariff-terraform-aws-production
     environment:
       TF_INPUT: 0
       TF_IN_AUTOMATION: 1

--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -71,6 +71,7 @@ No outputs.
 | <a name="module_frontend_secret_key_base"></a> [frontend\_secret\_key\_base](#module\_frontend\_secret\_key\_base) | ../../common/secret/ | n/a |
 | <a name="module_logs"></a> [logs](#module\_logs) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v3.14.0 |
 | <a name="module_mysql"></a> [mysql](#module\_mysql) | ../../common/rds | n/a |
+| <a name="module_notify_slack"></a> [notify\_slack](#module\_notify\_slack) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/aws-notify-slack | aws/aws-notify-slack-v1.0.0 |
 | <a name="module_opensearch"></a> [opensearch](#module\_opensearch) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/opensearch | aws/opensearch-v1.1.0 |
 | <a name="module_opensearch_packages_bucket"></a> [opensearch\_packages\_bucket](#module\_opensearch\_packages\_bucket) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v3.14.0 |
 | <a name="module_postgres"></a> [postgres](#module\_postgres) | ../../common/rds | n/a |
@@ -93,6 +94,7 @@ No outputs.
 | [aws_cloudfront_origin_request_policy.forward_all_qsa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_request_policy) | resource |
 | [aws_cloudwatch_log_group.redis_engine_lg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.redis_slow_lg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_cloudwatch_metric_alarm.lambda_duration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_elasticache_subnet_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_subnet_group) | resource |
 | [aws_iam_policy.ci_lambda_deployment_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.opensearch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
@@ -130,6 +132,7 @@ No outputs.
 | [aws_iam_policy_document.logs_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.opensearch_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
+| [aws_secretsmanager_secret_version.slack](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 | [terraform_remote_state.base](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 
 ## Inputs

--- a/environments/development/common/slack-notify.tf
+++ b/environments/development/common/slack-notify.tf
@@ -1,0 +1,52 @@
+data "aws_secretsmanager_secret_version" "slack" {
+  secret_id = "slack"
+}
+
+locals {
+  slack = jsondecode(
+    data.aws_secretsmanager_secret_version.slack.secret_string
+  )
+}
+
+module "notify_slack" {
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/aws-notify-slack?ref=aws/aws-notify-slack-v1.0.0"
+
+  for_each = toset([
+    "development"
+  ])
+
+  enable_sns_topic_delivery_status_logs = true
+
+  lambda_function_name = "notify_slack_${each.value}"
+  sns_topic_name       = "slack-topic"
+
+  slack_webhook_url = local.slack.webhook_url
+  slack_channel     = "tariff-alerts"
+  slack_username    = "@here"
+
+  lambda_description = "Lambda function which sends notifications to Slack"
+  log_events         = true
+
+  tags = {
+    Name = "cloudwatch-alerts-to-slack"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "lambda_duration" {
+  alarm_name          = "Test slack notification from CW alarm"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "Duration"
+  namespace           = "AWS/Lambda"
+  period              = "60"
+  statistic           = "Sum"
+  threshold           = "2"
+  alarm_description   = "Test Alarm!!!"
+
+  alarm_actions = [module.notify_slack["development"].slack_topic_arn]
+  ok_actions    = [module.notify_slack["development"].slack_topic_arn]
+
+  dimensions = {
+    FunctionName = module.notify_slack["development"].notify_slack_lambda_function_name
+  }
+}

--- a/environments/production/applications/locals.tf
+++ b/environments/production/applications/locals.tf
@@ -6,6 +6,7 @@ locals {
     "duty-calculator",
     "frontend",
     "search-query-parser",
-    "signon"
+    "signon",
+    "terraform-1.5.5-python3"
   ]
 }


### PR DESCRIPTION
### Jira link

HOTT-4081

## What?

I have:

- Added terraform module to send aws cloudwatch alarm alerts to slack


## Why?

I am doing this because:

-  To send slack alerts on triggered cloudwatch alarms
