### PR TITLE
BAU: Add DescribeRepositories for Lambda IAM User

### DIFF
--- a/environments/production/common/ecr.tf
+++ b/environments/production/common/ecr.tf
@@ -1,3 +1,18 @@
+locals {
+  ecr_actions = [
+    "ecr:BatchCheckLayerAvailability",
+    "ecr:BatchGetImage",
+    "ecr:CompleteLayerUpload",
+    "ecr:DescribeImages",
+    "ecr:DescribeRepositories",
+    "ecr:GetDownloadUrlForLayer",
+    "ecr:InitiateLayerUpload",
+    "ecr:ListImages",
+    "ecr:PutImage",
+    "ecr:UploadLayerPart",
+  ]
+}
+
 data "aws_iam_policy_document" "ecr_policy_document" {
   statement {
     principals {
@@ -11,17 +26,8 @@ data "aws_iam_policy_document" "ecr_policy_document" {
         "arn:aws:iam::${lookup(var.account_ids, "production")}:user/serverless-lambda-ci",
       ]
     }
-    actions = [
-      "ecr:BatchCheckLayerAvailability",
-      "ecr:BatchGetImage",
-      "ecr:CompleteLayerUpload",
-      "ecr:DescribeImages",
-      "ecr:GetDownloadUrlForLayer",
-      "ecr:InitiateLayerUpload",
-      "ecr:ListImages",
-      "ecr:PutImage",
-      "ecr:UploadLayerPart",
-    ]
+
+    actions = local.ecr_actions
   }
 
   statement {
@@ -32,16 +38,7 @@ data "aws_iam_policy_document" "ecr_policy_document" {
       ]
     }
 
-    actions = [
-      "ecr:ListImages",
-      "ecr:GetDownloadUrlForLayer",
-      "ecr:BatchGetImage",
-      "ecr:BatchCheckLayerAvailability",
-      "ecr:PutImage",
-      "ecr:InitiateLayerUpload",
-      "ecr:UploadLayerPart",
-      "ecr:CompleteLayerUpload"
-    ]
+    actions = local.ecr_actions
 
     condition {
       test     = "StringLike"


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Added `ecr:DescribeRepositories` to the ECR policy for the Lambda deployments IAM user.

## Why?

I am doing this because:

- It needs this permission to build and push to ECR.