### PR TITLE
BAU: Stop caching API docs

### DIFF
--- a/environments/development/common/cloudfront.tf
+++ b/environments/development/common/cloudfront.tf
@@ -178,7 +178,7 @@ module "api_cdn" {
       target_origin_id       = "api"
       viewer_protocol_policy = "redirect-to-https"
 
-      cache_policy_id            = aws_cloudfront_cache_policy.s3.id
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.s3.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
 

--- a/environments/production/common/cloudfront.tf
+++ b/environments/production/common/cloudfront.tf
@@ -179,7 +179,7 @@ module "api_cdn" {
       target_origin_id       = "api"
       viewer_protocol_policy = "redirect-to-https"
 
-      cache_policy_id            = aws_cloudfront_cache_policy.s3.id
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.s3.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
 

--- a/environments/staging/common/cloudfront.tf
+++ b/environments/staging/common/cloudfront.tf
@@ -178,7 +178,7 @@ module "api_cdn" {
       target_origin_id       = "api"
       viewer_protocol_policy = "redirect-to-https"
 
-      cache_policy_id            = aws_cloudfront_cache_policy.s3.id
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.s3.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
 


### PR DESCRIPTION
# Jira link

BAU

## What?

I have:

- Altered api docs policy not to cache

## Why?

I am doing this because:

- We deploy at any point in the day and we just want the updated documentation
