### PR TITLE
BAU: Add Cognito Client ID to SecretsManager

### DIFF
--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -74,6 +74,7 @@ No outputs.
 | <a name="module_cdn"></a> [cdn](#module\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.4.2 |
 | <a name="module_cloudwatch"></a> [cloudwatch](#module\_cloudwatch) | ../../common/cloudwatch/ | n/a |
 | <a name="module_cloudwatch-logs-exporter"></a> [cloudwatch-logs-exporter](#module\_cloudwatch-logs-exporter) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudwatch_log_exporter | aws/cloudwatch_log_exporter-v1.0.0 |
+| <a name="module_cognito_client_id"></a> [cognito\_client\_id](#module\_cognito\_client\_id) | ../../common/secret/ | n/a |
 | <a name="module_cognito_client_secret"></a> [cognito\_client\_secret](#module\_cognito\_client\_secret) | ../../common/secret/ | n/a |
 | <a name="module_dev_hub_backend_encryption_key"></a> [dev\_hub\_backend\_encryption\_key](#module\_dev\_hub\_backend\_encryption\_key) | ../../common/secret/ | n/a |
 | <a name="module_dev_hub_backend_sentry_dsn"></a> [dev\_hub\_backend\_sentry\_dsn](#module\_dev\_hub\_backend\_sentry\_dsn) | ../../common/secret/ | n/a |

--- a/environments/development/common/cognito.tf
+++ b/environments/development/common/cognito.tf
@@ -40,6 +40,14 @@ resource "aws_ssm_parameter" "cognito_public_keys" {
   value       = module.dev_hub_cognito.user_pool_public_keys_url
 }
 
+module "cognito_client_id" {
+  source          = "../../common/secret/"
+  name            = "cognito-fpo-client-id"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = module.dev_hub_cognito.client_id
+}
+
 module "cognito_client_secret" {
   source          = "../../common/secret/"
   name            = "cognito-fpo-client-secret"

--- a/environments/production/common/README.md
+++ b/environments/production/common/README.md
@@ -51,6 +51,7 @@
 | <a name="module_cdn"></a> [cdn](#module\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.4.2 |
 | <a name="module_cloudwatch"></a> [cloudwatch](#module\_cloudwatch) | ../../common/cloudwatch/ | n/a |
 | <a name="module_cloudwatch-logs-exporter"></a> [cloudwatch-logs-exporter](#module\_cloudwatch-logs-exporter) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudwatch_log_exporter | aws/cloudwatch_log_exporter-v1.0.0 |
+| <a name="module_cognito_client_id"></a> [cognito\_client\_id](#module\_cognito\_client\_id) | ../../common/secret/ | n/a |
 | <a name="module_cognito_client_secret"></a> [cognito\_client\_secret](#module\_cognito\_client\_secret) | ../../common/secret/ | n/a |
 | <a name="module_dev_hub_backend_encryption_key"></a> [dev\_hub\_backend\_encryption\_key](#module\_dev\_hub\_backend\_encryption\_key) | ../../common/secret/ | n/a |
 | <a name="module_dev_hub_backend_sentry_dsn"></a> [dev\_hub\_backend\_sentry\_dsn](#module\_dev\_hub\_backend\_sentry\_dsn) | ../../common/secret/ | n/a |

--- a/environments/production/common/cognito.tf
+++ b/environments/production/common/cognito.tf
@@ -40,6 +40,14 @@ resource "aws_ssm_parameter" "cognito_public_keys" {
   value       = module.dev_hub_cognito.user_pool_public_keys_url
 }
 
+module "cognito_client_id" {
+  source          = "../../common/secret/"
+  name            = "cognito-fpo-client-id"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = module.dev_hub_cognito.client_id
+}
+
 module "cognito_client_secret" {
   source          = "../../common/secret/"
   name            = "cognito-fpo-client-secret"

--- a/environments/staging/common/README.md
+++ b/environments/staging/common/README.md
@@ -51,6 +51,7 @@
 | <a name="module_cdn"></a> [cdn](#module\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.4.2 |
 | <a name="module_cloudwatch"></a> [cloudwatch](#module\_cloudwatch) | ../../common/cloudwatch/ | n/a |
 | <a name="module_cloudwatch-logs-exporter"></a> [cloudwatch-logs-exporter](#module\_cloudwatch-logs-exporter) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudwatch_log_exporter | aws/cloudwatch_log_exporter-v1.0.0 |
+| <a name="module_cognito_client_id"></a> [cognito\_client\_id](#module\_cognito\_client\_id) | ../../common/secret/ | n/a |
 | <a name="module_cognito_client_secret"></a> [cognito\_client\_secret](#module\_cognito\_client\_secret) | ../../common/secret/ | n/a |
 | <a name="module_dev_hub_backend_encryption_key"></a> [dev\_hub\_backend\_encryption\_key](#module\_dev\_hub\_backend\_encryption\_key) | ../../common/secret/ | n/a |
 | <a name="module_dev_hub_backend_sentry_dsn"></a> [dev\_hub\_backend\_sentry\_dsn](#module\_dev\_hub\_backend\_sentry\_dsn) | ../../common/secret/ | n/a |

--- a/environments/staging/common/cognito.tf
+++ b/environments/staging/common/cognito.tf
@@ -40,6 +40,14 @@ resource "aws_ssm_parameter" "cognito_public_keys" {
   value       = module.dev_hub_cognito.user_pool_public_keys_url
 }
 
+module "cognito_client_id" {
+  source          = "../../common/secret/"
+  name            = "cognito-fpo-client-id"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = module.dev_hub_cognito.client_id
+}
+
 module "cognito_client_secret" {
   source          = "../../common/secret/"
   name            = "cognito-fpo-client-secret"


### PR DESCRIPTION
## What?

I have:

- Added the Cognito client ID to secrets manager.

## Why?

I am doing this because:

- This is needed in the developer hub to be able to request a JWT from AWS Cognito.