### PR TITLE
HOTT-4479: CI changes to enable green lanes debug page

### DIFF
--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -76,6 +76,7 @@ No outputs.
 | <a name="module_cloudwatch-logs-exporter"></a> [cloudwatch-logs-exporter](#module\_cloudwatch-logs-exporter) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudwatch_log_exporter | aws/cloudwatch_log_exporter-v1.0.0 |
 | <a name="module_duty_calculator_secret_key_base"></a> [duty\_calculator\_secret\_key\_base](#module\_duty\_calculator\_secret\_key\_base) | ../../common/secret/ | n/a |
 | <a name="module_duty_calculator_sentry_dsn"></a> [duty\_calculator\_sentry\_dsn](#module\_duty\_calculator\_sentry\_dsn) | ../../common/secret/ | n/a |
+| <a name="module_frontend_green_lanes_api_token"></a> [frontend\_green\_lanes\_api\_token](#module\_frontend\_green\_lanes\_api\_token) | ../../common/secret/ | n/a |
 | <a name="module_frontend_secret_key_base"></a> [frontend\_secret\_key\_base](#module\_frontend\_secret\_key\_base) | ../../common/secret/ | n/a |
 | <a name="module_frontend_sentry_dsn"></a> [frontend\_sentry\_dsn](#module\_frontend\_sentry\_dsn) | ../../common/secret/ | n/a |
 | <a name="module_logs"></a> [logs](#module\_logs) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v3.14.0 |
@@ -208,6 +209,7 @@ No outputs.
 | <a name="input_tariff_backend_xi_sync_host"></a> [tariff\_backend\_xi\_sync\_host](#input\_tariff\_backend\_xi\_sync\_host) | Value of Tariff Sync host. | `string` | n/a | yes |
 | <a name="input_tariff_backend_xi_sync_password"></a> [tariff\_backend\_xi\_sync\_password](#input\_tariff\_backend\_xi\_sync\_password) | Value of Tariff Sync password. | `string` | n/a | yes |
 | <a name="input_tariff_backend_xi_sync_username"></a> [tariff\_backend\_xi\_sync\_username](#input\_tariff\_backend\_xi\_sync\_username) | Value of Tariff Sync username. | `string` | n/a | yes |
+| <a name="input_tariff_frontend_green_lanes_api_token"></a> [tariff\_frontend\_green\_lanes\_api\_token](#input\_tariff\_frontend\_green\_lanes\_api\_token) | Value of GREEN\_LANES\_API\_TOKEN for the tariff frontend access green lanes api. | `string` | n/a | yes |
 | <a name="input_waf_rpm_limit"></a> [waf\_rpm\_limit](#input\_waf\_rpm\_limit) | Request per minute limit for the WAF. | `number` | `500` | no |
 
 ## Outputs

--- a/environments/development/common/secrets.tf
+++ b/environments/development/common/secrets.tf
@@ -110,6 +110,14 @@ module "backend_green_lanes_api_tokens" {
   secret_string   = var.tariff_backend_green_lanes_api_tokens
 }
 
+module "frontend_green_lanes_api_token" {
+  source          = "../../common/secret/"
+  name            = "frontend-green-lanes-api-token"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.tariff_frontend_green_lanes_api_token
+}
+
 module "backend_sync_email" {
   source          = "../../common/secret/"
   name            = "backend-sync-email"

--- a/environments/development/common/variables.tf
+++ b/environments/development/common/variables.tf
@@ -124,6 +124,12 @@ variable "tariff_backend_green_lanes_api_tokens" {
   sensitive   = true
 }
 
+variable "tariff_frontend_green_lanes_api_token" {
+  description = "Value of GREEN_LANES_API_TOKEN for the tariff frontend access green lanes api."
+  type        = string
+  sensitive   = true
+}
+
 variable "tariff_backend_sync_email" {
   description = "Value of Tariff Sync email."
   type        = string

--- a/environments/production/common/README.md
+++ b/environments/production/common/README.md
@@ -54,6 +54,7 @@
 | <a name="module_duty_calculator_secret_key_base"></a> [duty\_calculator\_secret\_key\_base](#module\_duty\_calculator\_secret\_key\_base) | ../../common/secret/ | n/a |
 | <a name="module_duty_calculator_sentry_dsn"></a> [duty\_calculator\_sentry\_dsn](#module\_duty\_calculator\_sentry\_dsn) | ../../common/secret/ | n/a |
 | <a name="module_ecr"></a> [ecr](#module\_ecr) | ../../common/ecr/ | n/a |
+| <a name="module_frontend_green_lanes_api_token"></a> [frontend\_green\_lanes\_api\_token](#module\_frontend\_green\_lanes\_api\_token) | ../../common/secret/ | n/a |
 | <a name="module_frontend_secret_key_base"></a> [frontend\_secret\_key\_base](#module\_frontend\_secret\_key\_base) | ../../common/secret/ | n/a |
 | <a name="module_frontend_sentry_dsn"></a> [frontend\_sentry\_dsn](#module\_frontend\_sentry\_dsn) | ../../common/secret/ | n/a |
 | <a name="module_logs"></a> [logs](#module\_logs) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v3.14.0 |
@@ -198,6 +199,7 @@
 | <a name="input_tariff_backend_xi_sync_host"></a> [tariff\_backend\_xi\_sync\_host](#input\_tariff\_backend\_xi\_sync\_host) | Value of Tariff Sync host. | `string` | n/a | yes |
 | <a name="input_tariff_backend_xi_sync_password"></a> [tariff\_backend\_xi\_sync\_password](#input\_tariff\_backend\_xi\_sync\_password) | Value of Tariff Sync password. | `string` | n/a | yes |
 | <a name="input_tariff_backend_xi_sync_username"></a> [tariff\_backend\_xi\_sync\_username](#input\_tariff\_backend\_xi\_sync\_username) | Value of Tariff Sync username. | `string` | n/a | yes |
+| <a name="input_tariff_frontend_green_lanes_api_token"></a> [tariff\_frontend\_green\_lanes\_api\_token](#input\_tariff\_frontend\_green\_lanes\_api\_token) | Value of GREEN\_LANES\_API\_TOKEN for the tariff frontend access green lanes api. | `string` | n/a | yes |
 | <a name="input_waf_rpm_limit"></a> [waf\_rpm\_limit](#input\_waf\_rpm\_limit) | Request per minute limit for the WAF. | `number` | `5000` | no |
 
 ## Outputs

--- a/environments/production/common/secrets.tf
+++ b/environments/production/common/secrets.tf
@@ -110,6 +110,14 @@ module "backend_green_lanes_api_tokens" {
   secret_string   = var.tariff_backend_green_lanes_api_tokens
 }
 
+module "frontend_green_lanes_api_token" {
+  source          = "../../common/secret/"
+  name            = "frontend-green-lanes-api-token"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.tariff_frontend_green_lanes_api_token
+}
+
 module "backend_sync_email" {
   source          = "../../common/secret/"
   name            = "backend-sync-email"

--- a/environments/production/common/variables.tf
+++ b/environments/production/common/variables.tf
@@ -118,6 +118,12 @@ variable "tariff_backend_green_lanes_api_tokens" {
   sensitive   = true
 }
 
+variable "tariff_frontend_green_lanes_api_token" {
+  description = "Value of GREEN_LANES_API_TOKEN for the tariff frontend access green lanes api."
+  type        = string
+  sensitive   = true
+}
+
 variable "tariff_backend_sync_email" {
   description = "Value of Tariff Sync email."
   type        = string

--- a/environments/staging/common/README.md
+++ b/environments/staging/common/README.md
@@ -54,6 +54,7 @@
 | <a name="module_cloudwatch-logs-exporter"></a> [cloudwatch-logs-exporter](#module\_cloudwatch-logs-exporter) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudwatch_log_exporter | aws/cloudwatch_log_exporter-v1.0.0 |
 | <a name="module_duty_calculator_secret_key_base"></a> [duty\_calculator\_secret\_key\_base](#module\_duty\_calculator\_secret\_key\_base) | ../../common/secret/ | n/a |
 | <a name="module_duty_calculator_sentry_dsn"></a> [duty\_calculator\_sentry\_dsn](#module\_duty\_calculator\_sentry\_dsn) | ../../common/secret/ | n/a |
+| <a name="module_frontend_green_lanes_api_token"></a> [frontend\_green\_lanes\_api\_token](#module\_frontend\_green\_lanes\_api\_token) | ../../common/secret/ | n/a |
 | <a name="module_frontend_secret_key_base"></a> [frontend\_secret\_key\_base](#module\_frontend\_secret\_key\_base) | ../../common/secret/ | n/a |
 | <a name="module_frontend_sentry_dsn"></a> [frontend\_sentry\_dsn](#module\_frontend\_sentry\_dsn) | ../../common/secret/ | n/a |
 | <a name="module_logs"></a> [logs](#module\_logs) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v3.14.0 |
@@ -188,6 +189,7 @@
 | <a name="input_tariff_backend_xi_sync_host"></a> [tariff\_backend\_xi\_sync\_host](#input\_tariff\_backend\_xi\_sync\_host) | Value of Tariff Sync host. | `string` | n/a | yes |
 | <a name="input_tariff_backend_xi_sync_password"></a> [tariff\_backend\_xi\_sync\_password](#input\_tariff\_backend\_xi\_sync\_password) | Value of Tariff Sync password. | `string` | n/a | yes |
 | <a name="input_tariff_backend_xi_sync_username"></a> [tariff\_backend\_xi\_sync\_username](#input\_tariff\_backend\_xi\_sync\_username) | Value of Tariff Sync username. | `string` | n/a | yes |
+| <a name="input_tariff_frontend_green_lanes_api_token"></a> [tariff\_frontend\_green\_lanes\_api\_token](#input\_tariff\_frontend\_green\_lanes\_api\_token) | Value of GREEN\_LANES\_API\_TOKEN for the tariff frontend access green lanes api. | `string` | n/a | yes |
 | <a name="input_waf_rpm_limit"></a> [waf\_rpm\_limit](#input\_waf\_rpm\_limit) | Request per minute limit for the WAF. | `number` | `500` | no |
 
 ## Outputs

--- a/environments/staging/common/secrets.tf
+++ b/environments/staging/common/secrets.tf
@@ -110,6 +110,14 @@ module "backend_green_lanes_api_tokens" {
   secret_string   = var.tariff_backend_green_lanes_api_tokens
 }
 
+module "frontend_green_lanes_api_token" {
+  source          = "../../common/secret/"
+  name            = "frontend-green-lanes-api-token"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.tariff_frontend_green_lanes_api_token
+}
+
 module "backend_sync_email" {
   source          = "../../common/secret/"
   name            = "backend-sync-email"

--- a/environments/staging/common/variables.tf
+++ b/environments/staging/common/variables.tf
@@ -130,6 +130,12 @@ variable "tariff_backend_green_lanes_api_tokens" {
   sensitive   = true
 }
 
+variable "tariff_frontend_green_lanes_api_token" {
+  description = "Value of GREEN_LANES_API_TOKEN for the tariff frontend access green lanes api."
+  type        = string
+  sensitive   = true
+}
+
 variable "tariff_backend_sync_email" {
   description = "Value of Tariff Sync email."
   type        = string


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Added a secret for trade-tariff-front to access green lanes api


## Why?

I am doing this because:

- The new green lanes ui page need to send api requests to backend green lanes api, which is secured by auth token
-
-
