### PR TITLE
FPO-170: Remove now-defunct sandbox zone

### DIFF
--- a/environments/production/common/README.md
+++ b/environments/production/common/README.md
@@ -138,7 +138,6 @@
 | [aws_route53_record.origin_ns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.origin_root](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.origin_wildcard](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
-| [aws_route53_record.sandbox_name_servers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.staging_name_servers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_zone.origin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
 | [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |

--- a/environments/production/common/route53.tf
+++ b/environments/production/common/route53.tf
@@ -34,14 +34,6 @@ resource "aws_route53_record" "staging_name_servers" {
   records = data.terraform_remote_state.staging.outputs.hosted_zone_name_servers
 }
 
-resource "aws_route53_record" "sandbox_name_servers" {
-  zone_id = data.aws_route53_zone.this.zone_id
-  name    = "sandbox.${var.domain_name}"
-  type    = "NS"
-  ttl     = "30"
-  records = data.terraform_remote_state.staging.outputs.sandbox_hosted_zone_name_servers
-}
-
 resource "aws_route53_record" "google_site_verification" {
   zone_id = data.aws_route53_zone.this.zone_id
   name    = var.domain_name

--- a/environments/staging/common/README.md
+++ b/environments/staging/common/README.md
@@ -22,9 +22,8 @@
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_acm"></a> [acm](#module\_acm) | ../../common/acm/ | n/a |
+| <a name="module_acm_london"></a> [acm\_london](#module\_acm\_london) | ../../common/acm/ | n/a |
 | <a name="module_acm_origin"></a> [acm\_origin](#module\_acm\_origin) | ../../common/acm | n/a |
-| <a name="module_acm_sandbox"></a> [acm\_sandbox](#module\_acm\_sandbox) | ../../common/acm/ | n/a |
-| <a name="module_acm_sandbox_london"></a> [acm\_sandbox\_london](#module\_acm\_sandbox\_london) | ../../common/acm/ | n/a |
 | <a name="module_admin_bearer_token"></a> [admin\_bearer\_token](#module\_admin\_bearer\_token) | ../../common/secret/ | n/a |
 | <a name="module_admin_oauth_id"></a> [admin\_oauth\_id](#module\_admin\_oauth\_id) | ../../common/secret/ | n/a |
 | <a name="module_admin_oauth_secret"></a> [admin\_oauth\_secret](#module\_admin\_oauth\_secret) | ../../common/secret/ | n/a |
@@ -127,7 +126,6 @@
 | [aws_route53_record.origin_root](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.origin_wildcard](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_zone.origin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
-| [aws_route53_zone.sandbox](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
 | [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_policy.api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_policy.backups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
@@ -178,7 +176,6 @@
 | <a name="input_frontend_secret_key_base"></a> [frontend\_secret\_key\_base](#input\_frontend\_secret\_key\_base) | Value of SECRET\_KEY\_BASE for the frontend. | `string` | n/a | yes |
 | <a name="input_frontend_sentry_dsn"></a> [frontend\_sentry\_dsn](#input\_frontend\_sentry\_dsn) | Value of SENTRY\_DSN for the frontend. | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region to use. Defaults to `eu-west-2`. | `string` | `"eu-west-2"` | no |
-| <a name="input_sandbox_domain_name"></a> [sandbox\_domain\_name](#input\_sandbox\_domain\_name) | Sandbox domain name of the service. | `string` | `"sandbox.trade-tariff.service.gov.uk"` | no |
 | <a name="input_search_query_parser_sentry_dsn"></a> [search\_query\_parser\_sentry\_dsn](#input\_search\_query\_parser\_sentry\_dsn) | Value of SENTRY\_DSN for the search query parser. | `string` | n/a | yes |
 | <a name="input_signon_derivation_key"></a> [signon\_derivation\_key](#input\_signon\_derivation\_key) | Value of ACTIVE\_RECORD\_ENCRYPTION\_PRIMARY\_KEY for the signon app. | `string` | n/a | yes |
 | <a name="input_signon_derivation_salt"></a> [signon\_derivation\_salt](#input\_signon\_derivation\_salt) | Value of ACTIVE\_RECORD\_ENCRYPTION\_KEY\_DERIVATION\_SALT for the signon app. | `string` | n/a | yes |
@@ -209,5 +206,4 @@
 | Name | Description |
 |------|-------------|
 | <a name="output_hosted_zone_name_servers"></a> [hosted\_zone\_name\_servers](#output\_hosted\_zone\_name\_servers) | Name servers. |
-| <a name="output_sandbox_hosted_zone_name_servers"></a> [sandbox\_hosted\_zone\_name\_servers](#output\_sandbox\_hosted\_zone\_name\_servers) | Sandbox Name servers. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/environments/staging/common/acm.tf
+++ b/environments/staging/common/acm.tf
@@ -9,22 +9,11 @@ module "acm" {
   }
 }
 
-module "acm_sandbox" {
+module "acm_london" {
   source         = "../../common/acm/"
-  domain_name    = var.sandbox_domain_name
+  domain_name    = var.domain_name
   environment    = var.environment
-  hosted_zone_id = aws_route53_zone.sandbox.zone_id
-
-  providers = {
-    aws = aws.us_east_1
-  }
-}
-
-module "acm_sandbox_london" {
-  source         = "../../common/acm/"
-  domain_name    = var.sandbox_domain_name
-  environment    = var.environment
-  hosted_zone_id = aws_route53_zone.sandbox.zone_id
+  hosted_zone_id = data.aws_route53_zone.this.zone_id
 }
 
 module "acm_origin" {

--- a/environments/staging/common/iam.tf
+++ b/environments/staging/common/iam.tf
@@ -187,7 +187,7 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
         Action = [
           "route53:ChangeResourceRecordSets",
         ],
-        Resource = [aws_route53_zone.sandbox.arn]
+        Resource = [data.aws_route53_zone.this.arn]
       },
     ]
   })

--- a/environments/staging/common/outputs.tf
+++ b/environments/staging/common/outputs.tf
@@ -2,8 +2,3 @@ output "hosted_zone_name_servers" {
   description = "Name servers."
   value       = data.aws_route53_zone.this.name_servers
 }
-
-output "sandbox_hosted_zone_name_servers" {
-  description = "Sandbox Name servers."
-  value       = aws_route53_zone.sandbox.name_servers
-}

--- a/environments/staging/common/route53.tf
+++ b/environments/staging/common/route53.tf
@@ -7,10 +7,6 @@ resource "aws_route53_zone" "origin" {
   name = local.origin_domain_name
 }
 
-resource "aws_route53_zone" "sandbox" {
-  name = var.sandbox_domain_name
-}
-
 resource "aws_route53_record" "origin_ns" {
   zone_id = data.aws_route53_zone.this.zone_id
   name    = local.origin_domain_name

--- a/environments/staging/common/variables.tf
+++ b/environments/staging/common/variables.tf
@@ -10,12 +10,6 @@ variable "domain_name" {
   default     = "staging.trade-tariff.service.gov.uk"
 }
 
-variable "sandbox_domain_name" {
-  description = "Sandbox domain name of the service."
-  type        = string
-  default     = "sandbox.trade-tariff.service.gov.uk"
-}
-
 variable "region" {
   description = "AWS Region to use. Defaults to `eu-west-2`."
   type        = string


### PR DESCRIPTION
# Jira link

FPO-170

## What?

I have:

- Removed sandbox zone, certificates, references, etc

## Why?

I am doing this because:

- These are now redundant since we're moving into private beta
