### PR TITLE
HOTT-4373: Adds separate sandbox zone

### DIFF
--- a/environments/production/common/README.md
+++ b/environments/production/common/README.md
@@ -101,7 +101,8 @@
 | [aws_kms_key_policy.s3_kms_key_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key_policy) | resource |
 | [aws_route53_health_check.dns_health_check](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_health_check) | resource |
 | [aws_route53_record.dev_name_servers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.sandbox_record](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.sandbox_name_servers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.staging_name_servers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_zone.lower_env](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
 | [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_policy.api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |

--- a/environments/production/common/route53.tf
+++ b/environments/production/common/route53.tf
@@ -19,7 +19,7 @@ data "terraform_remote_state" "staging" {
 }
 
 resource "aws_route53_zone" "lower_env" {
-  for_each = ["dev", "staging", "sandbox"]
+  for_each = to_set(["dev", "staging", "sandbox"])
   name     = "${each.key}.${local.tariff_domain}"
 }
 

--- a/environments/production/common/route53.tf
+++ b/environments/production/common/route53.tf
@@ -19,7 +19,7 @@ data "terraform_remote_state" "staging" {
 }
 
 resource "aws_route53_zone" "lower_env" {
-  for_each = to_set(["dev", "staging", "sandbox"])
+  for_each = toset(["dev", "staging", "sandbox"])
   name     = "${each.key}.${local.tariff_domain}"
 }
 

--- a/environments/production/common/route53.tf
+++ b/environments/production/common/route53.tf
@@ -19,7 +19,7 @@ data "terraform_remote_state" "staging" {
 }
 
 resource "aws_route53_zone" "lower_env" {
-  for_each = toset(["dev", "staging"])
+  for_each = ["dev", "staging", "sandbox"]
   name     = "${each.key}.${local.tariff_domain}"
 }
 
@@ -31,10 +31,18 @@ resource "aws_route53_record" "dev_name_servers" {
   records = data.terraform_remote_state.development.outputs.hosted_zone_name_servers
 }
 
-resource "aws_route53_record" "sandbox_record" {
+resource "aws_route53_record" "staging_name_servers" {
   zone_id = aws_route53_zone.lower_env["staging"].zone_id
-  name    = "sandbox.${local.tariff_domain}"
-  type    = "CNAME"
+  name    = "staging.${local.tariff_domain}"
+  type    = "NS"
   ttl     = "30"
-  records = ["staging.${local.tariff_domain}"]
+  records = data.terraform_remote_state.staging.outputs.hosted_zone_name_servers
+}
+
+resource "aws_route53_record" "sandbox_name_servers" {
+  zone_id = aws_route53_zone.lower_env["sandbox"].zone_id
+  name    = "sandbox.${local.tariff_domain}"
+  type    = "NS"
+  ttl     = "30"
+  records = data.terraform_remote_state.staging.outputs.sandbox_hosted_zone_name_servers
 }

--- a/environments/staging/common/README.md
+++ b/environments/staging/common/README.md
@@ -21,6 +21,7 @@
 |------|--------|---------|
 | <a name="module_acm"></a> [acm](#module\_acm) | ../../common/acm/ | n/a |
 | <a name="module_acm_origin"></a> [acm\_origin](#module\_acm\_origin) | ../../common/acm | n/a |
+| <a name="module_acm_sandbox"></a> [acm\_sandbox](#module\_acm\_sandbox) | ../../common/acm/ | n/a |
 | <a name="module_admin_bearer_token"></a> [admin\_bearer\_token](#module\_admin\_bearer\_token) | ../../common/secret/ | n/a |
 | <a name="module_admin_oauth_id"></a> [admin\_oauth\_id](#module\_admin\_oauth\_id) | ../../common/secret/ | n/a |
 | <a name="module_admin_oauth_secret"></a> [admin\_oauth\_secret](#module\_admin\_oauth\_secret) | ../../common/secret/ | n/a |
@@ -104,6 +105,7 @@
 | [aws_route53_record.origin_root](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.origin_wildcard](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_zone.origin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
+| [aws_route53_zone.sandbox](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
 | [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_policy.api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_policy.backups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
@@ -144,6 +146,7 @@
 | <a name="input_environment"></a> [environment](#input\_environment) | Build environment | `string` | `"staging"` | no |
 | <a name="input_frontend_secret_key_base"></a> [frontend\_secret\_key\_base](#input\_frontend\_secret\_key\_base) | Value of SECRET\_KEY\_BASE for the frontend. | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region to use. Defaults to `eu-west-2`. | `string` | `"eu-west-2"` | no |
+| <a name="input_sandbox_domain_name"></a> [sandbox\_domain\_name](#input\_sandbox\_domain\_name) | Sandbox domain name of the service. | `string` | `"sandbox.trade-tariff.service.gov.uk"` | no |
 | <a name="input_signon_derivation_key"></a> [signon\_derivation\_key](#input\_signon\_derivation\_key) | Value of ACTIVE\_RECORD\_ENCRYPTION\_PRIMARY\_KEY for the signon app. | `string` | n/a | yes |
 | <a name="input_signon_derivation_salt"></a> [signon\_derivation\_salt](#input\_signon\_derivation\_salt) | Value of ACTIVE\_RECORD\_ENCRYPTION\_KEY\_DERIVATION\_SALT for the signon app. | `string` | n/a | yes |
 | <a name="input_signon_devise_pepper"></a> [signon\_devise\_pepper](#input\_signon\_devise\_pepper) | Value of DEVISE\_PEPPER for the signon app. | `string` | n/a | yes |
@@ -170,4 +173,5 @@
 | Name | Description |
 |------|-------------|
 | <a name="output_hosted_zone_name_servers"></a> [hosted\_zone\_name\_servers](#output\_hosted\_zone\_name\_servers) | Name servers. |
+| <a name="output_sandbox_hosted_zone_name_servers"></a> [sandbox\_hosted\_zone\_name\_servers](#output\_sandbox\_hosted\_zone\_name\_servers) | Sandbox Name servers. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/environments/staging/common/acm.tf
+++ b/environments/staging/common/acm.tf
@@ -13,7 +13,7 @@ module "acm_sandbox" {
   source         = "../../common/acm/"
   domain_name    = var.sandbox_domain_name
   environment    = var.environment
-  hosted_zone_id = data.aws_route53_zone.sandbox.zone_id
+  hosted_zone_id = aws_route53_zone.sandbox.zone_id
 
   providers = {
     aws = aws.us_east_1

--- a/environments/staging/common/acm.tf
+++ b/environments/staging/common/acm.tf
@@ -4,9 +4,16 @@ module "acm" {
   environment    = var.environment
   hosted_zone_id = data.aws_route53_zone.this.zone_id
 
-  subject_alternative_names = [
-    "sandbox.trade-tariff.service.gov.uk"
-  ]
+  providers = {
+    aws = aws.us_east_1
+  }
+}
+
+module "acm_sandbox" {
+  source         = "../../common/acm/"
+  domain_name    = var.sandbox_domain_name
+  environment    = var.environment
+  hosted_zone_id = data.aws_route53_zone.sandbox.zone_id
 
   providers = {
     aws = aws.us_east_1

--- a/environments/staging/common/outputs.tf
+++ b/environments/staging/common/outputs.tf
@@ -2,3 +2,8 @@ output "hosted_zone_name_servers" {
   description = "Name servers."
   value       = data.aws_route53_zone.this.name_servers
 }
+
+output "sandbox_hosted_zone_name_servers" {
+  description = "Sandbox Name servers."
+  value       = aws_route53_zone.sandbox.name_servers
+}

--- a/environments/staging/common/route53.tf
+++ b/environments/staging/common/route53.tf
@@ -8,8 +8,7 @@ resource "aws_route53_zone" "origin" {
 }
 
 resource "aws_route53_zone" "sandbox" {
-  name         = var.sandbox_domain_name
-  private_zone = false
+  name = var.sandbox_domain_name
 }
 
 resource "aws_route53_record" "origin_ns" {

--- a/environments/staging/common/route53.tf
+++ b/environments/staging/common/route53.tf
@@ -7,6 +7,11 @@ resource "aws_route53_zone" "origin" {
   name = local.origin_domain_name
 }
 
+resource "aws_route53_zone" "sandbox" {
+  name         = var.sandbox_domain_name
+  private_zone = false
+}
+
 resource "aws_route53_record" "origin_ns" {
   zone_id = data.aws_route53_zone.this.zone_id
   name    = local.origin_domain_name

--- a/environments/staging/common/variables.tf
+++ b/environments/staging/common/variables.tf
@@ -16,7 +16,6 @@ variable "sandbox_domain_name" {
   default     = "sandbox.trade-tariff.service.gov.uk"
 }
 
-
 variable "region" {
   description = "AWS Region to use. Defaults to `eu-west-2`."
   type        = string

--- a/environments/staging/common/variables.tf
+++ b/environments/staging/common/variables.tf
@@ -10,6 +10,13 @@ variable "domain_name" {
   default     = "staging.trade-tariff.service.gov.uk"
 }
 
+variable "sandbox_domain_name" {
+  description = "Sandbox domain name of the service."
+  type        = string
+  default     = "sandbox.trade-tariff.service.gov.uk"
+}
+
+
 variable "region" {
   description = "AWS Region to use. Defaults to `eu-west-2`."
   type        = string


### PR DESCRIPTION
# Pull Request

## What?

I have:

- [x] Adds sandbox zone and ACM cert in staging
- [x] Adds NS records and zone to point at sandbox in staging

## Why?

I am doing this because:

- Enables us to point a record at the apex to the API gateway we build for the FPO project
- Enables a clear separation between the sandbox URLs and the staging ones in the staging account
- Fixes an issue with SANs being validated in staging
