### PR TITLE
BAU: Adds SES verified identities

### DIFF
--- a/environments/production/common/README.md
+++ b/environments/production/common/README.md
@@ -63,6 +63,7 @@
 | <a name="module_reporting_cdn"></a> [reporting\_cdn](#module\_reporting\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.4.2 |
 | <a name="module_search_configuration_bucket"></a> [search\_configuration\_bucket](#module\_search\_configuration\_bucket) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v3.14.0 |
 | <a name="module_search_query_parser_sentry_dsn"></a> [search\_query\_parser\_sentry\_dsn](#module\_search\_query\_parser\_sentry\_dsn) | ../../common/secret/ | n/a |
+| <a name="module_ses"></a> [ses](#module\_ses) | ../../common/ses | n/a |
 | <a name="module_slack_web_hook_url"></a> [slack\_web\_hook\_url](#module\_slack\_web\_hook\_url) | ../../common/secret/ | n/a |
 | <a name="module_waf"></a> [waf](#module\_waf) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/waf | aws/waf-v1.2.1 |
 

--- a/environments/production/common/ses.tf
+++ b/environments/production/common/ses.tf
@@ -1,0 +1,5 @@
+module "ses" {
+  source          = "../../common/ses"
+  domain_name     = var.domain_name
+  route53_zone_id = data.aws_route53_zone.this.zone_id
+}


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Added SES verified identity for the base domain

## Why?

I am doing this because:

- This is required to send emails out of the production account and will automatically propagate verified identities in production when we switchover the base domain
