### PR TITLE
FPO-133: Adds ALB support for hub

### DIFF
--- a/environments/common/application-load-balancer/alb.tf
+++ b/environments/common/application-load-balancer/alb.tf
@@ -73,6 +73,8 @@ resource "aws_lb_listener_rule" "this" {
   for_each     = local.services
   listener_arn = aws_lb_listener.trade_tariff_listeners.arn
 
+  priority = each.value.priority
+
   action {
     type             = "forward"
     target_group_arn = aws_lb_target_group.trade_tariff_target_groups[each.key].arn

--- a/environments/common/application-load-balancer/locals.tf
+++ b/environments/common/application-load-balancer/locals.tf
@@ -10,6 +10,18 @@ locals {
       healthcheck_path = "/healthcheck/live"
     }
 
+    hub_backend = {
+      host             = ["hub.*"]
+      paths            = ["/api/healthcheck"]
+      healthcheck_path = "/api/healthcheckz"
+    }
+
+    hub_frontend = {
+      host             = ["hub.*"]
+      paths            = ["/*"]
+      healthcheck_path = "/healthcheckz"
+    }
+
     backend_uk = {
       paths            = ["/uk/api/beta/*"]
       healthcheck_path = "/healthcheckz"

--- a/environments/common/application-load-balancer/locals.tf
+++ b/environments/common/application-load-balancer/locals.tf
@@ -3,48 +3,57 @@ locals {
     admin = {
       host             = ["admin.*"]
       healthcheck_path = "/healthcheckz"
+      priority         = 11
     }
 
     signon = {
       host             = ["signon.*"]
       healthcheck_path = "/healthcheck/live"
+      priority         = 12
     }
 
     hub_backend = {
       host             = ["hub.*"]
       paths            = ["/api/healthcheck"]
       healthcheck_path = "/api/healthcheckz"
+      priority         = 13
     }
 
     hub_frontend = {
       host             = ["hub.*"]
       paths            = ["/*"]
       healthcheck_path = "/healthcheckz"
+      priority         = 14
     }
 
     backend_uk = {
       paths            = ["/uk/api/beta/*"]
       healthcheck_path = "/healthcheckz"
+      priority         = 15
     }
 
     backend_xi = {
       paths            = ["/xi/api/beta/*"]
       healthcheck_path = "/healthcheckz"
+      priority         = 16
     }
 
     duty_calculator = {
       paths            = ["/duty-calculator/*"]
       healthcheck_path = "/healthcheckz"
+      priority         = 17
     }
 
     search_query_parser = {
       paths            = ["/api/search/*"]
       healthcheck_path = "/healthcheckz"
+      priority         = 18
     }
 
     frontend = {
       paths            = ["/*"]
       healthcheck_path = "/healthcheckz"
+      priority         = 99 # Most generic rule for frontend should match last
     }
   }
 }

--- a/environments/development/common/cloudfront.tf
+++ b/environments/development/common/cloudfront.tf
@@ -1,7 +1,13 @@
 module "cdn" {
   source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront?ref=aws/cloudfront-v1.4.2"
 
-  aliases         = [var.domain_name, "signon.${var.domain_name}", "admin.${var.domain_name}"]
+  aliases = [
+    var.domain_name,
+    "signon.${var.domain_name}",
+    "admin.${var.domain_name}",
+    "hub.${var.domain_name}"
+  ]
+
   create_alias    = true
   route53_zone_id = data.aws_route53_zone.this.id
   comment         = "${title(var.environment)} CDN"

--- a/environments/production/common/cloudfront.tf
+++ b/environments/production/common/cloudfront.tf
@@ -6,6 +6,7 @@ module "cdn" {
     "signon.${var.domain_name}",
     "admin.${var.domain_name}",
     "www.${var.domain_name}",
+    "hub.${var.domain_name}",
   ]
 
   create_alias    = true

--- a/environments/staging/common/cloudfront.tf
+++ b/environments/staging/common/cloudfront.tf
@@ -1,7 +1,13 @@
 module "cdn" {
   source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront?ref=aws/cloudfront-v1.4.2"
 
-  aliases         = [var.domain_name, "signon.${var.domain_name}", "admin.${var.domain_name}"]
+  aliases = [
+    var.domain_name,
+    "signon.${var.domain_name}",
+    "admin.${var.domain_name}",
+    "hub.${var.domain_name}",
+  ]
+
   create_alias    = true
   route53_zone_id = data.aws_route53_zone.this.id
   comment         = "${title(var.environment)} CDN"


### PR DESCRIPTION
# Pull Request

Ran the infrastructure smoke tests to validate changing the rules

![2024-03-18-154222_563x523_scrot](https://github.com/trade-tariff/trade-tariff-platform-aws-terraform/assets/8156884/8c9275eb-f1d3-4f8b-94f0-aa50b5248d6c)

## What?

I have:

- Added CDN alias
- Added ALB listener rule to match the backend and frontend hub routes

## Why?

I am doing this because:

- This is required so we can have release notes for the backend hub and also to expose the frontend hub publicly to our hub developers
