### PR TITLE
HOTT-4427: Enable permissive reads but restricted writes

### DIFF
--- a/environments/development/common/iam.tf
+++ b/environments/development/common/iam.tf
@@ -177,9 +177,15 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
         Effect = "Allow",
         Action = [
           "route53:ListHostedZones",
-          "route53:ChangeResourceRecordSets",
           "route53:GetHostedZone",
           "route53:ListResourceRecordSets",
+        ],
+        Resource = ["*"]
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "route53:ChangeResourceRecordSets",
         ],
         Resource = [data.aws_route53_zone.this.arn]
       },

--- a/environments/production/common/iam.tf
+++ b/environments/production/common/iam.tf
@@ -177,9 +177,15 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
         Effect = "Allow",
         Action = [
           "route53:ListHostedZones",
-          "route53:ChangeResourceRecordSets",
           "route53:GetHostedZone",
           "route53:ListResourceRecordSets",
+        ],
+        Resource = ["*"]
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "route53:ChangeResourceRecordSets",
         ],
         Resource = [data.aws_route53_zone.this.arn]
       },

--- a/environments/staging/common/iam.tf
+++ b/environments/staging/common/iam.tf
@@ -177,9 +177,15 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
         Effect = "Allow",
         Action = [
           "route53:ListHostedZones",
-          "route53:ChangeResourceRecordSets",
           "route53:GetHostedZone",
           "route53:ListResourceRecordSets",
+        ],
+        Resource = ["*"]
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "route53:ChangeResourceRecordSets",
         ],
         Resource = [aws_route53_zone.sandbox.arn]
       },


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Added permissive ability to read information about all zones
- Preserved restriction on mutating actions for zones

## Why?

I am doing this because:

- This is required to enable the lambda deployment user to list zones
