### PR TITLE
HOTT-4204: Add SNS Topic and Event Subscription for RDS Snapshots

### DIFF
--- a/environments/common/rds/README.md
+++ b/environments/common/rds/README.md
@@ -63,7 +63,7 @@ No modules.
 |------|-------------|
 | <a name="output_db_arn"></a> [db\_arn](#output\_db\_arn) | ARN of the RDS instance. |
 | <a name="output_db_endpoint"></a> [db\_endpoint](#output\_db\_endpoint) | Connection endpoint for the RDS instance. Format: `address:port`. |
-| <a name="output_db_identifier"></a> [db\_identifier](#output\_db\_identifier) | Name of the RDS instance. |
+| <a name="output_db_id"></a> [db\_id](#output\_db\_id) | ID of the RDS instance. |
 | <a name="output_kms_key_arn"></a> [kms\_key\_arn](#output\_kms\_key\_arn) | ARN of the KMS Key created to encrypt database performance insights data. |
 | <a name="output_kms_key_id"></a> [kms\_key\_id](#output\_kms\_key\_id) | Globally unique ID of the KMS Key created to encrypt database performance insights data. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/environments/common/rds/README.md
+++ b/environments/common/rds/README.md
@@ -63,7 +63,7 @@ No modules.
 |------|-------------|
 | <a name="output_db_arn"></a> [db\_arn](#output\_db\_arn) | ARN of the RDS instance. |
 | <a name="output_db_endpoint"></a> [db\_endpoint](#output\_db\_endpoint) | Connection endpoint for the RDS instance. Format: `address:port`. |
-| <a name="output_db_id"></a> [db\_id](#output\_db\_id) | ID of the RDS instance. |
+| <a name="output_db_identifier"></a> [db\_identifier](#output\_db\_identifier) | ID of the RDS instance. |
 | <a name="output_kms_key_arn"></a> [kms\_key\_arn](#output\_kms\_key\_arn) | ARN of the KMS Key created to encrypt database performance insights data. |
 | <a name="output_kms_key_id"></a> [kms\_key\_id](#output\_kms\_key\_id) | Globally unique ID of the KMS Key created to encrypt database performance insights data. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/environments/common/rds/README.md
+++ b/environments/common/rds/README.md
@@ -63,7 +63,7 @@ No modules.
 |------|-------------|
 | <a name="output_db_arn"></a> [db\_arn](#output\_db\_arn) | ARN of the RDS instance. |
 | <a name="output_db_endpoint"></a> [db\_endpoint](#output\_db\_endpoint) | Connection endpoint for the RDS instance. Format: `address:port`. |
-| <a name="output_db_identifier"></a> [db\_identifier](#output\_db\_identifier) | ID of the RDS instance. |
+| <a name="output_db_id"></a> [db\_id](#output\_db\_id) | ID of the RDS instance. |
 | <a name="output_kms_key_arn"></a> [kms\_key\_arn](#output\_kms\_key\_arn) | ARN of the KMS Key created to encrypt database performance insights data. |
 | <a name="output_kms_key_id"></a> [kms\_key\_id](#output\_kms\_key\_id) | Globally unique ID of the KMS Key created to encrypt database performance insights data. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/environments/common/rds/README.md
+++ b/environments/common/rds/README.md
@@ -63,6 +63,7 @@ No modules.
 |------|-------------|
 | <a name="output_db_arn"></a> [db\_arn](#output\_db\_arn) | ARN of the RDS instance. |
 | <a name="output_db_endpoint"></a> [db\_endpoint](#output\_db\_endpoint) | Connection endpoint for the RDS instance. Format: `address:port`. |
+| <a name="output_db_identifier"></a> [db\_identifier](#output\_db\_identifier) | Name of the RDS instance. |
 | <a name="output_kms_key_arn"></a> [kms\_key\_arn](#output\_kms\_key\_arn) | ARN of the KMS Key created to encrypt database performance insights data. |
 | <a name="output_kms_key_id"></a> [kms\_key\_id](#output\_kms\_key\_id) | Globally unique ID of the KMS Key created to encrypt database performance insights data. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/environments/common/rds/outputs.tf
+++ b/environments/common/rds/outputs.tf
@@ -8,6 +8,11 @@ output "db_endpoint" {
   value       = aws_db_instance.this.endpoint
 }
 
+output "db_identifier" {
+  description = "Name of the RDS instance."
+  value       = aws_db_instance.this.identifier
+}
+
 output "kms_key_arn" {
   description = "ARN of the KMS Key created to encrypt database performance insights data."
   value       = aws_kms_key.this.arn

--- a/environments/common/rds/outputs.tf
+++ b/environments/common/rds/outputs.tf
@@ -8,9 +8,9 @@ output "db_endpoint" {
   value       = aws_db_instance.this.endpoint
 }
 
-output "db_identifier" {
+output "db_id" {
   description = "ID of the RDS instance."
-  value       = aws_db_instance.this.identifier
+  value       = aws_db_instance.this.id
 }
 
 output "kms_key_arn" {

--- a/environments/common/rds/outputs.tf
+++ b/environments/common/rds/outputs.tf
@@ -8,9 +8,9 @@ output "db_endpoint" {
   value       = aws_db_instance.this.endpoint
 }
 
-output "db_id" {
+output "db_identifier" {
   description = "ID of the RDS instance."
-  value       = aws_db_instance.this.id
+  value       = aws_db_instance.this.identifier
 }
 
 output "kms_key_arn" {

--- a/environments/common/rds/outputs.tf
+++ b/environments/common/rds/outputs.tf
@@ -8,9 +8,9 @@ output "db_endpoint" {
   value       = aws_db_instance.this.endpoint
 }
 
-output "db_identifier" {
-  description = "Name of the RDS instance."
-  value       = aws_db_instance.this.identifier
+output "db_id" {
+  description = "ID of the RDS instance."
+  value       = aws_db_instance.this.id
 }
 
 output "kms_key_arn" {

--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -30,12 +30,14 @@ No outputs.
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | 1.5.5 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.3 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.5 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 5.10.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
@@ -143,6 +145,7 @@ No outputs.
 | [aws_sns_topic.rds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
 | [aws_sns_topic_policy.db_event_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_policy) | resource |
 | [aws_ssm_parameter.ecr_url](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [random_id.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_cloudfront_cache_policy.caching_disabled](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudfront_cache_policy) | data source |
 | [aws_iam_policy_document.api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -135,12 +135,14 @@ No outputs.
 | [aws_secretsmanager_secret_version.redis_connection_string_value](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_secretsmanager_secret_version.redis_reader_connection_string_value](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_sns_topic.rds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
+| [aws_sns_topic_policy.db_event_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_policy) | resource |
 | [aws_ssm_parameter.ecr_url](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_cloudfront_cache_policy.caching_disabled](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudfront_cache_policy) | data source |
 | [aws_iam_policy_document.breakglass_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.logs_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.opensearch_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.sns_topic_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 | [terraform_remote_state.base](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 

--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -97,6 +97,7 @@ No outputs.
 | [aws_cloudfront_origin_request_policy.forward_all_qsa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_request_policy) | resource |
 | [aws_cloudwatch_log_group.redis_engine_lg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.redis_slow_lg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_db_event_subscription.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_event_subscription) | resource |
 | [aws_elasticache_subnet_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_subnet_group) | resource |
 | [aws_iam_policy.ci_appendix5a_peristence_readwrite_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.ci_lambda_deployment_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
@@ -130,6 +131,7 @@ No outputs.
 | [aws_secretsmanager_secret.redis_reader_connection_string](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret_version.redis_connection_string_value](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_secretsmanager_secret_version.redis_reader_connection_string_value](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
+| [aws_sns_topic.rds](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
 | [aws_ssm_parameter.ecr_url](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_cloudfront_cache_policy.caching_disabled](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudfront_cache_policy) | data source |

--- a/environments/development/common/rds.tf
+++ b/environments/development/common/rds.tf
@@ -26,23 +26,6 @@ module "postgres" {
   ]
 }
 
-resource "aws_sns_topic" "rds" {
-  name = "rds-events"
-}
-
-resource "aws_db_event_subscription" "this" {
-  name      = "rds-event-subscription"
-  sns_topic = aws_sns_topic.rds.arn
-
-  source_type = "db-snapshot"
-  source_ids  = [module.postgres.db_identifier]
-
-  event_categories = [
-    "creation",
-    "notification"
-  ]
-}
-
 # Admin Postgres
 module "postgres_admin" {
   source = "../../common/rds"

--- a/environments/development/common/rds.tf
+++ b/environments/development/common/rds.tf
@@ -35,7 +35,7 @@ resource "aws_db_event_subscription" "this" {
   sns_topic = aws_sns_topic.rds.arn
 
   source_type = "db-snapshot"
-  source_ids  = [module.postgres.db_identifier]
+  source_ids  = [module.postgres.db_id]
 
   event_categories = [
     "creation",

--- a/environments/development/common/rds.tf
+++ b/environments/development/common/rds.tf
@@ -35,7 +35,7 @@ resource "aws_db_event_subscription" "this" {
   sns_topic = aws_sns_topic.rds.arn
 
   source_type = "db-snapshot"
-  source_ids  = [module.postgres.db_id]
+  source_ids  = [module.postgres.db_identifier]
 
   event_categories = [
     "creation",

--- a/environments/development/common/rds.tf
+++ b/environments/development/common/rds.tf
@@ -26,6 +26,23 @@ module "postgres" {
   ]
 }
 
+resource "aws_sns_topic" "rds" {
+  name = "rds-events"
+}
+
+resource "aws_db_event_subscription" "this" {
+  name      = "rds-event-subscription"
+  sns_topic = aws_sns_topic.rds.arn
+
+  source_type = "db-snapshot"
+  source_ids  = [module.postgres.db_identifier]
+
+  event_categories = [
+    "creation",
+    "notification"
+  ]
+}
+
 # Admin Postgres
 module "postgres_admin" {
   source = "../../common/rds"

--- a/environments/development/common/sns.tf
+++ b/environments/development/common/sns.tf
@@ -1,0 +1,66 @@
+data "aws_iam_policy_document" "sns_topic_policy" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "sns:AddPermission",
+      "sns:DeleteTopic",
+      "sns:GetTopicAttributes",
+      "sns:ListSubscriptionsByTopic",
+      "sns:Publish",
+      "sns:Receive",
+      "sns:RemovePermission",
+      "sns:SetTopicAttributes",
+      "sns:Subscribe",
+    ]
+    resources = [aws_sns_topic.rds.arn]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceOwner"
+      values   = local.account_id
+    }
+  }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["sns:Publish"]
+    resources = [aws_sns_topic.rds.arn]
+
+    principals {
+      type = "Service"
+      identifiers = [
+        "events.amazonaws.com",
+        "rds.amazonaws.com",
+      ]
+    }
+  }
+}
+
+resource "aws_sns_topic" "rds" {
+  name = "rds-events"
+}
+
+resource "aws_sns_topic_policy" "db_event_policy" {
+  arn    = aws_sns_topic.rds.arn
+  policy = data.aws_iam_policy_document.sns_topic_policy.json
+}
+
+resource "aws_db_event_subscription" "this" {
+  name      = "rds-event-subscription"
+  sns_topic = aws_sns_topic.rds.arn
+
+  source_type = "db-snapshot"
+  source_ids  = [module.postgres.db_id]
+
+  event_categories = [
+    "creation",
+    "notification"
+  ]
+
+  depends_on = [aws_sns_topic_policy.db_event_policy]
+}

--- a/environments/development/common/sns.tf
+++ b/environments/development/common/sns.tf
@@ -1,4 +1,10 @@
+resource "random_id" "this" {
+  byte_length = 2
+}
+
 data "aws_iam_policy_document" "sns_topic_policy" {
+  policy_id = "rds_policy_${random_id.this.dec}"
+
   statement {
     effect = "Allow"
     actions = [

--- a/environments/development/common/sns.tf
+++ b/environments/development/common/sns.tf
@@ -22,7 +22,7 @@ data "aws_iam_policy_document" "sns_topic_policy" {
     condition {
       test     = "StringEquals"
       variable = "AWS:SourceOwner"
-      values   = local.account_id
+      values   = [local.account_id]
     }
   }
 

--- a/environments/development/common/sns.tf
+++ b/environments/development/common/sns.tf
@@ -62,7 +62,6 @@ resource "aws_db_event_subscription" "this" {
   sns_topic = aws_sns_topic.rds.arn
 
   source_type = "db-snapshot"
-  source_ids  = [module.postgres.db_id]
 
   event_categories = [
     "creation",

--- a/environments/development/common/versions.tf
+++ b/environments/development/common/versions.tf
@@ -5,6 +5,11 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 5.3"
     }
+
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5"
+    }
   }
 }
 


### PR DESCRIPTION
# Pull Request

[HOTT-4204](https://transformuk.atlassian.net/browse/HOTT-4204)

## What?

I have:

- Added SNS topic and event subscription for main database snapshots

## Why?

I am doing this because:

- We need a trigger for the Lambda function so that we can fetch the export task ID and SourceArn of the snapshots