### PR TITLE
FPO-132: Add dynamodb tables for FPO Developer Hub

### DIFF
--- a/environments/development/applications/README.md
+++ b/environments/development/applications/README.md
@@ -25,6 +25,7 @@
 
 | Name | Type |
 |------|------|
+| [aws_dynamodb_table.customer_api_keys](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
 | [aws_dynamodb_table.lock](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
 | [aws_kms_key.log_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_service_discovery_private_dns_namespace.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/service_discovery_private_dns_namespace) | resource |

--- a/environments/development/applications/dynamodb.tf
+++ b/environments/development/applications/dynamodb.tf
@@ -10,3 +10,45 @@ resource "aws_dynamodb_table" "lock" {
     type = "S"
   }
 }
+
+resource "aws_dynamodb_table" "customer_api_keys" {
+  name         = "CustomerApiKeys"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "CustomerApiKeyId" # Unique identifier for the API key
+  range_key    = "CustomerId"       # Localized in dynamodb for each SCP customer that logs in
+
+  attribute {
+    name = "CustomerApiKeyId"
+    type = "S"
+  }
+
+  attribute {
+    name = "CustomerId"
+    type = "S"
+  }
+
+  attribute {
+    name = "Secret"
+    type = "S"
+  }
+
+  attribute {
+    name = "Description"
+    type = "S"
+  }
+
+  attribute {
+    name = "Enabled"
+    type = "BOOL"
+  }
+
+  attribute {
+    name = "CreatedAt"
+    type = "S"
+  }
+
+  attribute {
+    name = "UpdatedAt"
+    type = "S"
+  }
+}

--- a/environments/development/applications/dynamodb.tf
+++ b/environments/development/applications/dynamodb.tf
@@ -51,4 +51,8 @@ resource "aws_dynamodb_table" "customer_api_keys" {
     name = "UpdatedAt"
     type = "S"
   }
+
+  tags = {
+    customer = "fpo"
+  }
 }

--- a/environments/development/applications/dynamodb.tf
+++ b/environments/development/applications/dynamodb.tf
@@ -39,7 +39,7 @@ resource "aws_dynamodb_table" "customer_api_keys" {
 
   attribute {
     name = "Enabled"
-    type = "BOOL"
+    type = "B"
   }
 
   attribute {

--- a/environments/development/applications/dynamodb.tf
+++ b/environments/development/applications/dynamodb.tf
@@ -27,31 +27,6 @@ resource "aws_dynamodb_table" "customer_api_keys" {
     type = "S"
   }
 
-  attribute {
-    name = "Secret"
-    type = "S"
-  }
-
-  attribute {
-    name = "Description"
-    type = "S"
-  }
-
-  attribute {
-    name = "Enabled"
-    type = "B"
-  }
-
-  attribute {
-    name = "CreatedAt"
-    type = "S"
-  }
-
-  attribute {
-    name = "UpdatedAt"
-    type = "S"
-  }
-
   tags = {
     customer = "fpo"
   }

--- a/environments/production/applications/README.md
+++ b/environments/production/applications/README.md
@@ -25,6 +25,7 @@
 
 | Name | Type |
 |------|------|
+| [aws_dynamodb_table.customer_api_keys](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
 | [aws_dynamodb_table.lock](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
 | [aws_kms_key.log_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_service_discovery_private_dns_namespace.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/service_discovery_private_dns_namespace) | resource |

--- a/environments/production/applications/dynamodb.tf
+++ b/environments/production/applications/dynamodb.tf
@@ -10,3 +10,49 @@ resource "aws_dynamodb_table" "lock" {
     type = "S"
   }
 }
+
+resource "aws_dynamodb_table" "customer_api_keys" {
+  name         = "CustomerApiKeys"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "CustomerApiKeyId" # Unique identifier for the API key
+  range_key    = "CustomerId"       # Localized in dynamodb for each SCP customer that logs in
+
+  attribute {
+    name = "CustomerApiKeyId"
+    type = "S"
+  }
+
+  attribute {
+    name = "CustomerId"
+    type = "S"
+  }
+
+  attribute {
+    name = "Secret"
+    type = "S"
+  }
+
+  attribute {
+    name = "Description"
+    type = "S"
+  }
+
+  attribute {
+    name = "Enabled"
+    type = "BOOL"
+  }
+
+  attribute {
+    name = "CreatedAt"
+    type = "S"
+  }
+
+  attribute {
+    name = "UpdatedAt"
+    type = "S"
+  }
+
+  tags = {
+    customer = "fpo"
+  }
+}

--- a/environments/production/applications/dynamodb.tf
+++ b/environments/production/applications/dynamodb.tf
@@ -39,7 +39,7 @@ resource "aws_dynamodb_table" "customer_api_keys" {
 
   attribute {
     name = "Enabled"
-    type = "BOOL"
+    type = "B"
   }
 
   attribute {

--- a/environments/production/applications/dynamodb.tf
+++ b/environments/production/applications/dynamodb.tf
@@ -27,31 +27,6 @@ resource "aws_dynamodb_table" "customer_api_keys" {
     type = "S"
   }
 
-  attribute {
-    name = "Secret"
-    type = "S"
-  }
-
-  attribute {
-    name = "Description"
-    type = "S"
-  }
-
-  attribute {
-    name = "Enabled"
-    type = "B"
-  }
-
-  attribute {
-    name = "CreatedAt"
-    type = "S"
-  }
-
-  attribute {
-    name = "UpdatedAt"
-    type = "S"
-  }
-
   tags = {
     customer = "fpo"
   }

--- a/environments/staging/applications/README.md
+++ b/environments/staging/applications/README.md
@@ -25,6 +25,7 @@
 
 | Name | Type |
 |------|------|
+| [aws_dynamodb_table.customer_api_keys](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
 | [aws_dynamodb_table.lock](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
 | [aws_kms_key.log_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_service_discovery_private_dns_namespace.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/service_discovery_private_dns_namespace) | resource |

--- a/environments/staging/applications/dynamodb.tf
+++ b/environments/staging/applications/dynamodb.tf
@@ -10,3 +10,45 @@ resource "aws_dynamodb_table" "lock" {
     type = "S"
   }
 }
+
+resource "aws_dynamodb_table" "customer_api_keys" {
+  name         = "CustomerApiKeys"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "CustomerApiKeyId" # Unique identifier for the API key
+  range_key    = "CustomerId"       # Localized in dynamodb for each SCP customer that logs in
+
+  attribute {
+    name = "CustomerApiKeyId"
+    type = "S"
+  }
+
+  attribute {
+    name = "CustomerId"
+    type = "S"
+  }
+
+  attribute {
+    name = "Secret"
+    type = "S"
+  }
+
+  attribute {
+    name = "Description"
+    type = "S"
+  }
+
+  attribute {
+    name = "Enabled"
+    type = "BOOL"
+  }
+
+  attribute {
+    name = "CreatedAt"
+    type = "S"
+  }
+
+  attribute {
+    name = "UpdatedAt"
+    type = "S"
+  }
+}

--- a/environments/staging/applications/dynamodb.tf
+++ b/environments/staging/applications/dynamodb.tf
@@ -51,4 +51,8 @@ resource "aws_dynamodb_table" "customer_api_keys" {
     name = "UpdatedAt"
     type = "S"
   }
+
+  tags = {
+    customer = "fpo"
+  }
 }

--- a/environments/staging/applications/dynamodb.tf
+++ b/environments/staging/applications/dynamodb.tf
@@ -39,7 +39,7 @@ resource "aws_dynamodb_table" "customer_api_keys" {
 
   attribute {
     name = "Enabled"
-    type = "BOOL"
+    type = "B"
   }
 
   attribute {

--- a/environments/staging/applications/dynamodb.tf
+++ b/environments/staging/applications/dynamodb.tf
@@ -27,31 +27,6 @@ resource "aws_dynamodb_table" "customer_api_keys" {
     type = "S"
   }
 
-  attribute {
-    name = "Secret"
-    type = "S"
-  }
-
-  attribute {
-    name = "Description"
-    type = "S"
-  }
-
-  attribute {
-    name = "Enabled"
-    type = "B"
-  }
-
-  attribute {
-    name = "CreatedAt"
-    type = "S"
-  }
-
-  attribute {
-    name = "UpdatedAt"
-    type = "S"
-  }
-
   tags = {
     customer = "fpo"
   }


### PR DESCRIPTION
## Jira Link

https://transformuk.atlassian.net/browse/FPO-132

## What?

I have:

- Added dynamo db table for CustomerApiKeys in development
- Added dynamo db table for CustomerApiKeys in staging
- Added dynamo db table for CustomerApiKeys in production

## Why?

I am doing this because:

- These are needed for the FPO developer hub in order to manage keys for accessing the inference apis
- We've optimised for the queries that we're going to do by using the CustomerId (e.g. yodel) as the range column so that when we filter by the keys that belong to a specific customer they are colocated and we don't have to hit multiple dynamodb nodes.
- We've added a tag to make billing easier
- We've opted for pay as you go billing since we do not anticipate the need for lots and lots of updates to this table
