### PR TITLE
HOTT-2796: Adds permission to invalidate the reporting distribution

### DIFF
--- a/environments/development/common/iam.tf
+++ b/environments/development/common/iam.tf
@@ -37,6 +37,15 @@ resource "aws_iam_policy" "ci_reporting_policy" {
         Resource = [
           aws_kms_alias.s3_kms_alias.target_key_arn
         ]
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "cloudfront:CreateInvalidation",
+        ],
+        Resource = [
+          "arn:aws:cloudfront::${local.account_id}:distribution/${module.reporting_cdn.aws_cloudfront_distribution_id}"
+        ]
       }
     ]
   })

--- a/environments/production/common/iam.tf
+++ b/environments/production/common/iam.tf
@@ -37,6 +37,15 @@ resource "aws_iam_policy" "ci_reporting_policy" {
         Resource = [
           aws_kms_alias.s3_kms_alias.target_key_arn
         ]
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "cloudfront:CreateInvalidation",
+        ],
+        Resource = [
+          "arn:aws:cloudfront::${local.account_id}:distribution/${module.reporting_cdn.aws_cloudfront_distribution_id}"
+        ]
       }
     ]
   })

--- a/environments/staging/common/iam.tf
+++ b/environments/staging/common/iam.tf
@@ -37,6 +37,15 @@ resource "aws_iam_policy" "ci_reporting_policy" {
         Resource = [
           aws_kms_alias.s3_kms_alias.target_key_arn
         ]
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "cloudfront:CreateInvalidation",
+        ],
+        Resource = [
+          "arn:aws:cloudfront::${local.account_id}:distribution/${module.reporting_cdn.aws_cloudfront_distribution_id}"
+        ]
       }
     ]
   })


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Added permission to enable distribution invalidation on the reporting ci user in development
- Added permission to enable distribution invalidation on the reporting ci user in staging
- Added permission to enable distribution invalidation on the reporting ci user in production

## Why?

I am doing this because:

- This enables us to automate deployments
