### PR TITLE
FPO-143: Adds tech docs bucket and CDN

### DIFF
--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -103,6 +103,7 @@ No outputs.
 | <a name="module_signon_govuk_notify_api_key"></a> [signon\_govuk\_notify\_api\_key](#module\_signon\_govuk\_notify\_api\_key) | ../../common/secret/ | n/a |
 | <a name="module_signon_secret_key_base"></a> [signon\_secret\_key\_base](#module\_signon\_secret\_key\_base) | ../../common/secret/ | n/a |
 | <a name="module_slack_web_hook_url"></a> [slack\_web\_hook\_url](#module\_slack\_web\_hook\_url) | ../../common/secret/ | n/a |
+| <a name="module_tech_docs_cdn"></a> [tech\_docs\_cdn](#module\_tech\_docs\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.4.2 |
 | <a name="module_waf"></a> [waf](#module\_waf) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/waf | aws/waf-v1.2.3 |
 
 ## Resources

--- a/environments/development/common/cloudfront.tf
+++ b/environments/development/common/cloudfront.tf
@@ -315,3 +315,64 @@ resource "aws_cloudfront_function" "basic_auth" {
   publish = true
   code    = local.cloudfront_auth
 }
+
+module "tech_docs_cdn" {
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront?ref=aws/cloudfront-v1.4.2"
+
+  aliases         = ["docs.${var.domain_name}"]
+  create_alias    = true
+  route53_zone_id = data.aws_route53_zone.this.id
+  comment         = "${title(var.environment)} Tech Docs CDN"
+
+  enabled         = true
+  is_ipv6_enabled = true
+  price_class     = "PriceClass_100"
+
+  web_acl_id = module.waf.web_acl_id
+
+  logging_config = {
+    bucket = module.logs.s3_bucket_bucket_domain_name
+    prefix = "cloudfront/${var.environment}"
+  }
+
+  default_root_object = "index.html"
+
+  origin = {
+    docs = {
+      domain_name              = aws_s3_bucket.this["tech-docs"].bucket_regional_domain_name
+      origin_access_control_id = aws_cloudfront_origin_access_control.s3.id
+    }
+  }
+
+  cache_behavior = {
+    default = {
+      target_origin_id       = "docs"
+      viewer_protocol_policy = "redirect-to-https"
+
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.s3.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+
+      min_ttl     = 0
+      default_ttl = 0
+      max_ttl     = 0
+
+      compress = true
+
+      # TODO: When we're ready to enable basic auth for tech docs, uncomment this block
+      # function_association = {
+      #   "viewer-request" = {
+      #     function_arn = aws_cloudfront_function.basic_auth.arn
+      #   }
+      # }
+    },
+  }
+
+  viewer_certificate = {
+    ssl_support_method  = "sni-only"
+    acm_certificate_arn = module.acm.validated_certificate_arn
+    depends_on = [
+      module.acm.validated_certificate_arn
+    ]
+  }
+}

--- a/environments/development/common/s3.tf
+++ b/environments/development/common/s3.tf
@@ -1,5 +1,6 @@
 locals {
   buckets = {
+    tech-docs         = "trade-tariff-tech-docs-${local.account_id}"
     api-docs          = "trade-tariff-api-docs-${local.account_id}"
     database-backups  = "trade-tariff-database-backups-${local.account_id}"
     lambda-deployment = "trade-tariff-lambda-deployment-${local.account_id}"

--- a/environments/production/common/README.md
+++ b/environments/production/common/README.md
@@ -73,6 +73,7 @@
 | <a name="module_search_query_parser_sentry_dsn"></a> [search\_query\_parser\_sentry\_dsn](#module\_search\_query\_parser\_sentry\_dsn) | ../../common/secret/ | n/a |
 | <a name="module_ses"></a> [ses](#module\_ses) | ../../common/ses | n/a |
 | <a name="module_slack_web_hook_url"></a> [slack\_web\_hook\_url](#module\_slack\_web\_hook\_url) | ../../common/secret/ | n/a |
+| <a name="module_tech_docs_cdn"></a> [tech\_docs\_cdn](#module\_tech\_docs\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.4.2 |
 | <a name="module_waf"></a> [waf](#module\_waf) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/waf | aws/waf-v1.2.3 |
 
 ## Resources

--- a/environments/production/common/cloudfront.tf
+++ b/environments/production/common/cloudfront.tf
@@ -316,3 +316,64 @@ resource "aws_cloudfront_function" "basic_auth" {
   publish = true
   code    = local.cloudfront_auth
 }
+
+module "tech_docs_cdn" {
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront?ref=aws/cloudfront-v1.4.2"
+
+  aliases         = ["docs.${var.domain_name}"]
+  create_alias    = true
+  route53_zone_id = data.aws_route53_zone.this.id
+  comment         = "${title(var.environment)} Tech Docs CDN"
+
+  enabled         = true
+  is_ipv6_enabled = true
+  price_class     = "PriceClass_100"
+
+  web_acl_id = module.waf.web_acl_id
+
+  logging_config = {
+    bucket = module.logs.s3_bucket_bucket_domain_name
+    prefix = "cloudfront/${var.environment}"
+  }
+
+  default_root_object = "index.html"
+
+  origin = {
+    docs = {
+      domain_name              = aws_s3_bucket.this["tech-docs"].bucket_regional_domain_name
+      origin_access_control_id = aws_cloudfront_origin_access_control.s3.id
+    }
+  }
+
+  cache_behavior = {
+    default = {
+      target_origin_id       = "docs"
+      viewer_protocol_policy = "redirect-to-https"
+
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.s3.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+
+      min_ttl     = 0
+      default_ttl = 0
+      max_ttl     = 0
+
+      compress = true
+
+      # TODO: When we're ready to enable basic auth for tech docs, uncomment this block
+      # function_association = {
+      #   "viewer-request" = {
+      #     function_arn = aws_cloudfront_function.basic_auth.arn
+      #   }
+      # }
+    },
+  }
+
+  viewer_certificate = {
+    ssl_support_method  = "sni-only"
+    acm_certificate_arn = module.acm.validated_certificate_arn
+    depends_on = [
+      module.acm.validated_certificate_arn
+    ]
+  }
+}

--- a/environments/production/common/s3.tf
+++ b/environments/production/common/s3.tf
@@ -1,5 +1,6 @@
 locals {
   buckets = {
+    tech-docs         = "trade-tariff-tech-docs-${local.account_id}"
     api-docs          = "trade-tariff-api-docs-${local.account_id}"
     database-backups  = "trade-tariff-database-backups-${local.account_id}"
     lambda-deployment = "trade-tariff-lambda-deployment-${local.account_id}"

--- a/environments/staging/common/README.md
+++ b/environments/staging/common/README.md
@@ -79,6 +79,7 @@
 | <a name="module_signon_govuk_notify_api_key"></a> [signon\_govuk\_notify\_api\_key](#module\_signon\_govuk\_notify\_api\_key) | ../../common/secret/ | n/a |
 | <a name="module_signon_secret_key_base"></a> [signon\_secret\_key\_base](#module\_signon\_secret\_key\_base) | ../../common/secret/ | n/a |
 | <a name="module_slack_web_hook_url"></a> [slack\_web\_hook\_url](#module\_slack\_web\_hook\_url) | ../../common/secret/ | n/a |
+| <a name="module_tech_docs_cdn"></a> [tech\_docs\_cdn](#module\_tech\_docs\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.4.2 |
 | <a name="module_waf"></a> [waf](#module\_waf) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/waf | aws/waf-v1.2.3 |
 
 ## Resources

--- a/environments/staging/common/cloudfront.tf
+++ b/environments/staging/common/cloudfront.tf
@@ -315,3 +315,64 @@ resource "aws_cloudfront_function" "basic_auth" {
   publish = true
   code    = local.cloudfront_auth
 }
+
+module "tech_docs_cdn" {
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront?ref=aws/cloudfront-v1.4.2"
+
+  aliases         = ["docs.${var.domain_name}"]
+  create_alias    = true
+  route53_zone_id = data.aws_route53_zone.this.id
+  comment         = "${title(var.environment)} Tech Docs CDN"
+
+  enabled         = true
+  is_ipv6_enabled = true
+  price_class     = "PriceClass_100"
+
+  web_acl_id = module.waf.web_acl_id
+
+  logging_config = {
+    bucket = module.logs.s3_bucket_bucket_domain_name
+    prefix = "cloudfront/${var.environment}"
+  }
+
+  default_root_object = "index.html"
+
+  origin = {
+    docs = {
+      domain_name              = aws_s3_bucket.this["tech-docs"].bucket_regional_domain_name
+      origin_access_control_id = aws_cloudfront_origin_access_control.s3.id
+    }
+  }
+
+  cache_behavior = {
+    default = {
+      target_origin_id       = "docs"
+      viewer_protocol_policy = "redirect-to-https"
+
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.s3.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+
+      min_ttl     = 0
+      default_ttl = 0
+      max_ttl     = 0
+
+      compress = true
+
+      # TODO: When we're ready to enable basic auth for tech docs, uncomment this block
+      # function_association = {
+      #   "viewer-request" = {
+      #     function_arn = aws_cloudfront_function.basic_auth.arn
+      #   }
+      # }
+    },
+  }
+
+  viewer_certificate = {
+    ssl_support_method  = "sni-only"
+    acm_certificate_arn = module.acm.validated_certificate_arn
+    depends_on = [
+      module.acm.validated_certificate_arn
+    ]
+  }
+}

--- a/environments/staging/common/s3.tf
+++ b/environments/staging/common/s3.tf
@@ -1,5 +1,6 @@
 locals {
   buckets = {
+    tech-docs         = "trade-tariff-tech-docs-${local.account_id}"
     api-docs          = "trade-tariff-api-docs-${local.account_id}"
     database-backups  = "trade-tariff-database-backups-${local.account_id}"
     lambda-deployment = "trade-tariff-lambda-deployment-${local.account_id}"


### PR DESCRIPTION
# Jira link

FPO-143

## What?

I have:

- Adds bucket and CDN configuration for tech-docs in development
- Adds bucket and CDN configuration for tech-docs in staging
- Adds bucket and CDN configuration for tech-docs in production

## Why?

I am doing this because:

- This is required to enable us to deploy a static site using govuk templates https://github.com/alphagov/tdt-documentation/
