### PR TITLE
BAU: Cache /api/v2/*

### DIFF
--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -99,6 +99,7 @@ No outputs.
 
 | Name | Type |
 |------|------|
+| [aws_cloudfront_cache_policy.cache_api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_cache_policy) | resource |
 | [aws_cloudfront_cache_policy.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_cache_policy) | resource |
 | [aws_cloudfront_function.basic_auth](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_function) | resource |
 | [aws_cloudfront_origin_access_control.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_access_control) | resource |

--- a/environments/development/common/cloudfront-policy.tf
+++ b/environments/development/common/cloudfront-policy.tf
@@ -2,6 +2,33 @@ data "aws_cloudfront_cache_policy" "caching_disabled" {
   name = "Managed-CachingDisabled"
 }
 
+resource "aws_cloudfront_cache_policy" "cache_api" {
+  name        = "cache-apiv2"
+  default_ttl = 180
+  max_ttl     = 180
+  min_ttl     = 1
+
+  parameters_in_cache_key_and_forwarded_to_origin {
+    cookies_config {
+      cookie_behavior = "none"
+    }
+
+    headers_config {
+      header_behavior = "whitelist"
+      headers {
+        items = [
+          "if-modified-since",
+          "if-none-match",
+        ]
+      }
+    }
+
+    query_strings_config {
+      query_string_behavior = "all"
+    }
+  }
+}
+
 resource "aws_cloudfront_origin_request_policy" "forward_all_qsa" {
   name    = "Forward-All-QSA-${var.environment}"
   comment = "Forward all QSA (managed by Terraform)"

--- a/environments/development/common/cloudfront.tf
+++ b/environments/development/common/cloudfront.tf
@@ -58,7 +58,39 @@ module "cdn" {
         "GET",
         "HEAD"
       ]
-    },
+    }
+
+    api = {
+      target_origin_id       = "frontend"
+      viewer_protocol_policy = "redirect-to-https"
+
+      path_pattern = "/api/v2/*"
+
+      cache_policy_id            = aws_cloudfront_cache_policy.cache_api.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+
+      min_ttl     = 1
+      default_ttl = 180
+      max_ttl     = 180
+
+      compress = true
+
+      allowed_methods = [
+        "GET",
+        "HEAD",
+        "OPTIONS",
+        "PUT",
+        "POST",
+        "PATCH",
+        "DELETE"
+      ]
+
+      cached_methods = [
+        "GET",
+        "HEAD"
+      ]
+    }
   }
 
   viewer_certificate = {


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Added custom cache behaviour for the CDN in dev

## Why?

I am doing this because:

- We want to test caching `/api/v2/*` paths