### PR TITLE
HOTT-4081 - updated slack channel

### DIFF
--- a/environments/production/common/slack-notify.tf
+++ b/environments/production/common/slack-notify.tf
@@ -21,7 +21,7 @@ module "notify_slack" {
   sns_topic_name       = "slack-topic"
 
   slack_webhook_url = local.slack.webhook_url
-  slack_channel     = "tariff-alerts"
+  slack_channel     = "trade-tariff-infrastructure"
   slack_username    = "@here"
 
   lambda_description = "Lambda function which sends notifications to Slack"


### PR DESCRIPTION
# Jira
https://transformuk.atlassian.net/browse/HOTT-4081

## What?

I have:

- Added updated slack channel for cloudwatch alerts


## Why?

I am doing this because:

- tariff-alerts is a private slack channel and the webhook fails to send alerts

