### PR TITLE
BAU: Adds "iam:CreateServiceLinkedRole" for lambda deployment user

### DIFF
--- a/environments/production/common/iam.tf
+++ b/environments/production/common/iam.tf
@@ -95,6 +95,7 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
         Effect = "Allow",
         Action = [
           "iam:CreateRole",
+          "iam:CreateServiceLinkedRole",
           "iam:DeleteRole",
           "iam:DeleteRolePolicy",
           "iam:GetRole",

--- a/environments/staging/common/iam.tf
+++ b/environments/staging/common/iam.tf
@@ -95,6 +95,7 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
         Effect = "Allow",
         Action = [
           "iam:CreateRole",
+          "iam:CreateServiceLinkedRole",
           "iam:DeleteRole",
           "iam:DeleteRolePolicy",
           "iam:GetRole",


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Added "iam:CreateServiceLinkedRole" for lambda deployment user in staging
- Added "iam:CreateServiceLinkedRole" for lambda deployment user in production

## Why?

I am doing this because:

- This was missed in a previous PR and is essential for creating custom domains
