### PR TITLE
BAU: Rename CustomerId to FpoId to avoid confusion with ApiGateway concepts

### DIFF
--- a/environments/development/applications/dynamodb.tf
+++ b/environments/development/applications/dynamodb.tf
@@ -15,7 +15,7 @@ resource "aws_dynamodb_table" "customer_api_keys" {
   name         = "CustomerApiKeys"
   billing_mode = "PAY_PER_REQUEST"
   hash_key     = "CustomerApiKeyId" # Unique identifier for the API key
-  range_key    = "CustomerId"       # Localized in dynamodb for each SCP customer that logs in
+  range_key    = "FpoId"            # Localized in dynamodb for each SCP customer that logs in
 
   attribute {
     name = "CustomerApiKeyId"
@@ -23,7 +23,7 @@ resource "aws_dynamodb_table" "customer_api_keys" {
   }
 
   attribute {
-    name = "CustomerId"
+    name = "FpoId"
     type = "S"
   }
 

--- a/environments/production/applications/dynamodb.tf
+++ b/environments/production/applications/dynamodb.tf
@@ -15,7 +15,7 @@ resource "aws_dynamodb_table" "customer_api_keys" {
   name         = "CustomerApiKeys"
   billing_mode = "PAY_PER_REQUEST"
   hash_key     = "CustomerApiKeyId" # Unique identifier for the API key
-  range_key    = "CustomerId"       # Localized in dynamodb for each SCP customer that logs in
+  range_key    = "FpoId"            # Localized in dynamodb for each SCP customer that logs in
 
   attribute {
     name = "CustomerApiKeyId"
@@ -23,7 +23,7 @@ resource "aws_dynamodb_table" "customer_api_keys" {
   }
 
   attribute {
-    name = "CustomerId"
+    name = "FpoId"
     type = "S"
   }
 

--- a/environments/staging/applications/dynamodb.tf
+++ b/environments/staging/applications/dynamodb.tf
@@ -15,7 +15,7 @@ resource "aws_dynamodb_table" "customer_api_keys" {
   name         = "CustomerApiKeys"
   billing_mode = "PAY_PER_REQUEST"
   hash_key     = "CustomerApiKeyId" # Unique identifier for the API key
-  range_key    = "CustomerId"       # Localized in dynamodb for each SCP customer that logs in
+  range_key    = "FpoId"            # Localized in dynamodb for each SCP customer that logs in
 
   attribute {
     name = "CustomerApiKeyId"
@@ -23,7 +23,7 @@ resource "aws_dynamodb_table" "customer_api_keys" {
   }
 
   attribute {
-    name = "CustomerId"
+    name = "FpoId"
     type = "S"
   }
 


### PR DESCRIPTION
# Pull Request

## What?

I have:

- Renamed CustomerId to FpoId

## Why?

I am doing this because:

- This is required to reflect the change in the FPO hub backend https://github.com/trade-tariff/trade-tariff-dev-hub-backend/pull/10
