### PR TITLE
BAU: Adjust IAM permissions in tech-docs CDN

### DIFF
--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -153,6 +153,7 @@ No outputs.
 | [aws_s3_bucket_policy.api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_policy.backups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_policy.reporting](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
+| [aws_s3_bucket_policy.tech_docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_s3_bucket_versioning.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
@@ -172,6 +173,7 @@ No outputs.
 | [aws_iam_policy_document.opensearch_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.reporting](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.s3_kms_key_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.tech_docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 | [terraform_remote_state.base](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 

--- a/environments/development/common/cloudfront-policy.tf
+++ b/environments/development/common/cloudfront-policy.tf
@@ -208,3 +208,28 @@ data "aws_iam_policy_document" "backups" {
     }
   }
 }
+
+resource "aws_s3_bucket_policy" "tech_docs" {
+  bucket = aws_s3_bucket.this["tech-docs"].id
+  policy = data.aws_iam_policy_document.tech_docs.json
+}
+
+data "aws_iam_policy_document" "tech_docs" {
+  statement {
+    sid       = "AllowCloudFrontServicePrincipal"
+    effect    = "Allow"
+    actions   = ["s3:GetObject", "s3:ListBucket"]
+    resources = [aws_s3_bucket.this["tech-docs"].arn, "${aws_s3_bucket.this["tech-docs"].arn}/*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+      values   = [module.tech_docs_cdn.aws_cloudfront_distribution_arn]
+    }
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+  }
+}

--- a/environments/development/common/cloudfront.tf
+++ b/environments/development/common/cloudfront.tf
@@ -319,23 +319,20 @@ resource "aws_cloudfront_function" "basic_auth" {
 module "tech_docs_cdn" {
   source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront?ref=aws/cloudfront-v1.4.2"
 
-  aliases         = ["docs.${var.domain_name}"]
-  create_alias    = true
-  route53_zone_id = data.aws_route53_zone.this.id
-  comment         = "${title(var.environment)} Tech Docs CDN"
+  aliases             = ["docs.${var.domain_name}"]
+  create_alias        = true
+  route53_zone_id     = data.aws_route53_zone.this.id
+  comment             = "${title(var.environment)} Tech Docs CDN"
+  default_root_object = "index.html"
 
   enabled         = true
   is_ipv6_enabled = true
   price_class     = "PriceClass_100"
 
-  web_acl_id = module.waf.web_acl_id
-
   logging_config = {
     bucket = module.logs.s3_bucket_bucket_domain_name
     prefix = "cloudfront/${var.environment}"
   }
-
-  default_root_object = "index.html"
 
   origin = {
     docs = {
@@ -349,7 +346,7 @@ module "tech_docs_cdn" {
       target_origin_id       = "docs"
       viewer_protocol_policy = "redirect-to-https"
 
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      cache_policy_id            = aws_cloudfront_cache_policy.s3.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.s3.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
 

--- a/environments/production/common/README.md
+++ b/environments/production/common/README.md
@@ -142,6 +142,7 @@
 | [aws_s3_bucket_policy.api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_policy.backups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_policy.reporting](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
+| [aws_s3_bucket_policy.tech_docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_s3_bucket_versioning.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
@@ -161,6 +162,7 @@
 | [aws_iam_policy_document.opensearch_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.reporting](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.s3_kms_key_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.tech_docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 | [aws_secretsmanager_secret_version.slack](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 | [terraform_remote_state.base](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |

--- a/environments/production/common/cloudfront-policy.tf
+++ b/environments/production/common/cloudfront-policy.tf
@@ -208,3 +208,28 @@ data "aws_iam_policy_document" "backups" {
     }
   }
 }
+
+resource "aws_s3_bucket_policy" "tech_docs" {
+  bucket = aws_s3_bucket.this["tech-docs"].id
+  policy = data.aws_iam_policy_document.tech_docs.json
+}
+
+data "aws_iam_policy_document" "tech_docs" {
+  statement {
+    sid       = "AllowCloudFrontServicePrincipal"
+    effect    = "Allow"
+    actions   = ["s3:GetObject", "s3:ListBucket"]
+    resources = [aws_s3_bucket.this["tech-docs"].arn, "${aws_s3_bucket.this["tech-docs"].arn}/*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+      values   = [module.tech_docs_cdn.aws_cloudfront_distribution_arn]
+    }
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+  }
+}

--- a/environments/production/common/cloudfront.tf
+++ b/environments/production/common/cloudfront.tf
@@ -320,10 +320,11 @@ resource "aws_cloudfront_function" "basic_auth" {
 module "tech_docs_cdn" {
   source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront?ref=aws/cloudfront-v1.4.2"
 
-  aliases         = ["docs.${var.domain_name}"]
-  create_alias    = true
-  route53_zone_id = data.aws_route53_zone.this.id
-  comment         = "${title(var.environment)} Tech Docs CDN"
+  aliases             = ["docs.${var.domain_name}"]
+  create_alias        = true
+  route53_zone_id     = data.aws_route53_zone.this.id
+  comment             = "${title(var.environment)} Tech Docs CDN"
+  default_root_object = "index.html"
 
   enabled         = true
   is_ipv6_enabled = true
@@ -335,8 +336,6 @@ module "tech_docs_cdn" {
     bucket = module.logs.s3_bucket_bucket_domain_name
     prefix = "cloudfront/${var.environment}"
   }
-
-  default_root_object = "index.html"
 
   origin = {
     docs = {
@@ -350,7 +349,7 @@ module "tech_docs_cdn" {
       target_origin_id       = "docs"
       viewer_protocol_policy = "redirect-to-https"
 
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      cache_policy_id            = aws_cloudfront_cache_policy.s3.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.s3.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
 

--- a/environments/staging/common/README.md
+++ b/environments/staging/common/README.md
@@ -129,6 +129,7 @@
 | [aws_s3_bucket_policy.api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_policy.backups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_policy.reporting](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
+| [aws_s3_bucket_policy.tech_docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_s3_bucket_versioning.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
@@ -147,6 +148,7 @@
 | [aws_iam_policy_document.opensearch_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.reporting](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.s3_kms_key_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.tech_docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 | [terraform_remote_state.base](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 

--- a/environments/staging/common/cloudfront-policy.tf
+++ b/environments/staging/common/cloudfront-policy.tf
@@ -208,3 +208,28 @@ data "aws_iam_policy_document" "backups" {
     }
   }
 }
+
+resource "aws_s3_bucket_policy" "tech_docs" {
+  bucket = aws_s3_bucket.this["tech-docs"].id
+  policy = data.aws_iam_policy_document.tech_docs.json
+}
+
+data "aws_iam_policy_document" "tech_docs" {
+  statement {
+    sid       = "AllowCloudFrontServicePrincipal"
+    effect    = "Allow"
+    actions   = ["s3:GetObject", "s3:ListBucket"]
+    resources = [aws_s3_bucket.this["tech-docs"].arn, "${aws_s3_bucket.this["tech-docs"].arn}/*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+      values   = [module.tech_docs_cdn.aws_cloudfront_distribution_arn]
+    }
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+  }
+}

--- a/environments/staging/common/cloudfront.tf
+++ b/environments/staging/common/cloudfront.tf
@@ -319,10 +319,11 @@ resource "aws_cloudfront_function" "basic_auth" {
 module "tech_docs_cdn" {
   source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront?ref=aws/cloudfront-v1.4.2"
 
-  aliases         = ["docs.${var.domain_name}"]
-  create_alias    = true
-  route53_zone_id = data.aws_route53_zone.this.id
-  comment         = "${title(var.environment)} Tech Docs CDN"
+  aliases             = ["docs.${var.domain_name}"]
+  create_alias        = true
+  route53_zone_id     = data.aws_route53_zone.this.id
+  comment             = "${title(var.environment)} Tech Docs CDN"
+  default_root_object = "index.html"
 
   enabled         = true
   is_ipv6_enabled = true
@@ -334,8 +335,6 @@ module "tech_docs_cdn" {
     bucket = module.logs.s3_bucket_bucket_domain_name
     prefix = "cloudfront/${var.environment}"
   }
-
-  default_root_object = "index.html"
 
   origin = {
     docs = {
@@ -349,7 +348,7 @@ module "tech_docs_cdn" {
       target_origin_id       = "docs"
       viewer_protocol_policy = "redirect-to-https"
 
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      cache_policy_id            = aws_cloudfront_cache_policy.s3.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.s3.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
 


### PR DESCRIPTION
# Jira link

BAU

## What?

I have:

- Removed WAF from tech-docs CDN
- Make sure we give permission to the tech-docs cloudfront distribution to have access to the tech-docs bucket

## Why?

I am doing this because:

- This isn't required and was a copy/paste error
