### PR TITLE
BAU: Make origin/certificate/ALB record match

### DIFF
--- a/environments/production/common/README.md
+++ b/environments/production/common/README.md
@@ -20,8 +20,8 @@
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_acm"></a> [acm](#module\_acm) | ../../common/acm/ | n/a |
-| <a name="module_acm_alb"></a> [acm\_alb](#module\_acm\_alb) | ../../common/acm/ | n/a |
 | <a name="module_acm_london"></a> [acm\_london](#module\_acm\_london) | ../../common/acm/ | n/a |
+| <a name="module_acm_origin"></a> [acm\_origin](#module\_acm\_origin) | ../../common/acm | n/a |
 | <a name="module_admin_bearer_token"></a> [admin\_bearer\_token](#module\_admin\_bearer\_token) | ../../common/secret/ | n/a |
 | <a name="module_admin_oauth_id"></a> [admin\_oauth\_id](#module\_admin\_oauth\_id) | ../../common/secret/ | n/a |
 | <a name="module_admin_oauth_secret"></a> [admin\_oauth\_secret](#module\_admin\_oauth\_secret) | ../../common/secret/ | n/a |
@@ -120,8 +120,12 @@
 | [aws_route53_health_check.dns_health_check](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_health_check) | resource |
 | [aws_route53_record.dev_name_servers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.google_site_verification](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.origin_ns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.origin_root](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.origin_wildcard](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.sandbox_name_servers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.staging_name_servers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_zone.origin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
 | [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_policy.api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_policy.backups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |

--- a/environments/production/common/acm.tf
+++ b/environments/production/common/acm.tf
@@ -16,9 +16,9 @@ module "acm_london" {
   hosted_zone_id = data.aws_route53_zone.this.zone_id
 }
 
-module "acm_alb" {
-  source         = "../../common/acm/"
-  domain_name    = var.domain_name
+module "acm_origin" {
+  source         = "../../common/acm"
+  domain_name    = "origin.${var.domain_name}"
   environment    = var.environment
-  hosted_zone_id = data.aws_route53_zone.this.zone_id
+  hosted_zone_id = aws_route53_zone.origin.zone_id
 }

--- a/environments/production/common/alb.tf
+++ b/environments/production/common/alb.tf
@@ -3,6 +3,6 @@ module "alb" {
   alb_name              = "trade-tariff-alb-${var.environment}"
   alb_security_group_id = module.alb-security-group.alb_security_group_id
   public_subnet_ids     = data.terraform_remote_state.base.outputs.public_subnet_ids
-  certificate_arn       = module.acm_alb.validated_certificate_arn
+  certificate_arn       = module.acm_origin.validated_certificate_arn
   vpc_id                = data.terraform_remote_state.base.outputs.vpc_id
 }

--- a/environments/production/common/locals.tf
+++ b/environments/production/common/locals.tf
@@ -1,6 +1,6 @@
 locals {
   account_id         = data.aws_caller_identity.current.account_id
-  origin_domain_name = module.alb.dns_name
+  origin_domain_name = "origin.${var.domain_name}"
   cloudfront_auth    = templatefile("../../common/cloudfront-auth.js.tpl", { base64 = var.backups_basic_auth })
 }
 

--- a/environments/production/common/route53.tf
+++ b/environments/production/common/route53.tf
@@ -49,3 +49,39 @@ resource "aws_route53_record" "google_site_verification" {
   ttl     = 30
   records = ["google-site-verification=cX_NM0eTiZv7isZsA-FsTMpPahArshEhyPNOKUG4Nxk"]
 }
+
+resource "aws_route53_zone" "origin" {
+  name = local.origin_domain_name
+}
+
+resource "aws_route53_record" "origin_ns" {
+  zone_id = data.aws_route53_zone.this.zone_id
+  name    = local.origin_domain_name
+  type    = "NS"
+  ttl     = "30"
+  records = aws_route53_zone.origin.name_servers
+}
+
+resource "aws_route53_record" "origin_root" {
+  zone_id = aws_route53_zone.origin.zone_id
+  name    = local.origin_domain_name
+  type    = "A"
+
+  alias {
+    name                   = module.alb.dns_name
+    zone_id                = module.alb.zone_id
+    evaluate_target_health = true
+  }
+}
+
+resource "aws_route53_record" "origin_wildcard" {
+  zone_id = aws_route53_zone.origin.zone_id
+  name    = "*.${local.origin_domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = module.alb.dns_name
+    zone_id                = module.alb.zone_id
+    evaluate_target_health = true
+  }
+}


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Altered the production origin match the dev/staging one

## Why?

I am doing this because:

- This is required to have a consistent means of terminating the origin which doesn't load the main certificate which is a mismatch with the ALBs host address
