### PR TITLE
BAU: Don't Cache /xi/api/v2/green_lanes/*

### DIFF
--- a/environments/development/common/cloudfront.tf
+++ b/environments/development/common/cloudfront.tf
@@ -65,19 +65,19 @@ module "cdn" {
       ]
     }
 
-    api = {
+    green_lanes = {
       target_origin_id       = "frontend"
       viewer_protocol_policy = "redirect-to-https"
 
-      path_pattern = "/api/v2/*"
+      path_pattern = "/xi/api/v2/green_lanes/*"
 
-      cache_policy_id            = aws_cloudfront_cache_policy.cache_api.id
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
 
-      min_ttl     = 1
-      default_ttl = 1800
-      max_ttl     = 1800
+      min_ttl     = 0
+      default_ttl = 0
+      max_ttl     = 0
 
       compress = true
 
@@ -97,19 +97,19 @@ module "cdn" {
       ]
     }
 
-    green_lanes = {
+    api = {
       target_origin_id       = "frontend"
       viewer_protocol_policy = "redirect-to-https"
 
-      path_pattern = "/xi/api/v2/green_lanes/*"
+      path_pattern = "/api/v2/*"
 
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      cache_policy_id            = aws_cloudfront_cache_policy.cache_api.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
 
-      min_ttl     = 0
-      default_ttl = 0
-      max_ttl     = 0
+      min_ttl     = 1
+      default_ttl = 1800
+      max_ttl     = 1800
 
       compress = true
 

--- a/environments/development/common/cloudfront.tf
+++ b/environments/development/common/cloudfront.tf
@@ -96,6 +96,38 @@ module "cdn" {
         "HEAD"
       ]
     }
+
+    green_lanes = {
+      target_origin_id       = "frontend"
+      viewer_protocol_policy = "redirect-to-https"
+
+      path_pattern = "/xi/api/v2/green_lanes/*"
+
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+
+      min_ttl     = 0
+      default_ttl = 0
+      max_ttl     = 0
+
+      compress = true
+
+      allowed_methods = [
+        "GET",
+        "HEAD",
+        "OPTIONS",
+        "PUT",
+        "POST",
+        "PATCH",
+        "DELETE"
+      ]
+
+      cached_methods = [
+        "GET",
+        "HEAD"
+      ]
+    }
   }
 
   viewer_certificate = {

--- a/environments/production/common/cloudfront.tf
+++ b/environments/production/common/cloudfront.tf
@@ -71,19 +71,19 @@ module "cdn" {
       ]
     }
 
-    api = {
+    green_lanes = {
       target_origin_id       = "frontend"
       viewer_protocol_policy = "redirect-to-https"
 
-      path_pattern = "/api/v2/*"
+      path_pattern = "/xi/api/v2/green_lanes/*"
 
-      cache_policy_id            = aws_cloudfront_cache_policy.cache_api.id
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
 
-      min_ttl     = 1
-      default_ttl = 1800
-      max_ttl     = 1800
+      min_ttl     = 0
+      default_ttl = 0
+      max_ttl     = 0
 
       compress = true
 
@@ -103,19 +103,19 @@ module "cdn" {
       ]
     }
 
-    green_lanes = {
+    api = {
       target_origin_id       = "frontend"
       viewer_protocol_policy = "redirect-to-https"
 
-      path_pattern = "/xi/api/v2/green_lanes/*"
+      path_pattern = "/api/v2/*"
 
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      cache_policy_id            = aws_cloudfront_cache_policy.cache_api.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
 
-      min_ttl     = 0
-      default_ttl = 0
-      max_ttl     = 0
+      min_ttl     = 1
+      default_ttl = 1800
+      max_ttl     = 1800
 
       compress = true
 

--- a/environments/production/common/cloudfront.tf
+++ b/environments/production/common/cloudfront.tf
@@ -102,6 +102,38 @@ module "cdn" {
         "HEAD"
       ]
     }
+
+    green_lanes = {
+      target_origin_id       = "frontend"
+      viewer_protocol_policy = "redirect-to-https"
+
+      path_pattern = "/xi/api/v2/green_lanes/*"
+
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+
+      min_ttl     = 0
+      default_ttl = 0
+      max_ttl     = 0
+
+      compress = true
+
+      allowed_methods = [
+        "GET",
+        "HEAD",
+        "OPTIONS",
+        "PUT",
+        "POST",
+        "PATCH",
+        "DELETE"
+      ]
+
+      cached_methods = [
+        "GET",
+        "HEAD"
+      ]
+    }
   }
 
   viewer_certificate = {

--- a/environments/staging/common/cloudfront.tf
+++ b/environments/staging/common/cloudfront.tf
@@ -65,19 +65,19 @@ module "cdn" {
       ]
     }
 
-    api = {
+    green_lanes = {
       target_origin_id       = "frontend"
       viewer_protocol_policy = "redirect-to-https"
 
-      path_pattern = "/api/v2/*"
+      path_pattern = "/xi/api/v2/green_lanes/*"
 
-      cache_policy_id            = aws_cloudfront_cache_policy.cache_api.id
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
 
-      min_ttl     = 1
-      default_ttl = 1800
-      max_ttl     = 1800
+      min_ttl     = 0
+      default_ttl = 0
+      max_ttl     = 0
 
       compress = true
 
@@ -97,19 +97,19 @@ module "cdn" {
       ]
     }
 
-    green_lanes = {
+    api = {
       target_origin_id       = "frontend"
       viewer_protocol_policy = "redirect-to-https"
 
-      path_pattern = "/xi/api/v2/green_lanes/*"
+      path_pattern = "/api/v2/*"
 
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      cache_policy_id            = aws_cloudfront_cache_policy.cache_api.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
 
-      min_ttl     = 0
-      default_ttl = 0
-      max_ttl     = 0
+      min_ttl     = 1
+      default_ttl = 1800
+      max_ttl     = 1800
 
       compress = true
 

--- a/environments/staging/common/cloudfront.tf
+++ b/environments/staging/common/cloudfront.tf
@@ -96,6 +96,38 @@ module "cdn" {
         "HEAD"
       ]
     }
+
+    green_lanes = {
+      target_origin_id       = "frontend"
+      viewer_protocol_policy = "redirect-to-https"
+
+      path_pattern = "/xi/api/v2/green_lanes/*"
+
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+
+      min_ttl     = 0
+      default_ttl = 0
+      max_ttl     = 0
+
+      compress = true
+
+      allowed_methods = [
+        "GET",
+        "HEAD",
+        "OPTIONS",
+        "PUT",
+        "POST",
+        "PATCH",
+        "DELETE"
+      ]
+
+      cached_methods = [
+        "GET",
+        "HEAD"
+      ]
+    }
   }
 
   viewer_certificate = {


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Added a rule to not cache `/xi/api/v2/green_lanes/*`

## Why?

I am doing this because:

- This section of the API should not be cached as it's not publically accessible.