### PR TITLE
BAU: Allow attaching/detaching role policies on lambda deployment user

### DIFF
--- a/environments/development/common/iam.tf
+++ b/environments/development/common/iam.tf
@@ -102,7 +102,9 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
           "iam:GetRolePolicy",
           "iam:PassRole",
           "iam:PutRolePolicy",
-          "iam:TagRole"
+          "iam:TagRole",
+          "iam:AttachRolePolicy",
+          "iam:DetachRolePolicy",
         ],
         Resource = "*"
       },

--- a/environments/production/common/iam.tf
+++ b/environments/production/common/iam.tf
@@ -102,7 +102,9 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
           "iam:GetRolePolicy",
           "iam:PassRole",
           "iam:PutRolePolicy",
-          "iam:TagRole"
+          "iam:TagRole",
+          "iam:AttachRolePolicy",
+          "iam:DetachRolePolicy",
         ],
         Resource = "*"
       },

--- a/environments/staging/common/iam.tf
+++ b/environments/staging/common/iam.tf
@@ -102,7 +102,9 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
           "iam:GetRolePolicy",
           "iam:PassRole",
           "iam:PutRolePolicy",
-          "iam:TagRole"
+          "iam:TagRole",
+          "iam:AttachRolePolicy",
+          "iam:DetachRolePolicy",
         ],
         Resource = "*"
       },


### PR DESCRIPTION
# Jira link

BAU

## What?

I have:

- Added ability for the lambda deployment user to attach/detach iam role policies

## Why?

I am doing this because:

- This is needed to deploy the status-checks serverless function
