### PR TITLE
BAU: Allow DescribeImages on ECR

### DIFF
--- a/environments/production/common/ecr.tf
+++ b/environments/production/common/ecr.tf
@@ -9,14 +9,15 @@ data "aws_iam_policy_document" "ecr_policy_document" {
       ]
     }
     actions = [
-      "ecr:ListImages",
-      "ecr:GetDownloadUrlForLayer",
-      "ecr:BatchGetImage",
       "ecr:BatchCheckLayerAvailability",
-      "ecr:PutImage",
+      "ecr:BatchGetImage",
+      "ecr:CompleteLayerUpload",
+      "ecr:DescribeImages",
+      "ecr:GetDownloadUrlForLayer",
       "ecr:InitiateLayerUpload",
+      "ecr:ListImages",
+      "ecr:PutImage",
       "ecr:UploadLayerPart",
-      "ecr:CompleteLayerUpload"
     ]
   }
 }


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Added `ecr:DescribeImages` to ECR policy.

## Why?

I am doing this because:

- The serverless user needs this permission.
