### PR TITLE
FPO-133: Adds locks and SSM params for FPO developer hub

### DIFF
--- a/environments/development/common/locals.tf
+++ b/environments/development/common/locals.tf
@@ -7,6 +7,8 @@ locals {
     "backend",
     "database-backups",
     "duty-calculator",
+    "fpo-developer-hub-backend",
+    "fpo-developer-hub-frontend",
     "fpo-search",
     "frontend",
     "search-query-parser",

--- a/environments/production/applications/locals.tf
+++ b/environments/production/applications/locals.tf
@@ -5,6 +5,8 @@ locals {
     "backend",
     "database-backups",
     "duty-calculator",
+    "fpo-developer-hub-backend",
+    "fpo-developer-hub-frontend",
     "fpo-search",
     "frontend",
     "search-query-parser",

--- a/environments/staging/applications/locals.tf
+++ b/environments/staging/applications/locals.tf
@@ -4,6 +4,8 @@ locals {
     "admin",
     "backend",
     "duty-calculator",
+    "fpo-developer-hub-backend",
+    "fpo-developer-hub-frontend",
     "frontend",
     "search-query-parser",
     "signon"

--- a/environments/staging/common/locals.tf
+++ b/environments/staging/common/locals.tf
@@ -7,6 +7,8 @@ locals {
     "backend",
     "database-backups",
     "duty-calculator",
+    "fpo-developer-hub-backend",
+    "fpo-developer-hub-frontend",
     "fpo-search",
     "frontend",
     "search-query-parser",


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Adds SSM parameter for ECR url in development
- Adds SSM parameter for ECR url in staging
- Adds dynamodb locks for staging hub apps
- Adds dynamodb locks for production hub apps

## Why?

I am doing this because:

- We need lock tables for staging and production
- We need ECR SSM parameters for development and staging
