### PR TITLE
BAU: Unset Content-Security-Policy override

### DIFF
--- a/environments/development/common/cloudfront-policy.tf
+++ b/environments/development/common/cloudfront-policy.tf
@@ -22,11 +22,6 @@ resource "aws_cloudfront_response_headers_policy" "this" {
   name = "secure-headers"
 
   security_headers_config {
-    content_security_policy {
-      content_security_policy = "default-src 'self'"
-      override                = true
-    }
-
     strict_transport_security {
       access_control_max_age_sec = 31536000
       include_subdomains         = true

--- a/environments/production/common/cloudfront-policy.tf
+++ b/environments/production/common/cloudfront-policy.tf
@@ -22,11 +22,6 @@ resource "aws_cloudfront_response_headers_policy" "this" {
   name = "secure-headers"
 
   security_headers_config {
-    content_security_policy {
-      content_security_policy = "default-src 'self'"
-      override                = true
-    }
-
     strict_transport_security {
       access_control_max_age_sec = 31536000
       include_subdomains         = true

--- a/environments/staging/common/cloudfront-policy.tf
+++ b/environments/staging/common/cloudfront-policy.tf
@@ -22,11 +22,6 @@ resource "aws_cloudfront_response_headers_policy" "this" {
   name = "secure-headers"
 
   security_headers_config {
-    content_security_policy {
-      content_security_policy = "default-src 'self'"
-      override                = true
-    }
-
     strict_transport_security {
       access_control_max_age_sec = 31536000
       include_subdomains         = true


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Removed the override of the `Content-Security-Policy` header in CloudFront response headers policy.

## Why?

I am doing this because:

- The frontend loads a lot of inline items which break when this header is set, so its easier right now to just unset this.