### PR TITLE
HOTT-4423: Add Basic Auth to Backups

### DIFF
--- a/environments/common/cloudfront-auth.js.tpl
+++ b/environments/common/cloudfront-auth.js.tpl
@@ -1,0 +1,20 @@
+function handler(event) {
+  var authHeaders = event.request.headers.authorization;
+  var expected = "Basic ${base64}";
+
+  if (authHeaders && authHeaders.value === expected) {
+    return event.request;
+  }
+
+  var response = {
+    statusCode: 401,
+    statusDescription: "Unauthorized",
+    headers: {
+      "www-authenticate": {
+        value: 'Basic realm="OTT Backups"',
+      },
+    },
+  };
+
+  return response;
+}

--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -64,7 +64,7 @@ No outputs.
 | <a name="module_backend_xi_sync_host"></a> [backend\_xi\_sync\_host](#module\_backend\_xi\_sync\_host) | ../../common/secret/ | n/a |
 | <a name="module_backend_xi_sync_password"></a> [backend\_xi\_sync\_password](#module\_backend\_xi\_sync\_password) | ../../common/secret/ | n/a |
 | <a name="module_backend_xi_sync_username"></a> [backend\_xi\_sync\_username](#module\_backend\_xi\_sync\_username) | ../../common/secret/ | n/a |
-| <a name="module_backups_cdn"></a> [backups\_cdn](#module\_backups\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.3.0 |
+| <a name="module_backups_cdn"></a> [backups\_cdn](#module\_backups\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.4.1 |
 | <a name="module_cdn"></a> [cdn](#module\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.3.0 |
 | <a name="module_cloudwatch"></a> [cloudwatch](#module\_cloudwatch) | ../../common/cloudwatch/ | n/a |
 | <a name="module_cloudwatch-logs-exporter"></a> [cloudwatch-logs-exporter](#module\_cloudwatch-logs-exporter) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudwatch_log_exporter | aws/cloudwatch_log_exporter-v1.0.0 |
@@ -93,6 +93,7 @@ No outputs.
 | Name | Type |
 |------|------|
 | [aws_cloudfront_cache_policy.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_cache_policy) | resource |
+| [aws_cloudfront_function.basic_auth](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_function) | resource |
 | [aws_cloudfront_origin_access_control.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_access_control) | resource |
 | [aws_cloudfront_origin_request_policy.forward_all_qsa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_request_policy) | resource |
 | [aws_cloudfront_origin_request_policy.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_request_policy) | resource |
@@ -162,6 +163,7 @@ No outputs.
 | <a name="input_admin_secret_key_base"></a> [admin\_secret\_key\_base](#input\_admin\_secret\_key\_base) | Value of SECRET\_KEY\_BASE for the admin tool. | `string` | n/a | yes |
 | <a name="input_admin_sentry_dsn"></a> [admin\_sentry\_dsn](#input\_admin\_sentry\_dsn) | Value of Sentry DSN for the admin tool. | `string` | n/a | yes |
 | <a name="input_backend_secret_key_base"></a> [backend\_secret\_key\_base](#input\_backend\_secret\_key\_base) | Value of SECRET\_KEY\_BASE for the backend. | `string` | n/a | yes |
+| <a name="input_backups_basic_auth"></a> [backups\_basic\_auth](#input\_backups\_basic\_auth) | base64 encoded credentials for backups basic auth. | `string` | n/a | yes |
 | <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | Domain name of the service. | `string` | `"dev.trade-tariff.service.gov.uk"` | no |
 | <a name="input_duty_calculator_secret_key_base"></a> [duty\_calculator\_secret\_key\_base](#input\_duty\_calculator\_secret\_key\_base) | Value of SECRET\_KEY\_BASE for the duty calculator. | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | Build environment | `string` | `"development"` | no |

--- a/environments/development/common/cloudfront.tf
+++ b/environments/development/common/cloudfront.tf
@@ -319,7 +319,7 @@ data "aws_iam_policy_document" "backups" {
 }
 
 module "backups_cdn" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront?ref=aws/cloudfront-v1.3.0"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront?ref=aws/cloudfront-v1.4.1"
 
   aliases         = ["dumps.${var.domain_name}"]
   create_alias    = true
@@ -357,6 +357,12 @@ module "backups_cdn" {
       max_ttl     = 0
 
       compress = true
+
+      function_association = {
+        "viewer-request" = {
+          function_arn = aws_cloudfront_function.basic_auth.arn
+        }
+      }
     },
   }
 
@@ -367,4 +373,11 @@ module "backups_cdn" {
       module.acm.validated_certificate_arn
     ]
   }
+}
+
+resource "aws_cloudfront_function" "basic_auth" {
+  name    = "backups-basic-auth"
+  runtime = "cloudfront-js-1.0"
+  publish = true
+  code    = local.cloudfront_auth
 }

--- a/environments/development/common/locals.tf
+++ b/environments/development/common/locals.tf
@@ -12,6 +12,8 @@ locals {
     "search-query-parser",
     "signon",
   ]
+
+  cloudfront_auth = templatefile("../../common/cloudfront-auth.js.tpl", { base64 = var.backups_basic_auth })
 }
 
 data "aws_caller_identity" "current" {}

--- a/environments/development/common/variables.tf
+++ b/environments/development/common/variables.tf
@@ -195,3 +195,9 @@ variable "signon_derivation_key" {
   type        = string
   sensitive   = true
 }
+
+variable "backups_basic_auth" {
+  description = "base64 encoded credentials for backups basic auth."
+  type        = string
+  sensitive   = true
+}

--- a/environments/production/common/README.md
+++ b/environments/production/common/README.md
@@ -41,8 +41,8 @@
 | <a name="module_backend_xi_sync_host"></a> [backend\_xi\_sync\_host](#module\_backend\_xi\_sync\_host) | ../../common/secret/ | n/a |
 | <a name="module_backend_xi_sync_password"></a> [backend\_xi\_sync\_password](#module\_backend\_xi\_sync\_password) | ../../common/secret/ | n/a |
 | <a name="module_backend_xi_sync_username"></a> [backend\_xi\_sync\_username](#module\_backend\_xi\_sync\_username) | ../../common/secret/ | n/a |
-| <a name="module_backups_cdn"></a> [backups\_cdn](#module\_backups\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.3.0 |
-| <a name="module_cdn"></a> [cdn](#module\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.2.1 |
+| <a name="module_backups_cdn"></a> [backups\_cdn](#module\_backups\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.4.1 |
+| <a name="module_cdn"></a> [cdn](#module\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.3.0 |
 | <a name="module_cloudwatch"></a> [cloudwatch](#module\_cloudwatch) | ../../common/cloudwatch/ | n/a |
 | <a name="module_cloudwatch-logs-exporter"></a> [cloudwatch-logs-exporter](#module\_cloudwatch-logs-exporter) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudwatch_log_exporter | aws/cloudwatch_log_exporter-v1.0.0 |
 | <a name="module_duty_calculator_secret_key_base"></a> [duty\_calculator\_secret\_key\_base](#module\_duty\_calculator\_secret\_key\_base) | ../../common/secret/ | n/a |
@@ -64,6 +64,7 @@
 | Name | Type |
 |------|------|
 | [aws_cloudfront_cache_policy.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_cache_policy) | resource |
+| [aws_cloudfront_function.basic_auth](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_function) | resource |
 | [aws_cloudfront_origin_access_control.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_access_control) | resource |
 | [aws_cloudfront_origin_request_policy.forward_all_qsa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_request_policy) | resource |
 | [aws_cloudfront_origin_request_policy.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_request_policy) | resource |
@@ -144,6 +145,7 @@
 | <a name="input_admin_secret_key_base"></a> [admin\_secret\_key\_base](#input\_admin\_secret\_key\_base) | Value of SECRET\_KEY\_BASE for the admin tool. | `string` | n/a | yes |
 | <a name="input_admin_sentry_dsn"></a> [admin\_sentry\_dsn](#input\_admin\_sentry\_dsn) | Value of Sentry DSN for the admin tool. | `string` | n/a | yes |
 | <a name="input_backend_secret_key_base"></a> [backend\_secret\_key\_base](#input\_backend\_secret\_key\_base) | Value of SECRET\_KEY\_BASE for the backend. | `string` | n/a | yes |
+| <a name="input_backups_basic_auth"></a> [backups\_basic\_auth](#input\_backups\_basic\_auth) | base64 encoded credentials for backups basic auth. | `string` | n/a | yes |
 | <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | Domain name of the service. | `string` | `"tradetesting.net"` | no |
 | <a name="input_duty_calculator_secret_key_base"></a> [duty\_calculator\_secret\_key\_base](#input\_duty\_calculator\_secret\_key\_base) | Value of SECRET\_KEY\_BASE for the duty calculator. | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | Build environment | `string` | `"production"` | no |

--- a/environments/production/common/locals.tf
+++ b/environments/production/common/locals.tf
@@ -1,6 +1,7 @@
 locals {
-  account_id    = data.aws_caller_identity.current.account_id
-  tariff_domain = "trade-tariff.service.gov.uk"
+  account_id      = data.aws_caller_identity.current.account_id
+  tariff_domain   = "trade-tariff.service.gov.uk"
+  cloudfront_auth = templatefile("../../common/cloudfront-auth.js.tpl", { base64 = var.backups_basic_auth })
 }
 
 data "aws_caller_identity" "current" {}

--- a/environments/production/common/variables.tf
+++ b/environments/production/common/variables.tf
@@ -159,3 +159,9 @@ variable "tariff_backend_oauth_secret" {
   type        = string
   sensitive   = true
 }
+
+variable "backups_basic_auth" {
+  description = "base64 encoded credentials for backups basic auth."
+  type        = string
+  sensitive   = true
+}

--- a/environments/staging/common/README.md
+++ b/environments/staging/common/README.md
@@ -42,7 +42,7 @@
 | <a name="module_backend_xi_sync_host"></a> [backend\_xi\_sync\_host](#module\_backend\_xi\_sync\_host) | ../../common/secret/ | n/a |
 | <a name="module_backend_xi_sync_password"></a> [backend\_xi\_sync\_password](#module\_backend\_xi\_sync\_password) | ../../common/secret/ | n/a |
 | <a name="module_backend_xi_sync_username"></a> [backend\_xi\_sync\_username](#module\_backend\_xi\_sync\_username) | ../../common/secret/ | n/a |
-| <a name="module_backups_cdn"></a> [backups\_cdn](#module\_backups\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.3.0 |
+| <a name="module_backups_cdn"></a> [backups\_cdn](#module\_backups\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.4.1 |
 | <a name="module_cdn"></a> [cdn](#module\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.3.0 |
 | <a name="module_cloudwatch"></a> [cloudwatch](#module\_cloudwatch) | ../../common/cloudwatch/ | n/a |
 | <a name="module_cloudwatch-logs-exporter"></a> [cloudwatch-logs-exporter](#module\_cloudwatch-logs-exporter) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudwatch_log_exporter | aws/cloudwatch_log_exporter-v1.0.0 |
@@ -71,6 +71,7 @@
 | Name | Type |
 |------|------|
 | [aws_cloudfront_cache_policy.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_cache_policy) | resource |
+| [aws_cloudfront_function.basic_auth](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_function) | resource |
 | [aws_cloudfront_origin_access_control.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_access_control) | resource |
 | [aws_cloudfront_origin_request_policy.forward_all_qsa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_request_policy) | resource |
 | [aws_cloudfront_origin_request_policy.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_request_policy) | resource |
@@ -141,6 +142,7 @@
 | <a name="input_admin_secret_key_base"></a> [admin\_secret\_key\_base](#input\_admin\_secret\_key\_base) | Value of SECRET\_KEY\_BASE for the admin tool. | `string` | n/a | yes |
 | <a name="input_admin_sentry_dsn"></a> [admin\_sentry\_dsn](#input\_admin\_sentry\_dsn) | Value of Sentry DSN for the admin tool. | `string` | n/a | yes |
 | <a name="input_backend_secret_key_base"></a> [backend\_secret\_key\_base](#input\_backend\_secret\_key\_base) | Value of SECRET\_KEY\_BASE for the backend. | `string` | n/a | yes |
+| <a name="input_backups_basic_auth"></a> [backups\_basic\_auth](#input\_backups\_basic\_auth) | base64 encoded credentials for backups basic auth. | `string` | n/a | yes |
 | <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | Domain name of the service. | `string` | `"staging.trade-tariff.service.gov.uk"` | no |
 | <a name="input_duty_calculator_secret_key_base"></a> [duty\_calculator\_secret\_key\_base](#input\_duty\_calculator\_secret\_key\_base) | Value of SECRET\_KEY\_BASE for the duty calculator. | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | Build environment | `string` | `"staging"` | no |

--- a/environments/staging/common/cloudfront.tf
+++ b/environments/staging/common/cloudfront.tf
@@ -45,7 +45,7 @@ module "cdn" {
       default_ttl = 0
       max_ttl     = 0
 
-      compress = false
+      compress = true
 
       allowed_methods = [
         "GET",
@@ -168,10 +168,11 @@ data "aws_iam_policy_document" "api" {
 module "api_cdn" {
   source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront?ref=aws/cloudfront-v1.3.0"
 
-  aliases         = ["api.${var.domain_name}"]
-  create_alias    = true
-  route53_zone_id = data.aws_route53_zone.this.id
-  comment         = "API Docs ${title(var.environment)} CDN"
+  aliases             = ["api.${var.domain_name}"]
+  create_alias        = true
+  route53_zone_id     = data.aws_route53_zone.this.id
+  comment             = "API Docs ${title(var.environment)} CDN"
+  default_root_object = "index.html"
 
   enabled         = true
   is_ipv6_enabled = true
@@ -318,7 +319,7 @@ data "aws_iam_policy_document" "backups" {
 }
 
 module "backups_cdn" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront?ref=aws/cloudfront-v1.3.0"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront?ref=aws/cloudfront-v1.4.1"
 
   aliases         = ["dumps.${var.domain_name}"]
   create_alias    = true
@@ -356,6 +357,12 @@ module "backups_cdn" {
       max_ttl     = 0
 
       compress = true
+
+      function_association = {
+        "viewer-request" = {
+          function_arn = aws_cloudfront_function.basic_auth.arn
+        }
+      }
     },
   }
 
@@ -366,4 +373,11 @@ module "backups_cdn" {
       module.acm.validated_certificate_arn
     ]
   }
+}
+
+resource "aws_cloudfront_function" "basic_auth" {
+  name    = "backups-basic-auth"
+  runtime = "cloudfront-js-1.0"
+  publish = true
+  code    = local.cloudfront_auth
 }

--- a/environments/staging/common/locals.tf
+++ b/environments/staging/common/locals.tf
@@ -12,6 +12,8 @@ locals {
     "search-query-parser",
     "signon",
   ]
+
+  cloudfront_auth = templatefile("../../common/cloudfront-auth.js.tpl", { base64 = var.backups_basic_auth })
 }
 
 data "aws_caller_identity" "current" {}

--- a/environments/staging/common/variables.tf
+++ b/environments/staging/common/variables.tf
@@ -201,3 +201,9 @@ variable "signon_derivation_key" {
   type        = string
   sensitive   = true
 }
+
+variable "backups_basic_auth" {
+  description = "base64 encoded credentials for backups basic auth."
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Added basic auth to the backups CDN using CloudFront functions

## Why?

I am doing this because:

- We need at least _some_ protection on these as they're literally database dumps