### PR TITLE
BAU: Make staging reflect production

### DIFF
--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -237,7 +237,7 @@ No outputs.
 | <a name="input_tariff_backend_xi_sync_host"></a> [tariff\_backend\_xi\_sync\_host](#input\_tariff\_backend\_xi\_sync\_host) | Value of Tariff Sync host. | `string` | n/a | yes |
 | <a name="input_tariff_backend_xi_sync_password"></a> [tariff\_backend\_xi\_sync\_password](#input\_tariff\_backend\_xi\_sync\_password) | Value of Tariff Sync password. | `string` | n/a | yes |
 | <a name="input_tariff_backend_xi_sync_username"></a> [tariff\_backend\_xi\_sync\_username](#input\_tariff\_backend\_xi\_sync\_username) | Value of Tariff Sync username. | `string` | n/a | yes |
-| <a name="input_waf_rpm_limit"></a> [waf\_rpm\_limit](#input\_waf\_rpm\_limit) | Request per minute limit for the WAF. | `number` | `500` | no |
+| <a name="input_waf_rpm_limit"></a> [waf\_rpm\_limit](#input\_waf\_rpm\_limit) | Request per minute limit for the WAF. | `number` | `2000` | no |
 
 ## Outputs
 

--- a/environments/development/common/variables.tf
+++ b/environments/development/common/variables.tf
@@ -39,7 +39,7 @@ variable "tags" {
 variable "waf_rpm_limit" {
   description = "Request per minute limit for the WAF."
   type        = number
-  default     = 500
+  default     = 2000
 }
 
 #

--- a/environments/staging/common/README.md
+++ b/environments/staging/common/README.md
@@ -214,7 +214,7 @@
 | <a name="input_tariff_backend_xi_sync_host"></a> [tariff\_backend\_xi\_sync\_host](#input\_tariff\_backend\_xi\_sync\_host) | Value of Tariff Sync host. | `string` | n/a | yes |
 | <a name="input_tariff_backend_xi_sync_password"></a> [tariff\_backend\_xi\_sync\_password](#input\_tariff\_backend\_xi\_sync\_password) | Value of Tariff Sync password. | `string` | n/a | yes |
 | <a name="input_tariff_backend_xi_sync_username"></a> [tariff\_backend\_xi\_sync\_username](#input\_tariff\_backend\_xi\_sync\_username) | Value of Tariff Sync username. | `string` | n/a | yes |
-| <a name="input_waf_rpm_limit"></a> [waf\_rpm\_limit](#input\_waf\_rpm\_limit) | Request per minute limit for the WAF. | `number` | `500` | no |
+| <a name="input_waf_rpm_limit"></a> [waf\_rpm\_limit](#input\_waf\_rpm\_limit) | Request per minute limit for the WAF. | `number` | `5000` | no |
 
 ## Outputs
 

--- a/environments/staging/common/variables.tf
+++ b/environments/staging/common/variables.tf
@@ -39,7 +39,7 @@ variable "tags" {
 variable "waf_rpm_limit" {
   description = "Request per minute limit for the WAF."
   type        = number
-  default     = 500
+  default     = 5000
 }
 
 #


### PR DESCRIPTION
# Jira link

## What?

I have:

- Altered WAF request per minute limits in development and staging

## Why?

I am doing this because:

- Development needs to be more permissive for performance verification
- Staging should always reflect production as much as possible
