### PR TITLE
FPO-139: Adds sentry secrets for FPO-search

### DIFF
--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -82,6 +82,7 @@ No outputs.
 | <a name="module_dev_hub_frontend_sentry_dsn"></a> [dev\_hub\_frontend\_sentry\_dsn](#module\_dev\_hub\_frontend\_sentry\_dsn) | ../../common/secret/ | n/a |
 | <a name="module_duty_calculator_secret_key_base"></a> [duty\_calculator\_secret\_key\_base](#module\_duty\_calculator\_secret\_key\_base) | ../../common/secret/ | n/a |
 | <a name="module_duty_calculator_sentry_dsn"></a> [duty\_calculator\_sentry\_dsn](#module\_duty\_calculator\_sentry\_dsn) | ../../common/secret/ | n/a |
+| <a name="module_fpo_search_sentry_dsn"></a> [fpo\_search\_sentry\_dsn](#module\_fpo\_search\_sentry\_dsn) | ../../common/secret/ | n/a |
 | <a name="module_frontend_secret_key_base"></a> [frontend\_secret\_key\_base](#module\_frontend\_secret\_key\_base) | ../../common/secret/ | n/a |
 | <a name="module_frontend_sentry_dsn"></a> [frontend\_sentry\_dsn](#module\_frontend\_sentry\_dsn) | ../../common/secret/ | n/a |
 | <a name="module_logs"></a> [logs](#module\_logs) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v3.14.0 |
@@ -200,6 +201,7 @@ No outputs.
 | <a name="input_duty_calculator_secret_key_base"></a> [duty\_calculator\_secret\_key\_base](#input\_duty\_calculator\_secret\_key\_base) | Value of SECRET\_KEY\_BASE for the duty calculator. | `string` | n/a | yes |
 | <a name="input_duty_calculator_sentry_dsn"></a> [duty\_calculator\_sentry\_dsn](#input\_duty\_calculator\_sentry\_dsn) | Value of SENTRY\_DSN for the duty calculator. | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | Build environment | `string` | `"development"` | no |
+| <a name="input_fpo_search_sentry_dsn"></a> [fpo\_search\_sentry\_dsn](#input\_fpo\_search\_sentry\_dsn) | Value of SENTRY\_DSN for the FPO search lambda. | `string` | n/a | yes |
 | <a name="input_frontend_secret_key_base"></a> [frontend\_secret\_key\_base](#input\_frontend\_secret\_key\_base) | Value of SECRET\_KEY\_BASE for the frontend. | `string` | n/a | yes |
 | <a name="input_frontend_sentry_dsn"></a> [frontend\_sentry\_dsn](#input\_frontend\_sentry\_dsn) | Value of SENTRY\_DSN for the frontend. | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region to use. Defaults to `eu-west-2`. | `string` | `"eu-west-2"` | no |

--- a/environments/development/common/iam.tf
+++ b/environments/development/common/iam.tf
@@ -128,7 +128,25 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
           "kms:Decrypt"
         ],
         Resource = [
-          aws_kms_alias.s3_kms_alias.target_key_arn
+          aws_kms_alias.s3_kms_alias.target_key_arn,
+          aws_kms_alias.secretsmanager_kms_alias.target_key_arn,
+        ]
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "secretsmanager:ListSecrets",
+          "secretsmanager:ListSecretVersionIds",
+        ],
+        Resource = ["*"]
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "secretsmanager:GetSecretValue",
+        ],
+        Resource = [
+          module.fpo_search_sentry_dsn.secret_arn,
         ]
       },
       {

--- a/environments/development/common/secrets.tf
+++ b/environments/development/common/secrets.tf
@@ -285,3 +285,11 @@ module "dev_hub_frontend_sentry_dsn" {
   recovery_window = 7
   secret_string   = var.dev_hub_frontend_sentry_dsn
 }
+
+module "fpo_search_sentry_dsn" {
+  source          = "../../common/secret/"
+  name            = "fpo-search-sentry-dsn"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.fpo_search_sentry_dsn
+}

--- a/environments/development/common/variables.tf
+++ b/environments/development/common/variables.tf
@@ -262,6 +262,12 @@ variable "dev_hub_frontend_sentry_dsn" {
   sensitive   = true
 }
 
+variable "fpo_search_sentry_dsn" {
+  description = "Value of SENTRY_DSN for the FPO search lambda."
+  type        = string
+  sensitive   = true
+}
+
 variable "backups_basic_auth" {
   description = "base64 encoded credentials for backups basic auth."
   type        = string

--- a/environments/production/common/README.md
+++ b/environments/production/common/README.md
@@ -60,6 +60,7 @@
 | <a name="module_duty_calculator_secret_key_base"></a> [duty\_calculator\_secret\_key\_base](#module\_duty\_calculator\_secret\_key\_base) | ../../common/secret/ | n/a |
 | <a name="module_duty_calculator_sentry_dsn"></a> [duty\_calculator\_sentry\_dsn](#module\_duty\_calculator\_sentry\_dsn) | ../../common/secret/ | n/a |
 | <a name="module_ecr"></a> [ecr](#module\_ecr) | ../../common/ecr/ | n/a |
+| <a name="module_fpo_search_sentry_dsn"></a> [fpo\_search\_sentry\_dsn](#module\_fpo\_search\_sentry\_dsn) | ../../common/secret/ | n/a |
 | <a name="module_frontend_secret_key_base"></a> [frontend\_secret\_key\_base](#module\_frontend\_secret\_key\_base) | ../../common/secret/ | n/a |
 | <a name="module_frontend_sentry_dsn"></a> [frontend\_sentry\_dsn](#module\_frontend\_sentry\_dsn) | ../../common/secret/ | n/a |
 | <a name="module_logs"></a> [logs](#module\_logs) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v3.14.0 |
@@ -195,6 +196,7 @@
 | <a name="input_duty_calculator_secret_key_base"></a> [duty\_calculator\_secret\_key\_base](#input\_duty\_calculator\_secret\_key\_base) | Value of SECRET\_KEY\_BASE for the duty calculator. | `string` | n/a | yes |
 | <a name="input_duty_calculator_sentry_dsn"></a> [duty\_calculator\_sentry\_dsn](#input\_duty\_calculator\_sentry\_dsn) | Value of SENTRY\_DSN for the duty calculator. | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | Build environment | `string` | `"production"` | no |
+| <a name="input_fpo_search_sentry_dsn"></a> [fpo\_search\_sentry\_dsn](#input\_fpo\_search\_sentry\_dsn) | Value of SENTRY\_DSN for the FPO search lambda. | `string` | n/a | yes |
 | <a name="input_frontend_secret_key_base"></a> [frontend\_secret\_key\_base](#input\_frontend\_secret\_key\_base) | Value of SECRET\_KEY\_BASE for the frontend. | `string` | n/a | yes |
 | <a name="input_frontend_sentry_dsn"></a> [frontend\_sentry\_dsn](#input\_frontend\_sentry\_dsn) | Value of SENTRY\_DSN for the frontend. | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region to use. Defaults to `eu-west-2`. | `string` | `"eu-west-2"` | no |

--- a/environments/production/common/iam.tf
+++ b/environments/production/common/iam.tf
@@ -128,7 +128,25 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
           "kms:Decrypt"
         ],
         Resource = [
-          aws_kms_alias.s3_kms_alias.target_key_arn
+          aws_kms_alias.s3_kms_alias.target_key_arn,
+          aws_kms_alias.secretsmanager_kms_alias.target_key_arn,
+        ]
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "secretsmanager:ListSecrets",
+          "secretsmanager:ListSecretVersionIds",
+        ],
+        Resource = ["*"]
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "secretsmanager:GetSecretValue",
+        ],
+        Resource = [
+          module.fpo_search_sentry_dsn.secret_arn,
         ]
       },
       {

--- a/environments/production/common/secrets.tf
+++ b/environments/production/common/secrets.tf
@@ -238,3 +238,11 @@ module "dev_hub_frontend_sentry_dsn" {
   recovery_window = 7
   secret_string   = var.dev_hub_frontend_sentry_dsn
 }
+
+module "fpo_search_sentry_dsn" {
+  source          = "../../common/secret/"
+  name            = "fpo-search-sentry-dsn"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.fpo_search_sentry_dsn
+}

--- a/environments/production/common/variables.tf
+++ b/environments/production/common/variables.tf
@@ -226,6 +226,12 @@ variable "dev_hub_frontend_sentry_dsn" {
   sensitive   = true
 }
 
+variable "fpo_search_sentry_dsn" {
+  description = "Value of SENTRY_DSN for the FPO search lambda."
+  type        = string
+  sensitive   = true
+}
+
 variable "backups_basic_auth" {
   description = "base64 encoded credentials for backups basic auth."
   type        = string

--- a/environments/staging/common/README.md
+++ b/environments/staging/common/README.md
@@ -59,6 +59,7 @@
 | <a name="module_dev_hub_frontend_sentry_dsn"></a> [dev\_hub\_frontend\_sentry\_dsn](#module\_dev\_hub\_frontend\_sentry\_dsn) | ../../common/secret/ | n/a |
 | <a name="module_duty_calculator_secret_key_base"></a> [duty\_calculator\_secret\_key\_base](#module\_duty\_calculator\_secret\_key\_base) | ../../common/secret/ | n/a |
 | <a name="module_duty_calculator_sentry_dsn"></a> [duty\_calculator\_sentry\_dsn](#module\_duty\_calculator\_sentry\_dsn) | ../../common/secret/ | n/a |
+| <a name="module_fpo_search_sentry_dsn"></a> [fpo\_search\_sentry\_dsn](#module\_fpo\_search\_sentry\_dsn) | ../../common/secret/ | n/a |
 | <a name="module_frontend_secret_key_base"></a> [frontend\_secret\_key\_base](#module\_frontend\_secret\_key\_base) | ../../common/secret/ | n/a |
 | <a name="module_frontend_sentry_dsn"></a> [frontend\_sentry\_dsn](#module\_frontend\_sentry\_dsn) | ../../common/secret/ | n/a |
 | <a name="module_logs"></a> [logs](#module\_logs) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v3.14.0 |
@@ -177,6 +178,7 @@
 | <a name="input_duty_calculator_secret_key_base"></a> [duty\_calculator\_secret\_key\_base](#input\_duty\_calculator\_secret\_key\_base) | Value of SECRET\_KEY\_BASE for the duty calculator. | `string` | n/a | yes |
 | <a name="input_duty_calculator_sentry_dsn"></a> [duty\_calculator\_sentry\_dsn](#input\_duty\_calculator\_sentry\_dsn) | Value of SENTRY\_DSN for the duty calculator. | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | Build environment | `string` | `"staging"` | no |
+| <a name="input_fpo_search_sentry_dsn"></a> [fpo\_search\_sentry\_dsn](#input\_fpo\_search\_sentry\_dsn) | Value of SENTRY\_DSN for the FPO search lambda. | `string` | n/a | yes |
 | <a name="input_frontend_secret_key_base"></a> [frontend\_secret\_key\_base](#input\_frontend\_secret\_key\_base) | Value of SECRET\_KEY\_BASE for the frontend. | `string` | n/a | yes |
 | <a name="input_frontend_sentry_dsn"></a> [frontend\_sentry\_dsn](#input\_frontend\_sentry\_dsn) | Value of SENTRY\_DSN for the frontend. | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region to use. Defaults to `eu-west-2`. | `string` | `"eu-west-2"` | no |

--- a/environments/staging/common/iam.tf
+++ b/environments/staging/common/iam.tf
@@ -128,7 +128,25 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
           "kms:Decrypt"
         ],
         Resource = [
-          aws_kms_alias.s3_kms_alias.target_key_arn
+          aws_kms_alias.s3_kms_alias.target_key_arn,
+          aws_kms_alias.secretsmanager_kms_alias.target_key_arn,
+        ]
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "secretsmanager:ListSecrets",
+          "secretsmanager:ListSecretVersionIds",
+        ],
+        Resource = ["*"]
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "secretsmanager:GetSecretValue",
+        ],
+        Resource = [
+          module.fpo_search_sentry_dsn.secret_arn,
         ]
       },
       {

--- a/environments/staging/common/secrets.tf
+++ b/environments/staging/common/secrets.tf
@@ -285,3 +285,11 @@ module "dev_hub_frontend_sentry_dsn" {
   recovery_window = 7
   secret_string   = var.dev_hub_frontend_sentry_dsn
 }
+
+module "fpo_search_sentry_dsn" {
+  source          = "../../common/secret/"
+  name            = "fpo-search-sentry-dsn"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.fpo_search_sentry_dsn
+}

--- a/environments/staging/common/variables.tf
+++ b/environments/staging/common/variables.tf
@@ -262,6 +262,12 @@ variable "dev_hub_frontend_sentry_dsn" {
   sensitive   = true
 }
 
+variable "fpo_search_sentry_dsn" {
+  description = "Value of SENTRY_DSN for the FPO search lambda."
+  type        = string
+  sensitive   = true
+}
+
 variable "backups_basic_auth" {
   description = "base64 encoded credentials for backups basic auth."
   type        = string


### PR DESCRIPTION
# Jira link

FPO-139

## What?

I have:

- Adds sentry dsn secret for fpo-search in development
- Adds sentry dsn secret for fpo-search in staging
- Adds sentry dsn secret for fpo-search in production

## Why?

I am doing this because:

- These are required to configure sentry in the FPO-search lambda using serverless/cloudformation
