### PR TITLE
HOTT-4365: Alter minimum-required opensearch cluster instance types

### DIFF
--- a/environments/development/common/opensearch.tf
+++ b/environments/development/common/opensearch.tf
@@ -68,7 +68,7 @@ module "opensearch" {
   master_instance_enabled = false
   warm_instance_enabled   = false
   instance_count          = 3
-  instance_type           = "t3.small.search" # small one for dev :)
+  instance_type           = "m5.xlarge.search"
   ebs_volume_size         = 80
 
   create_master_user = true


### PR DESCRIPTION
# Pull Request

![image](https://github.com/trade-tariff/trade-tariff-platform-aws-terraform/assets/8156884/755d94c4-5e12-4794-9949-e329c4a4ef3a)

## What?

I have:

- Altered instance type of opensearch cluster instances in development

## Why?

I am doing this because:

- This will fix an issue with system memory in the development cluster which is breaking our ability to generate opensearch indexes (see https://engine-le.sentry.io/issues/4679200734/?alert_rule_id=12852327&alert_type=issue&environment=development&notification_uuid=12ab3386-a130-4828-bfea-b1049f9c1c55&project=5557005&referrer=slack)
