### PR TITLE
BAU: Removes SES in production

### DIFF
--- a/environments/production/common/README.md
+++ b/environments/production/common/README.md
@@ -56,7 +56,6 @@
 | <a name="module_redis"></a> [redis](#module\_redis) | ../../common/elasticache-redis/ | n/a |
 | <a name="module_reporting_cdn"></a> [reporting\_cdn](#module\_reporting\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.2.1 |
 | <a name="module_search_configuration_bucket"></a> [search\_configuration\_bucket](#module\_search\_configuration\_bucket) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v3.14.0 |
-| <a name="module_ses"></a> [ses](#module\_ses) | ../../common/ses | n/a |
 | <a name="module_waf"></a> [waf](#module\_waf) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/waf | aws/waf-v1.2.1 |
 
 ## Resources

--- a/environments/production/common/ses.tf
+++ b/environments/production/common/ses.tf
@@ -1,5 +1,0 @@
-module "ses" {
-  source          = "../../common/ses"
-  domain_name     = var.domain_name
-  route53_zone_id = data.aws_route53_zone.this.zone_id
-}


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Removed the SES verification for the production domain

## Why?

I am doing this because:

- We can't safely manage SES in production right now - this would break the
current production feedback by unverifying the identity in the old account
- This is blocking apply steps in production
