### PR TITLE
HOTT-2949: Add Read-Only Backend Postgres Connection String

### DIFF
--- a/environments/common/rds/README.md
+++ b/environments/common/rds/README.md
@@ -67,4 +67,5 @@ No modules.
 | <a name="output_db_id"></a> [db\_id](#output\_db\_id) | ID of the RDS instance. |
 | <a name="output_kms_key_arn"></a> [kms\_key\_arn](#output\_kms\_key\_arn) | ARN of the KMS Key created to encrypt database performance insights data. |
 | <a name="output_kms_key_id"></a> [kms\_key\_id](#output\_kms\_key\_id) | Globally unique ID of the KMS Key created to encrypt database performance insights data. |
+| <a name="output_userless_connection_string"></a> [userless\_connection\_string](#output\_userless\_connection\_string) | A userless connection string (just the host and options) to use downstream. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/environments/common/rds/data.tf
+++ b/environments/common/rds/data.tf
@@ -29,5 +29,5 @@ resource "aws_secretsmanager_secret" "this" {
 
 resource "aws_secretsmanager_secret_version" "this" {
   secret_id     = aws_secretsmanager_secret.this.id
-  secret_string = local.db_string
+  secret_string = local.db_admin_string
 }

--- a/environments/common/rds/locals.tf
+++ b/environments/common/rds/locals.tf
@@ -10,8 +10,8 @@ locals {
     var.tags,
   )
 
-  db_engine  = var.engine == "mysql" ? "mysql2" : var.engine
-  db_options = var.engine == "mysql" ? "?reconnect=true&useSSL=true" : ""
-  db_string  = "${local.db_engine}://${local.master_username}:${local.master_password}@${aws_db_instance.this.endpoint}/${var.name}${local.db_options}"
-
+  db_engine        = var.engine == "mysql" ? "mysql2" : var.engine
+  db_options       = var.engine == "mysql" ? "?reconnect=true&useSSL=true" : ""
+  db_admin_string  = "${local.db_engine}://${local.master_username}:${local.master_password}@${aws_db_instance.this.endpoint}/${var.name}${local.db_options}"
+  db_host_and_opts = "${aws_db_instance.this.endpoint}/${var.name}${local.db_options}"
 }

--- a/environments/common/rds/outputs.tf
+++ b/environments/common/rds/outputs.tf
@@ -22,3 +22,8 @@ output "kms_key_id" {
   description = "Globally unique ID of the KMS Key created to encrypt database performance insights data."
   value       = aws_kms_key.this.key_id
 }
+
+output "userless_connection_string" {
+  description = "A userless connection string (just the host and options) to use downstream."
+  value       = local.db_host_and_opts
+}

--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -81,6 +81,7 @@ No outputs.
 | <a name="module_opensearch_packages_bucket"></a> [opensearch\_packages\_bucket](#module\_opensearch\_packages\_bucket) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v3.14.0 |
 | <a name="module_postgres"></a> [postgres](#module\_postgres) | ../../common/rds | n/a |
 | <a name="module_postgres_admin"></a> [postgres\_admin](#module\_postgres\_admin) | ../../common/rds | n/a |
+| <a name="module_read_only_postgres_connection_string"></a> [read\_only\_postgres\_connection\_string](#module\_read\_only\_postgres\_connection\_string) | ../../common/secret/ | n/a |
 | <a name="module_redis"></a> [redis](#module\_redis) | ../../common/elasticache-redis/ | n/a |
 | <a name="module_reporting_cdn"></a> [reporting\_cdn](#module\_reporting\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.4.2 |
 | <a name="module_search_configuration_bucket"></a> [search\_configuration\_bucket](#module\_search\_configuration\_bucket) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v3.14.0 |

--- a/environments/development/common/rds.tf
+++ b/environments/development/common/rds.tf
@@ -25,6 +25,14 @@ module "postgres" {
   ]
 }
 
+module "read_only_postgres_connection_string" {
+  source          = "../../common/secret/"
+  name            = "postgres-read-only"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = "postgres://tariff_read@${module.postgres.userless_connection_string}"
+}
+
 # Admin Postgres
 module "postgres_admin" {
   source = "../../common/rds"

--- a/environments/production/common/README.md
+++ b/environments/production/common/README.md
@@ -59,6 +59,7 @@
 | <a name="module_opensearch_packages_bucket"></a> [opensearch\_packages\_bucket](#module\_opensearch\_packages\_bucket) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v3.14.0 |
 | <a name="module_postgres"></a> [postgres](#module\_postgres) | ../../common/rds | n/a |
 | <a name="module_postgres_admin"></a> [postgres\_admin](#module\_postgres\_admin) | ../../common/rds | n/a |
+| <a name="module_read_only_postgres_connection_string"></a> [read\_only\_postgres\_connection\_string](#module\_read\_only\_postgres\_connection\_string) | ../../common/secret/ | n/a |
 | <a name="module_redis"></a> [redis](#module\_redis) | ../../common/elasticache-redis/ | n/a |
 | <a name="module_reporting_cdn"></a> [reporting\_cdn](#module\_reporting\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.4.2 |
 | <a name="module_search_configuration_bucket"></a> [search\_configuration\_bucket](#module\_search\_configuration\_bucket) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v3.14.0 |

--- a/environments/production/common/rds.tf
+++ b/environments/production/common/rds.tf
@@ -27,6 +27,15 @@ module "postgres" {
   ]
 }
 
+
+module "read_only_postgres_connection_string" {
+  source          = "../../common/secret/"
+  name            = "postgres-read-only"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = "postgres://tariff_read@${module.postgres.userless_connection_string}"
+}
+
 # Admin Postgres
 module "postgres_admin" {
   source = "../../common/rds"

--- a/environments/staging/common/README.md
+++ b/environments/staging/common/README.md
@@ -59,6 +59,7 @@
 | <a name="module_opensearch_packages_bucket"></a> [opensearch\_packages\_bucket](#module\_opensearch\_packages\_bucket) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v3.14.0 |
 | <a name="module_postgres"></a> [postgres](#module\_postgres) | ../../common/rds | n/a |
 | <a name="module_postgres_admin"></a> [postgres\_admin](#module\_postgres\_admin) | ../../common/rds | n/a |
+| <a name="module_read_only_postgres_connection_string"></a> [read\_only\_postgres\_connection\_string](#module\_read\_only\_postgres\_connection\_string) | ../../common/secret/ | n/a |
 | <a name="module_redis"></a> [redis](#module\_redis) | ../../common/elasticache-redis/ | n/a |
 | <a name="module_reporting_cdn"></a> [reporting\_cdn](#module\_reporting\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.4.2 |
 | <a name="module_search_configuration_bucket"></a> [search\_configuration\_bucket](#module\_search\_configuration\_bucket) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v3.14.0 |

--- a/environments/staging/common/rds.tf
+++ b/environments/staging/common/rds.tf
@@ -25,6 +25,15 @@ module "postgres" {
   ]
 }
 
+
+module "read_only_postgres_connection_string" {
+  source          = "../../common/secret/"
+  name            = "postgres-read-only"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = "postgres://tariff_read@${module.postgres.userless_connection_string}"
+}
+
 # Admin Postgres
 module "postgres_admin" {
   source = "../../common/rds"


### PR DESCRIPTION
# Pull Request

[`HOTT-2949`](https://transformuk.atlassian.net/browse/HOTT-2949)

## What?

I have:

- Added a read-only connection string secret for the backend postgres.

## Why?

I am doing this because:

- We want to have a read-only connection for everything except the admin API.