### PR TITLE
HOTT-4367: Enable ECR access to circle ci context users

### DIFF
--- a/environments/production/common/ecr.tf
+++ b/environments/production/common/ecr.tf
@@ -6,6 +6,9 @@ data "aws_iam_policy_document" "ecr_policy_document" {
         "arn:aws:iam::${lookup(var.account_ids, "development")}:root",
         "arn:aws:iam::${lookup(var.account_ids, "staging")}:root",
         "arn:aws:iam::${lookup(var.account_ids, "production")}:root",
+        "arn:aws:iam::${lookup(var.account_ids, "development")}:user/serverless-lambda-ci",
+        "arn:aws:iam::${lookup(var.account_ids, "staging")}:user/serverless-lambda-ci",
+        "arn:aws:iam::${lookup(var.account_ids, "production")}:user/serverless-lambda-ci",
       ]
     }
     actions = [


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Added access to ECR repositories to the serverless-lambda-ci in development
- Added access to ECR repositories to the serverless-lambda-ci in staging
- Added access to ECR repositories to the serverless-lambda-ci in production

## Why?

I am doing this because:

- This is required to enable us to deploy with ECR repos
