### PR TITLE
FPO-184: Adds user to deploy status-checks page

### DIFF
--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -127,10 +127,11 @@ No outputs.
 | [aws_cloudwatch_metric_alarm.high_5xx_codes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.long_response_times](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_elasticache_subnet_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_subnet_group) | resource |
-| [aws_iam_policy.ci_appendix5a_peristence_readwrite_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.ci_appendix5a_persistence_readwrite_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.ci_lambda_deployment_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.ci_reporting_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.ci_tech_docs_peristence_readwrite_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.ci_status_checks_persistence_readwrite_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.ci_tech_docs_persistence_readwrite_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.opensearch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.breakglass](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.breakglass_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
@@ -138,11 +139,13 @@ No outputs.
 | [aws_iam_user.opensearch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_iam_user.reporting_ci](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_iam_user.serverless_lambda_ci](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
+| [aws_iam_user.status_checks_ci](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_iam_user.tech_docs_ci](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_iam_user_policy_attachment.appendix5a_ci_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
 | [aws_iam_user_policy_attachment.opensearch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
 | [aws_iam_user_policy_attachment.reporting_ci_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
 | [aws_iam_user_policy_attachment.serverless_lambda_ci_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
+| [aws_iam_user_policy_attachment.status_checks_ci_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
 | [aws_iam_user_policy_attachment.tech_docs_ci_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
 | [aws_kms_alias.logs_bucket_kms_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_alias.opensearch_kms_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
@@ -237,7 +240,7 @@ No outputs.
 | <a name="input_tariff_backend_xi_sync_host"></a> [tariff\_backend\_xi\_sync\_host](#input\_tariff\_backend\_xi\_sync\_host) | Value of Tariff Sync host. | `string` | n/a | yes |
 | <a name="input_tariff_backend_xi_sync_password"></a> [tariff\_backend\_xi\_sync\_password](#input\_tariff\_backend\_xi\_sync\_password) | Value of Tariff Sync password. | `string` | n/a | yes |
 | <a name="input_tariff_backend_xi_sync_username"></a> [tariff\_backend\_xi\_sync\_username](#input\_tariff\_backend\_xi\_sync\_username) | Value of Tariff Sync username. | `string` | n/a | yes |
-| <a name="input_waf_rpm_limit"></a> [waf\_rpm\_limit](#input\_waf\_rpm\_limit) | Request per minute limit for the WAF. | `number` | `2000` | no |
+| <a name="input_waf_rpm_limit"></a> [waf\_rpm\_limit](#input\_waf\_rpm\_limit) | Request per minute limit for the WAF. This limit applies to our main CDN distribution and applies to all aliases on that CDN. | `number` | `2000` | no |
 
 ## Outputs
 

--- a/environments/development/common/iam.tf
+++ b/environments/development/common/iam.tf
@@ -263,10 +263,10 @@ resource "aws_iam_user" "appendix5a_ci" {
 
 resource "aws_iam_user_policy_attachment" "appendix5a_ci_attachment" {
   user       = aws_iam_user.appendix5a_ci.name
-  policy_arn = aws_iam_policy.ci_appendix5a_peristence_readwrite_policy.arn
+  policy_arn = aws_iam_policy.ci_appendix5a_persistence_readwrite_policy.arn
 }
 
-resource "aws_iam_policy" "ci_appendix5a_peristence_readwrite_policy" {
+resource "aws_iam_policy" "ci_appendix5a_persistence_readwrite_policy" {
   name        = "ci-appendix5a-persistence-readwrite-policy"
   description = "Policy for CircleCI context to enable read/write access to Appendix5a persistence bucket"
 
@@ -308,10 +308,10 @@ resource "aws_iam_user" "tech_docs_ci" {
 
 resource "aws_iam_user_policy_attachment" "tech_docs_ci_attachment" {
   user       = aws_iam_user.tech_docs_ci.name
-  policy_arn = aws_iam_policy.ci_tech_docs_peristence_readwrite_policy.arn
+  policy_arn = aws_iam_policy.ci_tech_docs_persistence_readwrite_policy.arn
 }
 
-resource "aws_iam_policy" "ci_tech_docs_peristence_readwrite_policy" {
+resource "aws_iam_policy" "ci_tech_docs_persistence_readwrite_policy" {
   name        = "ci-tech-docs-persistence-readwrite-policy"
   description = "Policy for CircleCI context to enable read/write access to Tech Docs bucket"
 
@@ -331,6 +331,51 @@ resource "aws_iam_policy" "ci_tech_docs_peristence_readwrite_policy" {
         Resource = [
           "arn:aws:s3:::${aws_s3_bucket.this["tech-docs"].id}",
           "arn:aws:s3:::${aws_s3_bucket.this["tech-docs"].id}/*"
+        ]
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "kms:GenerateDataKey",
+          "kms:Decrypt"
+        ],
+        Resource = [
+          aws_kms_alias.s3_kms_alias.target_key_arn
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_user" "status_checks_ci" {
+  name = "status-checks-ci"
+}
+
+resource "aws_iam_user_policy_attachment" "status_checks_ci_attachment" {
+  user       = aws_iam_user.status_checks_ci.name
+  policy_arn = aws_iam_policy.ci_status_checks_persistence_readwrite_policy.arn
+}
+
+resource "aws_iam_policy" "ci_status_checks_persistence_readwrite_policy" {
+  name        = "ci-status-checks-persistence-readwrite-policy"
+  description = "Policy for CircleCI context to enable read/write access to Status Checks bucket"
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "s3:DeleteObject",
+          "s3:GetBucketLocation",
+          "s3:GetObject",
+          "s3:ListBucket",
+          "s3:PutObject",
+        ],
+
+        Resource = [
+          "arn:aws:s3:::${aws_s3_bucket.this["status-checks"].id}",
+          "arn:aws:s3:::${aws_s3_bucket.this["status-checks"].id}/*"
         ]
       },
       {

--- a/environments/development/common/variables.tf
+++ b/environments/development/common/variables.tf
@@ -37,7 +37,7 @@ variable "tags" {
 }
 
 variable "waf_rpm_limit" {
-  description = "Request per minute limit for the WAF."
+  description = "Request per minute limit for the WAF. This limit applies to our main CDN distribution and applies to all aliases on that CDN. "
   type        = number
   default     = 2000
 }

--- a/environments/production/common/README.md
+++ b/environments/production/common/README.md
@@ -99,12 +99,13 @@
 | [aws_cloudwatch_metric_alarm.long_response_times](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_ecr_repository_policy.ecr_allow_staging_and_development](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository_policy) | resource |
 | [aws_elasticache_subnet_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_subnet_group) | resource |
-| [aws_iam_policy.ci_appendix5a_peristence_readwrite_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.ci_appendix5a_persistence_readwrite_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.ci_cds_downloader_file_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.ci_etf_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.ci_lambda_deployment_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.ci_reporting_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.ci_tech_docs_peristence_readwrite_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.ci_status_checks_persistence_readwrite_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.ci_tech_docs_persistence_readwrite_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.opensearch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.release_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.breakglass](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
@@ -116,6 +117,7 @@
 | [aws_iam_user.releases_user](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_iam_user.reporting_ci](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_iam_user.serverless_lambda_ci](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
+| [aws_iam_user.status_checks_ci](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_iam_user.tech_docs_ci](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_iam_user_policy_attachment.appendix5a_ci_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
 | [aws_iam_user_policy_attachment.cds_downloader_file_ci_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
@@ -124,6 +126,7 @@
 | [aws_iam_user_policy_attachment.release_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
 | [aws_iam_user_policy_attachment.reporting_ci_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
 | [aws_iam_user_policy_attachment.serverless_lambda_ci_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
+| [aws_iam_user_policy_attachment.status_checks_ci_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
 | [aws_iam_user_policy_attachment.tech_docs_ci_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
 | [aws_kms_alias.logs_bucket_kms_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_alias.opensearch_kms_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
@@ -218,7 +221,7 @@
 | <a name="input_tariff_backend_xi_sync_host"></a> [tariff\_backend\_xi\_sync\_host](#input\_tariff\_backend\_xi\_sync\_host) | Value of Tariff Sync host. | `string` | n/a | yes |
 | <a name="input_tariff_backend_xi_sync_password"></a> [tariff\_backend\_xi\_sync\_password](#input\_tariff\_backend\_xi\_sync\_password) | Value of Tariff Sync password. | `string` | n/a | yes |
 | <a name="input_tariff_backend_xi_sync_username"></a> [tariff\_backend\_xi\_sync\_username](#input\_tariff\_backend\_xi\_sync\_username) | Value of Tariff Sync username. | `string` | n/a | yes |
-| <a name="input_waf_rpm_limit"></a> [waf\_rpm\_limit](#input\_waf\_rpm\_limit) | Request per minute limit for the WAF. | `number` | `5000` | no |
+| <a name="input_waf_rpm_limit"></a> [waf\_rpm\_limit](#input\_waf\_rpm\_limit) | Request per minute limit for the WAF. This limit applies to our main CDN distribution and applies to all aliases on that CDN. | `number` | `5000` | no |
 
 ## Outputs
 

--- a/environments/production/common/iam.tf
+++ b/environments/production/common/iam.tf
@@ -253,10 +253,10 @@ resource "aws_iam_user" "appendix5a_ci" {
 
 resource "aws_iam_user_policy_attachment" "appendix5a_ci_attachment" {
   user       = aws_iam_user.appendix5a_ci.name
-  policy_arn = aws_iam_policy.ci_appendix5a_peristence_readwrite_policy.arn
+  policy_arn = aws_iam_policy.ci_appendix5a_persistence_readwrite_policy.arn
 }
 
-resource "aws_iam_policy" "ci_appendix5a_peristence_readwrite_policy" {
+resource "aws_iam_policy" "ci_appendix5a_persistence_readwrite_policy" {
   name        = "ci-appendix5a-persistence-readwrite-policy"
   description = "Policy for CircleCI context to enable read/write access to Appendix5a persistence bucket"
 
@@ -444,10 +444,10 @@ resource "aws_iam_user" "tech_docs_ci" {
 
 resource "aws_iam_user_policy_attachment" "tech_docs_ci_attachment" {
   user       = aws_iam_user.tech_docs_ci.name
-  policy_arn = aws_iam_policy.ci_tech_docs_peristence_readwrite_policy.arn
+  policy_arn = aws_iam_policy.ci_tech_docs_persistence_readwrite_policy.arn
 }
 
-resource "aws_iam_policy" "ci_tech_docs_peristence_readwrite_policy" {
+resource "aws_iam_policy" "ci_tech_docs_persistence_readwrite_policy" {
   name        = "ci-tech-docs-persistence-readwrite-policy"
   description = "Policy for CircleCI context to enable read/write access to Tech Docs bucket"
 
@@ -467,6 +467,50 @@ resource "aws_iam_policy" "ci_tech_docs_peristence_readwrite_policy" {
         Resource = [
           "arn:aws:s3:::${aws_s3_bucket.this["tech-docs"].id}",
           "arn:aws:s3:::${aws_s3_bucket.this["tech-docs"].id}/*"
+        ]
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "kms:GenerateDataKey",
+          "kms:Decrypt"
+        ],
+        Resource = [
+          aws_kms_alias.s3_kms_alias.target_key_arn
+        ]
+      }
+    ]
+  })
+}
+resource "aws_iam_user" "status_checks_ci" {
+  name = "status-checks-ci"
+}
+
+resource "aws_iam_user_policy_attachment" "status_checks_ci_attachment" {
+  user       = aws_iam_user.status_checks_ci.name
+  policy_arn = aws_iam_policy.ci_status_checks_persistence_readwrite_policy.arn
+}
+
+resource "aws_iam_policy" "ci_status_checks_persistence_readwrite_policy" {
+  name        = "ci-status-checks-persistence-readwrite-policy"
+  description = "Policy for CircleCI context to enable read/write access to Status Checks bucket"
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "s3:DeleteObject",
+          "s3:GetBucketLocation",
+          "s3:GetObject",
+          "s3:ListBucket",
+          "s3:PutObject",
+        ],
+
+        Resource = [
+          "arn:aws:s3:::${aws_s3_bucket.this["status-checks"].id}",
+          "arn:aws:s3:::${aws_s3_bucket.this["status-checks"].id}/*"
         ]
       },
       {

--- a/environments/production/common/variables.tf
+++ b/environments/production/common/variables.tf
@@ -37,7 +37,7 @@ variable "tags" {
 }
 
 variable "waf_rpm_limit" {
-  description = "Request per minute limit for the WAF."
+  description = "Request per minute limit for the WAF. This limit applies to our main CDN distribution and applies to all aliases on that CDN. "
   type        = number
   default     = 5000
 }

--- a/environments/staging/common/README.md
+++ b/environments/staging/common/README.md
@@ -104,10 +104,11 @@
 | [aws_cloudwatch_metric_alarm.high_5xx_codes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.long_response_times](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_elasticache_subnet_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_subnet_group) | resource |
-| [aws_iam_policy.ci_appendix5a_peristence_readwrite_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.ci_appendix5a_persistence_readwrite_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.ci_lambda_deployment_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.ci_reporting_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.ci_tech_docs_peristence_readwrite_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.ci_status_checks_persistence_readwrite_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.ci_tech_docs_persistence_readwrite_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.opensearch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.breakglass](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.breakglass_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
@@ -115,11 +116,13 @@
 | [aws_iam_user.opensearch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_iam_user.reporting_ci](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_iam_user.serverless_lambda_ci](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
+| [aws_iam_user.status_checks_ci](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_iam_user.tech_docs_ci](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_iam_user_policy_attachment.appendix5a_ci_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
 | [aws_iam_user_policy_attachment.opensearch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
 | [aws_iam_user_policy_attachment.reporting_ci_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
 | [aws_iam_user_policy_attachment.serverless_lambda_ci_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
+| [aws_iam_user_policy_attachment.status_checks_ci_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
 | [aws_iam_user_policy_attachment.tech_docs_ci_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
 | [aws_kms_alias.logs_bucket_kms_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_alias.opensearch_kms_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
@@ -214,7 +217,7 @@
 | <a name="input_tariff_backend_xi_sync_host"></a> [tariff\_backend\_xi\_sync\_host](#input\_tariff\_backend\_xi\_sync\_host) | Value of Tariff Sync host. | `string` | n/a | yes |
 | <a name="input_tariff_backend_xi_sync_password"></a> [tariff\_backend\_xi\_sync\_password](#input\_tariff\_backend\_xi\_sync\_password) | Value of Tariff Sync password. | `string` | n/a | yes |
 | <a name="input_tariff_backend_xi_sync_username"></a> [tariff\_backend\_xi\_sync\_username](#input\_tariff\_backend\_xi\_sync\_username) | Value of Tariff Sync username. | `string` | n/a | yes |
-| <a name="input_waf_rpm_limit"></a> [waf\_rpm\_limit](#input\_waf\_rpm\_limit) | Request per minute limit for the WAF. | `number` | `5000` | no |
+| <a name="input_waf_rpm_limit"></a> [waf\_rpm\_limit](#input\_waf\_rpm\_limit) | Request per minute limit for the WAF. This limit applies to our main CDN distribution and applies to all aliases on that CDN. | `number` | `5000` | no |
 
 ## Outputs
 

--- a/environments/staging/common/iam.tf
+++ b/environments/staging/common/iam.tf
@@ -253,10 +253,10 @@ resource "aws_iam_user" "appendix5a_ci" {
 
 resource "aws_iam_user_policy_attachment" "appendix5a_ci_attachment" {
   user       = aws_iam_user.appendix5a_ci.name
-  policy_arn = aws_iam_policy.ci_appendix5a_peristence_readwrite_policy.arn
+  policy_arn = aws_iam_policy.ci_appendix5a_persistence_readwrite_policy.arn
 }
 
-resource "aws_iam_policy" "ci_appendix5a_peristence_readwrite_policy" {
+resource "aws_iam_policy" "ci_appendix5a_persistence_readwrite_policy" {
   name        = "ci-appendix5a-persistence-readwrite-policy"
   description = "Policy for CircleCI context to enable read/write access to Appendix5a persistence bucket"
 
@@ -298,10 +298,10 @@ resource "aws_iam_user" "tech_docs_ci" {
 
 resource "aws_iam_user_policy_attachment" "tech_docs_ci_attachment" {
   user       = aws_iam_user.tech_docs_ci.name
-  policy_arn = aws_iam_policy.ci_tech_docs_peristence_readwrite_policy.arn
+  policy_arn = aws_iam_policy.ci_tech_docs_persistence_readwrite_policy.arn
 }
 
-resource "aws_iam_policy" "ci_tech_docs_peristence_readwrite_policy" {
+resource "aws_iam_policy" "ci_tech_docs_persistence_readwrite_policy" {
   name        = "ci-tech-docs-persistence-readwrite-policy"
   description = "Policy for CircleCI context to enable read/write access to Tech Docs bucket"
 
@@ -321,6 +321,51 @@ resource "aws_iam_policy" "ci_tech_docs_peristence_readwrite_policy" {
         Resource = [
           "arn:aws:s3:::${aws_s3_bucket.this["tech-docs"].id}",
           "arn:aws:s3:::${aws_s3_bucket.this["tech-docs"].id}/*"
+        ]
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "kms:GenerateDataKey",
+          "kms:Decrypt"
+        ],
+        Resource = [
+          aws_kms_alias.s3_kms_alias.target_key_arn
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_user" "status_checks_ci" {
+  name = "status-checks-ci"
+}
+
+resource "aws_iam_user_policy_attachment" "status_checks_ci_attachment" {
+  user       = aws_iam_user.status_checks_ci.name
+  policy_arn = aws_iam_policy.ci_status_checks_persistence_readwrite_policy.arn
+}
+
+resource "aws_iam_policy" "ci_status_checks_persistence_readwrite_policy" {
+  name        = "ci-status-checks-persistence-readwrite-policy"
+  description = "Policy for CircleCI context to enable read/write access to Status Checks bucket"
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "s3:DeleteObject",
+          "s3:GetBucketLocation",
+          "s3:GetObject",
+          "s3:ListBucket",
+          "s3:PutObject",
+        ],
+
+        Resource = [
+          "arn:aws:s3:::${aws_s3_bucket.this["status-checks"].id}",
+          "arn:aws:s3:::${aws_s3_bucket.this["status-checks"].id}/*"
         ]
       },
       {

--- a/environments/staging/common/variables.tf
+++ b/environments/staging/common/variables.tf
@@ -37,7 +37,7 @@ variable "tags" {
 }
 
 variable "waf_rpm_limit" {
-  description = "Request per minute limit for the WAF."
+  description = "Request per minute limit for the WAF. This limit applies to our main CDN distribution and applies to all aliases on that CDN. "
   type        = number
   default     = 5000
 }


### PR DESCRIPTION
# Jira link

FPO-184

## What?

I have:

- Added a user to deploy our status checks page

## Why?

I am doing this because:

- This is needed for isolated permissions to push to our status-checks s3 bucket
