### PR TITLE
FPO-143: Enable PITR on CustomerApiKeys

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-# Pull Request
+# Jira link
 
 ## What?
 

--- a/environments/development/applications/dynamodb.tf
+++ b/environments/development/applications/dynamodb.tf
@@ -14,8 +14,12 @@ resource "aws_dynamodb_table" "lock" {
 resource "aws_dynamodb_table" "customer_api_keys" {
   name         = "CustomerApiKeys"
   billing_mode = "PAY_PER_REQUEST"
-  hash_key     = "CustomerApiKeyId" # Unique identifier for the API key
-  range_key    = "FpoId"            # Localized in dynamodb for each SCP customer that logs in
+  hash_key     = "CustomerApiKeyId"
+  range_key    = "FpoId"
+
+  point_in_time_recovery {
+    enabled = true
+  }
 
   attribute {
     name = "CustomerApiKeyId"

--- a/environments/production/applications/dynamodb.tf
+++ b/environments/production/applications/dynamodb.tf
@@ -14,8 +14,12 @@ resource "aws_dynamodb_table" "lock" {
 resource "aws_dynamodb_table" "customer_api_keys" {
   name         = "CustomerApiKeys"
   billing_mode = "PAY_PER_REQUEST"
-  hash_key     = "CustomerApiKeyId" # Unique identifier for the API key
-  range_key    = "FpoId"            # Localized in dynamodb for each SCP customer that logs in
+  hash_key     = "CustomerApiKeyId"
+  range_key    = "FpoId"
+
+  point_in_time_recovery {
+    enabled = true
+  }
 
   attribute {
     name = "CustomerApiKeyId"

--- a/environments/staging/applications/dynamodb.tf
+++ b/environments/staging/applications/dynamodb.tf
@@ -14,8 +14,12 @@ resource "aws_dynamodb_table" "lock" {
 resource "aws_dynamodb_table" "customer_api_keys" {
   name         = "CustomerApiKeys"
   billing_mode = "PAY_PER_REQUEST"
-  hash_key     = "CustomerApiKeyId" # Unique identifier for the API key
-  range_key    = "FpoId"            # Localized in dynamodb for each SCP customer that logs in
+  hash_key     = "CustomerApiKeyId"
+  range_key    = "FpoId"
+
+  point_in_time_recovery {
+    enabled = true
+  }
 
   attribute {
     name = "CustomerApiKeyId"


### PR DESCRIPTION
# Pull Request

FPO-143

![image](https://github.com/trade-tariff/trade-tariff-platform-aws-terraform/assets/8156884/53a77c9c-e833-4421-aab6-b732e375dbb0)

![image](https://github.com/trade-tariff/trade-tariff-platform-aws-terraform/assets/8156884/a4f6862a-ab6e-46f6-b1de-557d4ebb93d1)


## What?

I have:

- Enable PITR recovery for CustomerApiKeys in development
- Enable PITR recovery for CustomerApiKeys in staging
- Enable PITR recovery for CustomerApiKeys in production

## Why?

I am doing this because:

- These are required for automating the recovery of secrets configuration in the event of DR scenario
