### PR TITLE
OTT-224: Disable caching in the reporting bucket

### DIFF
--- a/environments/development/common/cloudfront.tf
+++ b/environments/development/common/cloudfront.tf
@@ -230,7 +230,7 @@ module "reporting_cdn" {
       target_origin_id       = "reporting"
       viewer_protocol_policy = "redirect-to-https"
 
-      cache_policy_id            = aws_cloudfront_cache_policy.s3.id
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.s3.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
 

--- a/environments/production/common/cloudfront.tf
+++ b/environments/production/common/cloudfront.tf
@@ -231,7 +231,7 @@ module "reporting_cdn" {
       target_origin_id       = "reporting"
       viewer_protocol_policy = "redirect-to-https"
 
-      cache_policy_id            = aws_cloudfront_cache_policy.s3.id
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.s3.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
 

--- a/environments/staging/common/cloudfront.tf
+++ b/environments/staging/common/cloudfront.tf
@@ -230,7 +230,7 @@ module "reporting_cdn" {
       target_origin_id       = "reporting"
       viewer_protocol_policy = "redirect-to-https"
 
-      cache_policy_id            = aws_cloudfront_cache_policy.s3.id
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.s3.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
 


### PR DESCRIPTION
# Jira link

OTT-224

## What?

I have:

- Disabled caching in the reporting bucket CDN

## Why?

I am doing this because:

- To avoid having index.html getting a list result that is cached
