### PR TITLE
HOTT-4358: Enable KMS decrypt for cloudfront

### DIFF
--- a/environments/development/common/s3.tf
+++ b/environments/development/common/s3.tf
@@ -29,7 +29,7 @@ data "aws_iam_policy_document" "s3_kms_key_policy" {
   }
 
   statement {
-    sid       = "Allow use of the key for CloudFront OAI"
+    sid       = "Allow use of the key for CloudFront OAC"
     effect    = "Allow"
     actions   = ["kms:Decrypt"]
     resources = ["*"]

--- a/environments/production/common/README.md
+++ b/environments/production/common/README.md
@@ -98,6 +98,7 @@
 | [aws_kms_key.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_kms_key.secretsmanager_kms_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_kms_key_policy.logs_bucket_kms_key_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key_policy) | resource |
+| [aws_kms_key_policy.s3_kms_key_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key_policy) | resource |
 | [aws_route53_health_check.dns_health_check](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_health_check) | resource |
 | [aws_route53_record.dev_name_servers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.staging_name_servers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
@@ -123,6 +124,7 @@
 | [aws_iam_policy_document.logs_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.opensearch_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.reporting](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.s3_kms_key_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 | [aws_secretsmanager_secret_version.slack](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 | [terraform_remote_state.base](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |

--- a/environments/production/common/s3.tf
+++ b/environments/production/common/s3.tf
@@ -20,6 +20,37 @@ resource "aws_kms_alias" "s3_kms_alias" {
   target_key_id = aws_kms_key.s3.key_id
 }
 
+data "aws_iam_policy_document" "s3_kms_key_policy" {
+  statement {
+    sid       = "Enable IAM User Permissions"
+    effect    = "Allow"
+    actions   = ["kms:*"]
+    resources = ["*"]
+
+    principals {
+      identifiers = ["arn:aws:iam::${local.account_id}:root"]
+      type        = "AWS"
+    }
+  }
+
+  statement {
+    sid       = "Allow use of the key for CloudFront OAC"
+    effect    = "Allow"
+    actions   = ["kms:Decrypt"]
+    resources = ["*"]
+
+    principals {
+      identifiers = ["cloudfront.amazonaws.com"]
+      type        = "Service"
+    }
+  }
+}
+
+resource "aws_kms_key_policy" "s3_kms_key_policy" {
+  key_id = aws_kms_key.s3.key_id
+  policy = data.aws_iam_policy_document.s3_kms_key_policy.json
+}
+
 resource "aws_s3_bucket" "this" {
   for_each = local.buckets
   bucket   = each.value

--- a/environments/staging/common/README.md
+++ b/environments/staging/common/README.md
@@ -99,6 +99,7 @@
 | [aws_kms_key.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_kms_key.secretsmanager_kms_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_kms_key_policy.logs_bucket_kms_key_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key_policy) | resource |
+| [aws_kms_key_policy.s3_kms_key_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key_policy) | resource |
 | [aws_route53_record.origin_ns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.origin_root](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.origin_wildcard](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
@@ -123,6 +124,7 @@
 | [aws_iam_policy_document.logs_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.opensearch_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.reporting](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.s3_kms_key_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 | [terraform_remote_state.base](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 

--- a/environments/staging/common/s3.tf
+++ b/environments/staging/common/s3.tf
@@ -20,6 +20,37 @@ resource "aws_kms_alias" "s3_kms_alias" {
   target_key_id = aws_kms_key.s3.key_id
 }
 
+data "aws_iam_policy_document" "s3_kms_key_policy" {
+  statement {
+    sid       = "Enable IAM User Permissions"
+    effect    = "Allow"
+    actions   = ["kms:*"]
+    resources = ["*"]
+
+    principals {
+      identifiers = ["arn:aws:iam::${local.account_id}:root"]
+      type        = "AWS"
+    }
+  }
+
+  statement {
+    sid       = "Allow use of the key for CloudFront OAC"
+    effect    = "Allow"
+    actions   = ["kms:Decrypt"]
+    resources = ["*"]
+
+    principals {
+      identifiers = ["cloudfront.amazonaws.com"]
+      type        = "Service"
+    }
+  }
+}
+
+resource "aws_kms_key_policy" "s3_kms_key_policy" {
+  key_id = aws_kms_key.s3.key_id
+  policy = data.aws_iam_policy_document.s3_kms_key_policy.json
+}
+
 resource "aws_s3_bucket" "this" {
   for_each = local.buckets
   bucket   = each.value


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Added KMS policy for cloudfront in staging
- Added KMS policy for cloudfront in production

## Why?

I am doing this because:

- This is necessary for using s3 as an origin
