### PR TITLE
FPO-183: Reduce alerts in slack and extend to lower environments

### DIFF
--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -87,6 +87,7 @@ No outputs.
 | <a name="module_frontend_sentry_dsn"></a> [frontend\_sentry\_dsn](#module\_frontend\_sentry\_dsn) | ../../common/secret/ | n/a |
 | <a name="module_logs"></a> [logs](#module\_logs) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v3.14.0 |
 | <a name="module_mysql"></a> [mysql](#module\_mysql) | ../../common/rds | n/a |
+| <a name="module_notify_slack"></a> [notify\_slack](#module\_notify\_slack) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/aws-notify-slack | aws/aws-notify-slack-v1.0.0 |
 | <a name="module_opensearch"></a> [opensearch](#module\_opensearch) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/opensearch | aws/opensearch-v1.2.0 |
 | <a name="module_opensearch_packages_bucket"></a> [opensearch\_packages\_bucket](#module\_opensearch\_packages\_bucket) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v3.14.0 |
 | <a name="module_postgres"></a> [postgres](#module\_postgres) | ../../common/rds | n/a |
@@ -103,6 +104,7 @@ No outputs.
 | <a name="module_signon_devise_secret_key"></a> [signon\_devise\_secret\_key](#module\_signon\_devise\_secret\_key) | ../../common/secret/ | n/a |
 | <a name="module_signon_govuk_notify_api_key"></a> [signon\_govuk\_notify\_api\_key](#module\_signon\_govuk\_notify\_api\_key) | ../../common/secret/ | n/a |
 | <a name="module_signon_secret_key_base"></a> [signon\_secret\_key\_base](#module\_signon\_secret\_key\_base) | ../../common/secret/ | n/a |
+| <a name="module_slack_notify_lambda_slack_webhook_url"></a> [slack\_notify\_lambda\_slack\_webhook\_url](#module\_slack\_notify\_lambda\_slack\_webhook\_url) | ../../common/secret/ | n/a |
 | <a name="module_slack_web_hook_url"></a> [slack\_web\_hook\_url](#module\_slack\_web\_hook\_url) | ../../common/secret/ | n/a |
 | <a name="module_tech_docs_cdn"></a> [tech\_docs\_cdn](#module\_tech\_docs\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.4.2 |
 | <a name="module_waf"></a> [waf](#module\_waf) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/waf | aws/waf-v1.2.3 |
@@ -120,6 +122,8 @@ No outputs.
 | [aws_cloudfront_response_headers_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_response_headers_policy) | resource |
 | [aws_cloudwatch_log_group.redis_engine_lg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.redis_slow_lg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_cloudwatch_metric_alarm.high_5xx_codes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.long_response_times](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_elasticache_subnet_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_subnet_group) | resource |
 | [aws_iam_policy.ci_appendix5a_peristence_readwrite_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.ci_lambda_deployment_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
@@ -212,6 +216,7 @@ No outputs.
 | <a name="input_signon_devise_secret_key"></a> [signon\_devise\_secret\_key](#input\_signon\_devise\_secret\_key) | Value of DEVISE\_SECRET\_KEY for the signon app. | `string` | n/a | yes |
 | <a name="input_signon_govuk_notify_api_key"></a> [signon\_govuk\_notify\_api\_key](#input\_signon\_govuk\_notify\_api\_key) | Value of GOVUK\_NOTIFY\_API\_KEY for the signon app. | `string` | n/a | yes |
 | <a name="input_signon_secret_key_base"></a> [signon\_secret\_key\_base](#input\_signon\_secret\_key\_base) | Value of SECRET\_KEY\_BASE for the signon app. | `string` | n/a | yes |
+| <a name="input_slack_notify_lambda_slack_webhook_url"></a> [slack\_notify\_lambda\_slack\_webhook\_url](#input\_slack\_notify\_lambda\_slack\_webhook\_url) | Value of SLACK\_WEB\_HOOK\_URL for the slack notify lambda. | `string` | n/a | yes |
 | <a name="input_slack_web_hook_url"></a> [slack\_web\_hook\_url](#input\_slack\_web\_hook\_url) | Value of SLACK\_WEB\_HOOK\_URL for the backend. | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to resources. | `map(string)` | <pre>{<br>  "Billing": "TRN.HMR11896",<br>  "Environment": "development",<br>  "Project": "trade-tariff",<br>  "Terraform": true<br>}</pre> | no |
 | <a name="input_tariff_backend_differences_to_emails"></a> [tariff\_backend\_differences\_to\_emails](#input\_tariff\_backend\_differences\_to\_emails) | Differences report TO email addresses. | `string` | n/a | yes |

--- a/environments/development/common/iam.tf
+++ b/environments/development/common/iam.tf
@@ -110,9 +110,21 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
         Effect = "Allow",
         Action = [
           "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "logs:DeleteLogGroup",
           "logs:TagResource",
           "logs:DescribeLogGroups",
           "logs:DescribeLogStreams"
+        ],
+        Resource = "*"
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "cloudwatch:PutMetricAlarm",
+          "cloudwatch:DescribeAlarms",
+          "cloudwatch:DeleteAlarms"
         ],
         Resource = "*"
       },

--- a/environments/development/common/secrets.tf
+++ b/environments/development/common/secrets.tf
@@ -293,3 +293,11 @@ module "fpo_search_sentry_dsn" {
   recovery_window = 7
   secret_string   = var.fpo_search_sentry_dsn
 }
+
+module "slack_notify_lambda_slack_webhook_url" {
+  source          = "../../common/secret/"
+  name            = "slack-notify-lambda-slack-webhook-url"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.slack_notify_lambda_slack_webhook_url
+}

--- a/environments/development/common/slack-notify.tf
+++ b/environments/development/common/slack-notify.tf
@@ -6,7 +6,7 @@ module "notify_slack" {
   lambda_function_name = "notify_slack_${var.environment}"
   sns_topic_name       = "slack-topic"
 
-  slack_webhook_url = module.slack_notify_lambda_slack_webhook_url.secret_string
+  slack_webhook_url = var.slack_notify_lambda_slack_webhook_url
   slack_channel     = "trade-tariff-cloudwatch-alarms"
   slack_username    = "@here"
 

--- a/environments/development/common/slack-notify.tf
+++ b/environments/development/common/slack-notify.tf
@@ -1,0 +1,57 @@
+module "notify_slack" {
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/aws-notify-slack?ref=aws/aws-notify-slack-v1.0.0"
+
+  enable_sns_topic_delivery_status_logs = true
+
+  lambda_function_name = "notify_slack_${var.environment}"
+  sns_topic_name       = "slack-topic"
+
+  slack_webhook_url = module.slack_notify_lambda_slack_webhook_url.secret_string
+  slack_channel     = "trade-tariff-cloudwatch-alarms"
+  slack_username    = "@here"
+
+  lambda_description = "Lambda function which sends notifications to Slack"
+  log_events         = true
+}
+
+resource "aws_cloudwatch_metric_alarm" "high_5xx_codes" {
+  alarm_name          = "High-5xx-errors"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "HTTPCode_ELB_5XX_Count"
+  namespace           = "AWS/ApplicationELB"
+  period              = "300"
+  statistic           = "Average"
+  unit                = "Count"
+  threshold           = 10
+  alarm_description   = "Too many HTTP 5xx errors"
+  treat_missing_data  = "missing"
+
+  alarm_actions = [module.notify_slack[var.environment].slack_topic_arn]
+  ok_actions    = [module.notify_slack[var.environment].slack_topic_arn]
+
+  dimensions = {
+    LoadBalancer = module.alb.arn_suffix
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "long_response_times" {
+  alarm_name          = "Long-response-times"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "TargetResponseTime"
+  namespace           = "AWS/ApplicationELB"
+  period              = "300"
+  statistic           = "Average"
+  unit                = "Seconds"
+  threshold           = 0.6
+  alarm_description   = "Long response times"
+  treat_missing_data  = "missing"
+
+  alarm_actions = [module.notify_slack[var.environment].slack_topic_arn]
+  ok_actions    = [module.notify_slack[var.environment].slack_topic_arn]
+
+  dimensions = {
+    LoadBalancer = module.alb.arn_suffix
+  }
+}

--- a/environments/development/common/slack-notify.tf
+++ b/environments/development/common/slack-notify.tf
@@ -27,8 +27,8 @@ resource "aws_cloudwatch_metric_alarm" "high_5xx_codes" {
   alarm_description   = "Too many HTTP 5xx errors"
   treat_missing_data  = "missing"
 
-  alarm_actions = [module.notify_slack[var.environment].slack_topic_arn]
-  ok_actions    = [module.notify_slack[var.environment].slack_topic_arn]
+  alarm_actions = [module.notify_slack.slack_topic_arn]
+  ok_actions    = [module.notify_slack.slack_topic_arn]
 
   dimensions = {
     LoadBalancer = module.alb.arn_suffix
@@ -48,8 +48,8 @@ resource "aws_cloudwatch_metric_alarm" "long_response_times" {
   alarm_description   = "Long response times"
   treat_missing_data  = "missing"
 
-  alarm_actions = [module.notify_slack[var.environment].slack_topic_arn]
-  ok_actions    = [module.notify_slack[var.environment].slack_topic_arn]
+  alarm_actions = [module.notify_slack.slack_topic_arn]
+  ok_actions    = [module.notify_slack.slack_topic_arn]
 
   dimensions = {
     LoadBalancer = module.alb.arn_suffix

--- a/environments/development/common/variables.tf
+++ b/environments/development/common/variables.tf
@@ -273,3 +273,9 @@ variable "backups_basic_auth" {
   type        = string
   sensitive   = true
 }
+
+variable "slack_notify_lambda_slack_webhook_url" {
+  description = "Value of SLACK_WEB_HOOK_URL for the slack notify lambda."
+  type        = string
+  sensitive   = true
+}

--- a/environments/production/common/README.md
+++ b/environments/production/common/README.md
@@ -75,6 +75,7 @@
 | <a name="module_search_configuration_bucket"></a> [search\_configuration\_bucket](#module\_search\_configuration\_bucket) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v3.14.0 |
 | <a name="module_search_query_parser_sentry_dsn"></a> [search\_query\_parser\_sentry\_dsn](#module\_search\_query\_parser\_sentry\_dsn) | ../../common/secret/ | n/a |
 | <a name="module_ses"></a> [ses](#module\_ses) | ../../common/ses | n/a |
+| <a name="module_slack_notify_lambda_slack_webhook_url"></a> [slack\_notify\_lambda\_slack\_webhook\_url](#module\_slack\_notify\_lambda\_slack\_webhook\_url) | ../../common/secret/ | n/a |
 | <a name="module_slack_web_hook_url"></a> [slack\_web\_hook\_url](#module\_slack\_web\_hook\_url) | ../../common/secret/ | n/a |
 | <a name="module_tech_docs_cdn"></a> [tech\_docs\_cdn](#module\_tech\_docs\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.4.2 |
 | <a name="module_waf"></a> [waf](#module\_waf) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/waf | aws/waf-v1.2.3 |
@@ -92,10 +93,7 @@
 | [aws_cloudfront_response_headers_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_response_headers_policy) | resource |
 | [aws_cloudwatch_log_group.redis_engine_lg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.redis_slow_lg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
-| [aws_cloudwatch_metric_alarm.dns_alarm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
-| [aws_cloudwatch_metric_alarm.high_4xx_codes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.high_5xx_codes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
-| [aws_cloudwatch_metric_alarm.high_connections_refused](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.long_response_times](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_ecr_repository_policy.ecr_allow_staging_and_development](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository_policy) | resource |
 | [aws_elasticache_subnet_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_subnet_group) | resource |
@@ -135,7 +133,6 @@
 | [aws_kms_key.secretsmanager_kms_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_kms_key_policy.logs_bucket_kms_key_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key_policy) | resource |
 | [aws_kms_key_policy.s3_kms_key_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key_policy) | resource |
-| [aws_route53_health_check.dns_health_check](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_health_check) | resource |
 | [aws_route53_record.cognito_custom_domain](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.dev_name_servers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.google_site_verification](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
@@ -171,7 +168,6 @@
 | [aws_iam_policy_document.s3_kms_key_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.tech_docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
-| [aws_secretsmanager_secret_version.slack](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 | [terraform_remote_state.base](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.development](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.staging](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
@@ -201,6 +197,7 @@
 | <a name="input_frontend_sentry_dsn"></a> [frontend\_sentry\_dsn](#input\_frontend\_sentry\_dsn) | Value of SENTRY\_DSN for the frontend. | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region to use. Defaults to `eu-west-2`. | `string` | `"eu-west-2"` | no |
 | <a name="input_search_query_parser_sentry_dsn"></a> [search\_query\_parser\_sentry\_dsn](#input\_search\_query\_parser\_sentry\_dsn) | Value of SENTRY\_DSN for the search query parser. | `string` | n/a | yes |
+| <a name="input_slack_notify_lambda_slack_webhook_url"></a> [slack\_notify\_lambda\_slack\_webhook\_url](#input\_slack\_notify\_lambda\_slack\_webhook\_url) | Value of SLACK\_WEB\_HOOK\_URL for the slack notify lambda. | `string` | n/a | yes |
 | <a name="input_slack_web_hook_url"></a> [slack\_web\_hook\_url](#input\_slack\_web\_hook\_url) | Value of SLACK\_WEB\_HOOK\_URL for the backend. | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to resources. | `map(string)` | <pre>{<br>  "Billing": "TRN.HMR11896",<br>  "Environment": "production",<br>  "Project": "trade-tariff",<br>  "Terraform": true<br>}</pre> | no |
 | <a name="input_tariff_backend_differences_to_emails"></a> [tariff\_backend\_differences\_to\_emails](#input\_tariff\_backend\_differences\_to\_emails) | Differences report TO email addresses. | `string` | n/a | yes |

--- a/environments/production/common/iam.tf
+++ b/environments/production/common/iam.tf
@@ -110,9 +110,21 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
         Effect = "Allow",
         Action = [
           "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "logs:DeleteLogGroup",
           "logs:TagResource",
           "logs:DescribeLogGroups",
           "logs:DescribeLogStreams"
+        ],
+        Resource = "*"
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "cloudwatch:PutMetricAlarm",
+          "cloudwatch:DescribeAlarms",
+          "cloudwatch:DeleteAlarms"
         ],
         Resource = "*"
       },

--- a/environments/production/common/secrets.tf
+++ b/environments/production/common/secrets.tf
@@ -246,3 +246,11 @@ module "fpo_search_sentry_dsn" {
   recovery_window = 7
   secret_string   = var.fpo_search_sentry_dsn
 }
+
+module "slack_notify_lambda_slack_webhook_url" {
+  source          = "../../common/secret/"
+  name            = "slack-notify-lambda-slack-webhook-url"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.slack_notify_lambda_slack_webhook_url
+}

--- a/environments/production/common/slack-notify.tf
+++ b/environments/production/common/slack-notify.tf
@@ -101,10 +101,10 @@ resource "aws_cloudwatch_metric_alarm" "long_response_times" {
   evaluation_periods  = "2"
   metric_name         = "TargetResponseTime"
   namespace           = "AWS/ApplicationELB"
-  period              = "60"
+  period              = "300"
   statistic           = "Average"
   unit                = "Seconds"
-  threshold           = 0.2
+  threshold           = 0.6
   alarm_description   = "Long response times"
   treat_missing_data  = "missing"
 

--- a/environments/production/common/slack-notify.tf
+++ b/environments/production/common/slack-notify.tf
@@ -6,7 +6,7 @@ module "notify_slack" {
   lambda_function_name = "notify_slack_${var.environment}"
   sns_topic_name       = "slack-topic"
 
-  slack_webhook_url = module.slack_notify_lambda_slack_webhook_url.secret_string
+  slack_webhook_url = var.slack_notify_lambda_slack_webhook_url
   slack_channel     = "trade-tariff-cloudwatch-alarms"
   slack_username    = "@here"
 

--- a/environments/production/common/slack-notify.tf
+++ b/environments/production/common/slack-notify.tf
@@ -1,35 +1,17 @@
-data "aws_secretsmanager_secret_version" "slack" {
-  secret_id = "slack"
-}
-
-locals {
-  slack = jsondecode(
-    data.aws_secretsmanager_secret_version.slack.secret_string
-  )
-}
-
 module "notify_slack" {
   source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/aws-notify-slack?ref=aws/aws-notify-slack-v1.0.0"
 
-  for_each = toset([
-    "production"
-  ])
-
   enable_sns_topic_delivery_status_logs = true
 
-  lambda_function_name = "notify_slack_${each.value}"
+  lambda_function_name = "notify_slack_${var.environment}"
   sns_topic_name       = "slack-topic"
 
-  slack_webhook_url = local.slack.webhook_url
+  slack_webhook_url = module.slack_notify_lambda_slack_webhook_url.secret_string
   slack_channel     = "trade-tariff-cloudwatch-alarms"
   slack_username    = "@here"
 
   lambda_description = "Lambda function which sends notifications to Slack"
   log_events         = true
-
-  tags = {
-    Name = "cloudwatch-alerts-to-slack"
-  }
 }
 
 resource "aws_cloudwatch_metric_alarm" "high_5xx_codes" {
@@ -38,57 +20,15 @@ resource "aws_cloudwatch_metric_alarm" "high_5xx_codes" {
   evaluation_periods  = "1"
   metric_name         = "HTTPCode_ELB_5XX_Count"
   namespace           = "AWS/ApplicationELB"
-  period              = "60"
-  statistic           = "Sum"
+  period              = "300"
+  statistic           = "Average"
   unit                = "Count"
-  threshold           = 2
+  threshold           = 10
   alarm_description   = "Too many HTTP 5xx errors"
   treat_missing_data  = "missing"
 
-  alarm_actions = [module.notify_slack["production"].slack_topic_arn]
-  ok_actions    = [module.notify_slack["production"].slack_topic_arn]
-
-  dimensions = {
-    LoadBalancer = module.alb.arn_suffix
-  }
-}
-
-resource "aws_cloudwatch_metric_alarm" "high_4xx_codes" {
-  alarm_name          = "High-4xx-errors"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "2"
-  metric_name         = "HTTPCode_ELB_4XX_Count"
-  namespace           = "AWS/ApplicationELB"
-  period              = "120"
-  statistic           = "Sum"
-  unit                = "Count"
-  threshold           = 3
-  alarm_description   = "Too many HTTP 4xx errors"
-  treat_missing_data  = "missing"
-
-  alarm_actions = [module.notify_slack["production"].slack_topic_arn]
-  ok_actions    = [module.notify_slack["production"].slack_topic_arn]
-
-  dimensions = {
-    LoadBalancer = module.alb.arn_suffix
-  }
-}
-
-resource "aws_cloudwatch_metric_alarm" "high_connections_refused" {
-  alarm_name          = "High-connections-refused"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "5"
-  metric_name         = "RejectedConnectionCount"
-  namespace           = "AWS/ApplicationELB"
-  period              = "60"
-  statistic           = "Sum"
-  unit                = "Count"
-  threshold           = 2
-  alarm_description   = "Too many connection refused errors"
-  treat_missing_data  = "missing"
-
-  alarm_actions = [module.notify_slack["production"].slack_topic_arn]
-  ok_actions    = [module.notify_slack["production"].slack_topic_arn]
+  alarm_actions = [module.notify_slack[var.environment].slack_topic_arn]
+  ok_actions    = [module.notify_slack[var.environment].slack_topic_arn]
 
   dimensions = {
     LoadBalancer = module.alb.arn_suffix
@@ -108,40 +48,10 @@ resource "aws_cloudwatch_metric_alarm" "long_response_times" {
   alarm_description   = "Long response times"
   treat_missing_data  = "missing"
 
-  alarm_actions = [module.notify_slack["production"].slack_topic_arn]
-  ok_actions    = [module.notify_slack["production"].slack_topic_arn]
+  alarm_actions = [module.notify_slack[var.environment].slack_topic_arn]
+  ok_actions    = [module.notify_slack[var.environment].slack_topic_arn]
 
   dimensions = {
     LoadBalancer = module.alb.arn_suffix
-  }
-}
-
-resource "aws_route53_health_check" "dns_health_check" {
-  fqdn              = "trade-tariff.service.gov.uk"
-  port              = 443
-  type              = "HTTPS"
-  measure_latency   = true
-  request_interval  = 30
-  failure_threshold = 3
-}
-
-resource "aws_cloudwatch_metric_alarm" "dns_alarm" {
-  alarm_name                = "dns-health-check-failed"
-  comparison_operator       = "LessThanThreshold"
-  evaluation_periods        = "1"
-  metric_name               = "HealthCheckStatus"
-  namespace                 = "AWS/Route53"
-  period                    = "60"
-  statistic                 = "Minimum"
-  threshold                 = "1"
-  treat_missing_data        = "missing"
-  insufficient_data_actions = []
-
-  alarm_actions     = [module.notify_slack["production"].slack_topic_arn]
-  ok_actions        = [module.notify_slack["production"].slack_topic_arn]
-  alarm_description = "DNS resolution failed, so environment is down"
-
-  dimensions = {
-    HealthCheckId = aws_route53_health_check.dns_health_check.id
   }
 }

--- a/environments/production/common/slack-notify.tf
+++ b/environments/production/common/slack-notify.tf
@@ -27,8 +27,8 @@ resource "aws_cloudwatch_metric_alarm" "high_5xx_codes" {
   alarm_description   = "Too many HTTP 5xx errors"
   treat_missing_data  = "missing"
 
-  alarm_actions = [module.notify_slack[var.environment].slack_topic_arn]
-  ok_actions    = [module.notify_slack[var.environment].slack_topic_arn]
+  alarm_actions = [module.notify_slack.slack_topic_arn]
+  ok_actions    = [module.notify_slack.slack_topic_arn]
 
   dimensions = {
     LoadBalancer = module.alb.arn_suffix
@@ -48,8 +48,8 @@ resource "aws_cloudwatch_metric_alarm" "long_response_times" {
   alarm_description   = "Long response times"
   treat_missing_data  = "missing"
 
-  alarm_actions = [module.notify_slack[var.environment].slack_topic_arn]
-  ok_actions    = [module.notify_slack[var.environment].slack_topic_arn]
+  alarm_actions = [module.notify_slack.slack_topic_arn]
+  ok_actions    = [module.notify_slack.slack_topic_arn]
 
   dimensions = {
     LoadBalancer = module.alb.arn_suffix

--- a/environments/production/common/variables.tf
+++ b/environments/production/common/variables.tf
@@ -237,3 +237,9 @@ variable "backups_basic_auth" {
   type        = string
   sensitive   = true
 }
+
+variable "slack_notify_lambda_slack_webhook_url" {
+  description = "Value of SLACK_WEB_HOOK_URL for the slack notify lambda."
+  type        = string
+  sensitive   = true
+}

--- a/environments/staging/common/README.md
+++ b/environments/staging/common/README.md
@@ -64,6 +64,7 @@
 | <a name="module_frontend_sentry_dsn"></a> [frontend\_sentry\_dsn](#module\_frontend\_sentry\_dsn) | ../../common/secret/ | n/a |
 | <a name="module_logs"></a> [logs](#module\_logs) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v3.14.0 |
 | <a name="module_mysql"></a> [mysql](#module\_mysql) | ../../common/rds | n/a |
+| <a name="module_notify_slack"></a> [notify\_slack](#module\_notify\_slack) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/aws-notify-slack | aws/aws-notify-slack-v1.0.0 |
 | <a name="module_opensearch"></a> [opensearch](#module\_opensearch) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/opensearch | aws/opensearch-v1.2.0 |
 | <a name="module_opensearch_packages_bucket"></a> [opensearch\_packages\_bucket](#module\_opensearch\_packages\_bucket) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v3.14.0 |
 | <a name="module_postgres"></a> [postgres](#module\_postgres) | ../../common/rds | n/a |
@@ -80,6 +81,7 @@
 | <a name="module_signon_devise_secret_key"></a> [signon\_devise\_secret\_key](#module\_signon\_devise\_secret\_key) | ../../common/secret/ | n/a |
 | <a name="module_signon_govuk_notify_api_key"></a> [signon\_govuk\_notify\_api\_key](#module\_signon\_govuk\_notify\_api\_key) | ../../common/secret/ | n/a |
 | <a name="module_signon_secret_key_base"></a> [signon\_secret\_key\_base](#module\_signon\_secret\_key\_base) | ../../common/secret/ | n/a |
+| <a name="module_slack_notify_lambda_slack_webhook_url"></a> [slack\_notify\_lambda\_slack\_webhook\_url](#module\_slack\_notify\_lambda\_slack\_webhook\_url) | ../../common/secret/ | n/a |
 | <a name="module_slack_web_hook_url"></a> [slack\_web\_hook\_url](#module\_slack\_web\_hook\_url) | ../../common/secret/ | n/a |
 | <a name="module_tech_docs_cdn"></a> [tech\_docs\_cdn](#module\_tech\_docs\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.4.2 |
 | <a name="module_waf"></a> [waf](#module\_waf) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/waf | aws/waf-v1.2.3 |
@@ -97,6 +99,8 @@
 | [aws_cloudfront_response_headers_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_response_headers_policy) | resource |
 | [aws_cloudwatch_log_group.redis_engine_lg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.redis_slow_lg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_cloudwatch_metric_alarm.high_5xx_codes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.long_response_times](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_elasticache_subnet_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_subnet_group) | resource |
 | [aws_iam_policy.ci_appendix5a_peristence_readwrite_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.ci_lambda_deployment_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
@@ -189,6 +193,7 @@
 | <a name="input_signon_devise_secret_key"></a> [signon\_devise\_secret\_key](#input\_signon\_devise\_secret\_key) | Value of DEVISE\_SECRET\_KEY for the signon app. | `string` | n/a | yes |
 | <a name="input_signon_govuk_notify_api_key"></a> [signon\_govuk\_notify\_api\_key](#input\_signon\_govuk\_notify\_api\_key) | Value of GOVUK\_NOTIFY\_API\_KEY for the signon app. | `string` | n/a | yes |
 | <a name="input_signon_secret_key_base"></a> [signon\_secret\_key\_base](#input\_signon\_secret\_key\_base) | Value of SECRET\_KEY\_BASE for the signon app. | `string` | n/a | yes |
+| <a name="input_slack_notify_lambda_slack_webhook_url"></a> [slack\_notify\_lambda\_slack\_webhook\_url](#input\_slack\_notify\_lambda\_slack\_webhook\_url) | Value of SLACK\_WEB\_HOOK\_URL for the slack notify lambda. | `string` | n/a | yes |
 | <a name="input_slack_web_hook_url"></a> [slack\_web\_hook\_url](#input\_slack\_web\_hook\_url) | Value of SLACK\_WEB\_HOOK\_URL for the backend. | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to resources. | `map(string)` | <pre>{<br>  "Billing": "TRN.HMR11896",<br>  "Environment": "staging",<br>  "Project": "trade-tariff",<br>  "Terraform": true<br>}</pre> | no |
 | <a name="input_tariff_backend_differences_to_emails"></a> [tariff\_backend\_differences\_to\_emails](#input\_tariff\_backend\_differences\_to\_emails) | Differences report TO email addresses. | `string` | n/a | yes |

--- a/environments/staging/common/iam.tf
+++ b/environments/staging/common/iam.tf
@@ -110,9 +110,21 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
         Effect = "Allow",
         Action = [
           "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "logs:DeleteLogGroup",
           "logs:TagResource",
           "logs:DescribeLogGroups",
           "logs:DescribeLogStreams"
+        ],
+        Resource = "*"
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "cloudwatch:PutMetricAlarm",
+          "cloudwatch:DescribeAlarms",
+          "cloudwatch:DeleteAlarms"
         ],
         Resource = "*"
       },

--- a/environments/staging/common/secrets.tf
+++ b/environments/staging/common/secrets.tf
@@ -293,3 +293,11 @@ module "fpo_search_sentry_dsn" {
   recovery_window = 7
   secret_string   = var.fpo_search_sentry_dsn
 }
+
+module "slack_notify_lambda_slack_webhook_url" {
+  source          = "../../common/secret/"
+  name            = "slack-notify-lambda-slack-webhook-url"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.slack_notify_lambda_slack_webhook_url
+}

--- a/environments/staging/common/slack-notify.tf
+++ b/environments/staging/common/slack-notify.tf
@@ -6,7 +6,7 @@ module "notify_slack" {
   lambda_function_name = "notify_slack_${var.environment}"
   sns_topic_name       = "slack-topic"
 
-  slack_webhook_url = module.slack_notify_lambda_slack_webhook_url.secret_string
+  slack_webhook_url = var.slack_notify_lambda_slack_webhook_url
   slack_channel     = "trade-tariff-cloudwatch-alarms"
   slack_username    = "@here"
 

--- a/environments/staging/common/slack-notify.tf
+++ b/environments/staging/common/slack-notify.tf
@@ -1,0 +1,57 @@
+module "notify_slack" {
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/aws-notify-slack?ref=aws/aws-notify-slack-v1.0.0"
+
+  enable_sns_topic_delivery_status_logs = true
+
+  lambda_function_name = "notify_slack_${var.environment}"
+  sns_topic_name       = "slack-topic"
+
+  slack_webhook_url = module.slack_notify_lambda_slack_webhook_url.secret_string
+  slack_channel     = "trade-tariff-cloudwatch-alarms"
+  slack_username    = "@here"
+
+  lambda_description = "Lambda function which sends notifications to Slack"
+  log_events         = true
+}
+
+resource "aws_cloudwatch_metric_alarm" "high_5xx_codes" {
+  alarm_name          = "High-5xx-errors"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "HTTPCode_ELB_5XX_Count"
+  namespace           = "AWS/ApplicationELB"
+  period              = "300"
+  statistic           = "Average"
+  unit                = "Count"
+  threshold           = 10
+  alarm_description   = "Too many HTTP 5xx errors"
+  treat_missing_data  = "missing"
+
+  alarm_actions = [module.notify_slack[var.environment].slack_topic_arn]
+  ok_actions    = [module.notify_slack[var.environment].slack_topic_arn]
+
+  dimensions = {
+    LoadBalancer = module.alb.arn_suffix
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "long_response_times" {
+  alarm_name          = "Long-response-times"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "TargetResponseTime"
+  namespace           = "AWS/ApplicationELB"
+  period              = "300"
+  statistic           = "Average"
+  unit                = "Seconds"
+  threshold           = 0.6
+  alarm_description   = "Long response times"
+  treat_missing_data  = "missing"
+
+  alarm_actions = [module.notify_slack[var.environment].slack_topic_arn]
+  ok_actions    = [module.notify_slack[var.environment].slack_topic_arn]
+
+  dimensions = {
+    LoadBalancer = module.alb.arn_suffix
+  }
+}

--- a/environments/staging/common/slack-notify.tf
+++ b/environments/staging/common/slack-notify.tf
@@ -27,8 +27,8 @@ resource "aws_cloudwatch_metric_alarm" "high_5xx_codes" {
   alarm_description   = "Too many HTTP 5xx errors"
   treat_missing_data  = "missing"
 
-  alarm_actions = [module.notify_slack[var.environment].slack_topic_arn]
-  ok_actions    = [module.notify_slack[var.environment].slack_topic_arn]
+  alarm_actions = [module.notify_slack.slack_topic_arn]
+  ok_actions    = [module.notify_slack.slack_topic_arn]
 
   dimensions = {
     LoadBalancer = module.alb.arn_suffix
@@ -48,8 +48,8 @@ resource "aws_cloudwatch_metric_alarm" "long_response_times" {
   alarm_description   = "Long response times"
   treat_missing_data  = "missing"
 
-  alarm_actions = [module.notify_slack[var.environment].slack_topic_arn]
-  ok_actions    = [module.notify_slack[var.environment].slack_topic_arn]
+  alarm_actions = [module.notify_slack.slack_topic_arn]
+  ok_actions    = [module.notify_slack.slack_topic_arn]
 
   dimensions = {
     LoadBalancer = module.alb.arn_suffix

--- a/environments/staging/common/variables.tf
+++ b/environments/staging/common/variables.tf
@@ -273,3 +273,9 @@ variable "backups_basic_auth" {
   type        = string
   sensitive   = true
 }
+
+variable "slack_notify_lambda_slack_webhook_url" {
+  description = "Value of SLACK_WEB_HOOK_URL for the slack notify lambda."
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
# Jira link

FPO-183

## What?

I have:

- Replicated slack-notify lambda into lower environments
- Fixed super noisy alarms that lead to signal fatigue
- Extended lambda deployment user IAM policy to be able to create alarms and have them register against the slack topic

## Why?

I am doing this because:

- People have ended up muting the channel since we were getting lots of
notifications for what are ultimately acceptable request times
- The original times would be comfortable low water marks but not high water marks
- For validation before we make changes straight to production
