### PR TITLE
GL-133 Allow access control headers from the browser

### DIFF
--- a/environments/development/common/cloudfront-policy.tf
+++ b/environments/development/common/cloudfront-policy.tf
@@ -74,10 +74,10 @@ resource "aws_cloudfront_response_headers_policy" "this" {
     access_control_max_age_sec = 7200
 
     access_control_allow_headers {
-      items = ["*"]
+      items = ["Authorization"]
     }
 
-    access_control_allow_credentials = false
+    access_control_allow_credentials = true
 
     origin_override = false
   }

--- a/environments/staging/common/cloudfront-policy.tf
+++ b/environments/staging/common/cloudfront-policy.tf
@@ -74,10 +74,10 @@ resource "aws_cloudfront_response_headers_policy" "this" {
     access_control_max_age_sec = 7200
 
     access_control_allow_headers {
-      items = ["*"]
+      items = ["Authorization"]
     }
 
-    access_control_allow_credentials = false
+    access_control_allow_credentials = true
 
     origin_override = false
   }


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Altered the CDN config for Dev and Staging to allow Authenticated CORS API requests

## Why?

I am doing this because:

- It will allow the API Docs api client to access the api's from a browser
- I'm not changing production at this time because we don't require access to the production version of the API yet and it will be good to give chance to ensure the allow listing of headers doesn't have any unintended consequences
