### PR TITLE
BAU: Enable more tolerant alarms to reflect regular cache refresh

### DIFF
--- a/environments/development/common/slack-notify.tf
+++ b/environments/development/common/slack-notify.tf
@@ -44,7 +44,7 @@ resource "aws_cloudwatch_metric_alarm" "long_response_times" {
   period              = "300"
   statistic           = "Average"
   unit                = "Seconds"
-  threshold           = 0.6
+  threshold           = 1.5
   alarm_description   = "Long response times in ${var.environment} environment"
   treat_missing_data  = "notBreaching"
 

--- a/environments/production/common/slack-notify.tf
+++ b/environments/production/common/slack-notify.tf
@@ -44,7 +44,7 @@ resource "aws_cloudwatch_metric_alarm" "long_response_times" {
   period              = "300"
   statistic           = "Average"
   unit                = "Seconds"
-  threshold           = 0.6
+  threshold           = 1.5
   alarm_description   = "Long response times in ${var.environment} environment"
   treat_missing_data  = "notBreaching"
 

--- a/environments/staging/common/slack-notify.tf
+++ b/environments/staging/common/slack-notify.tf
@@ -44,7 +44,7 @@ resource "aws_cloudwatch_metric_alarm" "long_response_times" {
   period              = "300"
   statistic           = "Average"
   unit                = "Seconds"
-  threshold           = 0.6
+  threshold           = 1.5
   alarm_description   = "Long response times in ${var.environment} environment"
   treat_missing_data  = "notBreaching"
 


### PR DESCRIPTION
# Jira link

BAU

## What?

I have:

- Altered alarm thresholds for long response times

## Why?

I am doing this because:

- This is to reflect what is occasinally normal for our ALB service overall
