### PR TITLE
FPO-128: Adds ECR repo for the fpo hub

### DIFF
--- a/environments/common/ecr/locals.tf
+++ b/environments/common/ecr/locals.tf
@@ -15,6 +15,12 @@ locals {
     "fpo-search" = {
       lifecycle_policy = false
     },
+    "fpo-developer-hub-backend" = {
+      lifecycle_policy = true
+    }
+    "fpo-developer-hub-frontend" = {
+      lifecycle_policy = true
+    }
     "frontend" = {
       lifecycle_policy = true
     },


### PR DESCRIPTION
# Pull Request

https://transformuk.atlassian.net/browse/FPO-128

## What?

I have:

- Added ECR repo in production for the fpo hub

## Why?

I am doing this because:

- This is needed as part of dockerising the FPO hub application
