### PR TITLE
BAU: Allow Serverless user SSM access

### DIFF
--- a/environments/development/common/iam.tf
+++ b/environments/development/common/iam.tf
@@ -129,6 +129,15 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
         Resource = [
           aws_kms_alias.s3_kms_alias.target_key_arn
         ]
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "ssm:DescribeParameters",
+          "ssm:GetParameter",
+          "ssm:GetParameters"
+        ],
+        Resource = [for v in aws_ssm_parameter.ecr_url : v.arn]
       }
     ]
   })

--- a/environments/production/common/iam.tf
+++ b/environments/production/common/iam.tf
@@ -129,6 +129,15 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
         Resource = [
           aws_kms_alias.s3_kms_alias.target_key_arn
         ]
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "ssm:DescribeParameters",
+          "ssm:GetParameter",
+          "ssm:GetParameters"
+        ],
+        Resource = [for v in aws_ssm_parameter.ecr_url : v.arn]
       }
     ]
   })
@@ -181,6 +190,7 @@ resource "aws_iam_policy" "ci_appendix5a_peristence_readwrite_policy" {
           "s3:ListBucket",
           "s3:PutObject",
         ],
+
         Resource = [
           "arn:aws:s3:::${aws_s3_bucket.this["persistence"].id}",
           "arn:aws:s3:::${aws_s3_bucket.this["persistence"].id}/config/chief_cds_guidance.json"

--- a/environments/staging/common/iam.tf
+++ b/environments/staging/common/iam.tf
@@ -129,6 +129,15 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
         Resource = [
           aws_kms_alias.s3_kms_alias.target_key_arn
         ]
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "ssm:DescribeParameters",
+          "ssm:GetParameter",
+          "ssm:GetParameters"
+        ],
+        Resource = [for v in aws_ssm_parameter.ecr_url : v.arn]
       }
     ]
   })
@@ -181,6 +190,7 @@ resource "aws_iam_policy" "ci_appendix5a_peristence_readwrite_policy" {
           "s3:ListBucket",
           "s3:PutObject",
         ],
+
         Resource = [
           "arn:aws:s3:::${aws_s3_bucket.this["persistence"].id}",
           "arn:aws:s3:::${aws_s3_bucket.this["persistence"].id}/config/chief_cds_guidance.json"


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Given severless user access to the ECR URL SSM parameters

## Why?

I am doing this because:

- The serverless user needs to be able to pull the image for Docker-in-Lambda setups
