### PR TITLE
HOTT-4106: Adds ACM certs for London and update lambda deployment permissions

### DIFF
--- a/environments/common/security-group/.terraform.lock.hcl
+++ b/environments/common/security-group/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = ">= 5.3.0"
   hashes = [
     "h1:N6Iu1W6tvozB4RsClM9aHPuZhrKD6GCUAjlnl8THcLs=",
+    "h1:UkBMGEScvNP+9JDzKXGrgj931LngYpIB8TBBUY+mvdg=",
     "zh:11a4062491e574c8e96b6bc7ced67b5e9338ccfa068223fc9042f9e1e7eda47a",
     "zh:4331f85aeb22223ab656d04b48337a033f44f02f685c8def604c4f8f4687d10f",
     "zh:915d6c996390736709f7ac7582cd41418463cfc07696218af6fea4a282df744a",

--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -43,6 +43,7 @@ No outputs.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_acm"></a> [acm](#module\_acm) | ../../common/acm/ | n/a |
+| <a name="module_acm_london"></a> [acm\_london](#module\_acm\_london) | ../../common/acm/ | n/a |
 | <a name="module_acm_origin"></a> [acm\_origin](#module\_acm\_origin) | ../../common/acm | n/a |
 | <a name="module_admin_bearer_token"></a> [admin\_bearer\_token](#module\_admin\_bearer\_token) | ../../common/secret/ | n/a |
 | <a name="module_admin_oauth_id"></a> [admin\_oauth\_id](#module\_admin\_oauth\_id) | ../../common/secret/ | n/a |

--- a/environments/development/common/acm.tf
+++ b/environments/development/common/acm.tf
@@ -9,6 +9,14 @@ module "acm" {
   }
 }
 
+module "acm_london" {
+  source         = "../../common/acm/"
+  domain_name    = var.domain_name
+  environment    = var.environment
+  hosted_zone_id = data.aws_route53_zone.this.zone_id
+}
+
+
 module "acm_origin" {
   source         = "../../common/acm"
   domain_name    = "origin.${var.domain_name}"

--- a/environments/development/common/acm.tf
+++ b/environments/development/common/acm.tf
@@ -16,7 +16,6 @@ module "acm_london" {
   hosted_zone_id = data.aws_route53_zone.this.zone_id
 }
 
-
 module "acm_origin" {
   source         = "../../common/acm"
   domain_name    = "origin.${var.domain_name}"

--- a/environments/development/common/iam.tf
+++ b/environments/development/common/iam.tf
@@ -95,6 +95,7 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
         Effect = "Allow",
         Action = [
           "iam:CreateRole",
+          "iam:CreateServiceLinkedRole",
           "iam:DeleteRole",
           "iam:DeleteRolePolicy",
           "iam:GetRole",
@@ -164,7 +165,24 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
         Resource = [
           "*"
         ]
-      }
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "acm:ListCertificates",
+        ],
+        Resource = ["*"]
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "route53:ListHostedZones",
+          "route53:ChangeResourceRecordSets",
+          "route53:GetHostedZone",
+          "route53:ListResourceRecordSets",
+        ],
+        Resource = ["*"]
+      },
     ]
   })
 }

--- a/environments/development/common/iam.tf
+++ b/environments/development/common/iam.tf
@@ -181,7 +181,7 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
           "route53:GetHostedZone",
           "route53:ListResourceRecordSets",
         ],
-        Resource = ["*"]
+        Resource = [data.aws_route53_zone.this.arn]
       },
     ]
   })

--- a/environments/production/common/README.md
+++ b/environments/production/common/README.md
@@ -21,6 +21,7 @@
 |------|--------|---------|
 | <a name="module_acm"></a> [acm](#module\_acm) | ../../common/acm/ | n/a |
 | <a name="module_acm_alb"></a> [acm\_alb](#module\_acm\_alb) | ../../common/acm/ | n/a |
+| <a name="module_acm_london"></a> [acm\_london](#module\_acm\_london) | ../../common/acm/ | n/a |
 | <a name="module_admin_bearer_token"></a> [admin\_bearer\_token](#module\_admin\_bearer\_token) | ../../common/secret/ | n/a |
 | <a name="module_admin_oauth_id"></a> [admin\_oauth\_id](#module\_admin\_oauth\_id) | ../../common/secret/ | n/a |
 | <a name="module_admin_oauth_secret"></a> [admin\_oauth\_secret](#module\_admin\_oauth\_secret) | ../../common/secret/ | n/a |

--- a/environments/production/common/acm.tf
+++ b/environments/production/common/acm.tf
@@ -9,6 +9,13 @@ module "acm" {
   }
 }
 
+module "acm_london" {
+  source         = "../../common/acm/"
+  domain_name    = var.domain_name
+  environment    = var.environment
+  hosted_zone_id = data.aws_route53_zone.this.zone_id
+}
+
 module "acm_alb" {
   source         = "../../common/acm/"
   domain_name    = var.domain_name

--- a/environments/production/common/iam.tf
+++ b/environments/production/common/iam.tf
@@ -164,7 +164,24 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
         Resource = [
           "*"
         ]
-      }
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "acm:ListCertificates",
+        ],
+        Resource = ["*"]
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "route53:ListHostedZones",
+          "route53:ChangeResourceRecordSets",
+          "route53:GetHostedZone",
+          "route53:ListResourceRecordSets",
+        ],
+        Resource = ["*"]
+      },
     ]
   })
 }

--- a/environments/production/common/iam.tf
+++ b/environments/production/common/iam.tf
@@ -180,7 +180,7 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
           "route53:GetHostedZone",
           "route53:ListResourceRecordSets",
         ],
-        Resource = ["*"]
+        Resource = [data.aws_route53_zone.this.arn]
       },
     ]
   })

--- a/environments/staging/common/README.md
+++ b/environments/staging/common/README.md
@@ -22,6 +22,7 @@
 | <a name="module_acm"></a> [acm](#module\_acm) | ../../common/acm/ | n/a |
 | <a name="module_acm_origin"></a> [acm\_origin](#module\_acm\_origin) | ../../common/acm | n/a |
 | <a name="module_acm_sandbox"></a> [acm\_sandbox](#module\_acm\_sandbox) | ../../common/acm/ | n/a |
+| <a name="module_acm_sandbox_london"></a> [acm\_sandbox\_london](#module\_acm\_sandbox\_london) | ../../common/acm/ | n/a |
 | <a name="module_admin_bearer_token"></a> [admin\_bearer\_token](#module\_admin\_bearer\_token) | ../../common/secret/ | n/a |
 | <a name="module_admin_oauth_id"></a> [admin\_oauth\_id](#module\_admin\_oauth\_id) | ../../common/secret/ | n/a |
 | <a name="module_admin_oauth_secret"></a> [admin\_oauth\_secret](#module\_admin\_oauth\_secret) | ../../common/secret/ | n/a |

--- a/environments/staging/common/acm.tf
+++ b/environments/staging/common/acm.tf
@@ -20,6 +20,13 @@ module "acm_sandbox" {
   }
 }
 
+module "acm_sandbox_london" {
+  source         = "../../common/acm/"
+  domain_name    = var.sandbox_domain_name
+  environment    = var.environment
+  hosted_zone_id = aws_route53_zone.sandbox.zone_id
+}
+
 module "acm_origin" {
   source         = "../../common/acm"
   domain_name    = "origin.${var.domain_name}"

--- a/environments/staging/common/iam.tf
+++ b/environments/staging/common/iam.tf
@@ -164,7 +164,24 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
         Resource = [
           "*"
         ]
-      }
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "acm:ListCertificates",
+        ],
+        Resource = ["*"]
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "route53:ListHostedZones",
+          "route53:ChangeResourceRecordSets",
+          "route53:GetHostedZone",
+          "route53:ListResourceRecordSets",
+        ],
+        Resource = ["*"]
+      },
     ]
   })
 }

--- a/environments/staging/common/iam.tf
+++ b/environments/staging/common/iam.tf
@@ -180,7 +180,7 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
           "route53:GetHostedZone",
           "route53:ListResourceRecordSets",
         ],
-        Resource = ["*"]
+        Resource = [data.aws_route53_zone.this.arn]
       },
     ]
   })


### PR DESCRIPTION
# Pull Request

## What?

I have:

- [x] Adds certificates in London for the api gateway custom domains in development
- [x] Adds certificates in London for the api gateway custom domains in staging
- [x] Adds certificates in London for the api gateway custom domains in production
- [x] Adds permissions to enable the lambda deployment user to create the relevant resources for custom domains in development
- [x] Adds permissions to enable the lambda deployment user to create the relevant resources for custom domains in staging
- [x] Adds permissions to enable the lambda deployment user to create the relevant resources for custom domains in production

## Why?

I am doing this because:

- This is required to have custom domains for our FPO lambda
