### PR TITLE
FPO-201: Adds dedicated VPC for extra-region us-east-1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,6 +92,14 @@ jobs:
             cd environments/<< parameters.environment >>/common
             terragrunt run-all apply --terragrunt-non-interactive
 
+      - run:
+          name: Terraform apply extra regions
+          command: |
+            if [ -d environments/<< parameters.environment >>/extra_regions ]; then
+              cd environments/<< parameters.environment >>/extra_regions
+              terragrunt run-all apply --terragrunt-non-interactive
+            fi
+
 workflows:
   version: 2
   deploy-to-development:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,8 +95,8 @@ jobs:
       - run:
           name: Terraform apply extra regions
           command: |
-            if [ -d environments/<< parameters.environment >>/extra_regions ]; then
-              cd environments/<< parameters.environment >>/extra_regions
+            if [ -d environments/<< parameters.environment >>/extra-regions ]; then
+              cd environments/<< parameters.environment >>/extra-regions
               terragrunt run-all apply --terragrunt-non-interactive
             fi
 

--- a/environments/development/applications/README.md
+++ b/environments/development/applications/README.md
@@ -20,7 +20,6 @@
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_ecs"></a> [ecs](#module\_ecs) | github.com/trade-tariff/terraform-aws-ecs | 57244e69abea685f7d45352abc994779b5f6d352 |
-| <a name="module_fpo-training-vpc"></a> [fpo-training-vpc](#module\_fpo-training-vpc) | github.com/terraform-aws-modules/terraform-aws-vpc | v5.5.2 |
 
 ## Resources
 
@@ -30,10 +29,7 @@
 | [aws_dynamodb_table.lock](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
 | [aws_dynamodb_table.users](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
 | [aws_kms_key.log_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
-| [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_service_discovery_private_dns_namespace.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/service_discovery_private_dns_namespace) | resource |
-| [aws_vpc_security_group_egress_rule.allow_all_outbound](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_egress_rule) | resource |
-| [aws_vpc_security_group_ingress_rule.allow_ssh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [terraform_remote_state.base](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 

--- a/environments/development/extra-regions/us-east-1/README.md
+++ b/environments/development/extra-regions/us-east-1/README.md
@@ -1,0 +1,44 @@
+# base
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | 1.5.5 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.3 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.3 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | github.com/terraform-aws-modules/terraform-aws-vpc | v5.1.2 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_vpc_security_group_egress_rule.allow_all_outbound](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_egress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.allow_ssh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_private_subnet_ids"></a> [private\_subnet\_ids](#output\_private\_subnet\_ids) | A list of the VPC's private subnets. |
+| <a name="output_private_subnets_cidr_blocks"></a> [private\_subnets\_cidr\_blocks](#output\_private\_subnets\_cidr\_blocks) | A list of cidr\_blocks of private subnets. |
+| <a name="output_public_subnet_ids"></a> [public\_subnet\_ids](#output\_public\_subnet\_ids) | A list of the VPC's public subnets. |
+| <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | VPC ID |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/environments/development/extra-regions/us-east-1/data.tf
+++ b/environments/development/extra-regions/us-east-1/data.tf
@@ -1,0 +1,1 @@
+data "aws_region" "current" {}

--- a/environments/development/extra-regions/us-east-1/locals.tf
+++ b/environments/development/extra-regions/us-east-1/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  region = data.aws_region.current.name
+}

--- a/environments/development/extra-regions/us-east-1/outputs.tf
+++ b/environments/development/extra-regions/us-east-1/outputs.tf
@@ -1,0 +1,19 @@
+output "public_subnet_ids" {
+  description = "A list of the VPC's public subnets."
+  value       = module.vpc.public_subnets
+}
+
+output "private_subnet_ids" {
+  description = "A list of the VPC's private subnets."
+  value       = module.vpc.private_subnets
+}
+
+output "vpc_id" {
+  description = "VPC ID"
+  value       = module.vpc.vpc_id
+}
+
+output "private_subnets_cidr_blocks" {
+  description = "A list of cidr_blocks of private subnets."
+  value       = module.vpc.private_subnets_cidr_blocks
+}

--- a/environments/development/extra-regions/us-east-1/outputs.tf
+++ b/environments/development/extra-regions/us-east-1/outputs.tf
@@ -1,19 +1,19 @@
-output "public_subnet_ids" {
-  description = "A list of the VPC's public subnets."
-  value       = module.vpc.public_subnets
-}
-
-output "private_subnet_ids" {
-  description = "A list of the VPC's private subnets."
-  value       = module.vpc.private_subnets
-}
-
-output "vpc_id" {
-  description = "VPC ID"
-  value       = module.vpc.vpc_id
-}
-
-output "private_subnets_cidr_blocks" {
-  description = "A list of cidr_blocks of private subnets."
-  value       = module.vpc.private_subnets_cidr_blocks
-}
+# output "public_subnet_ids" {
+#   description = "A list of the VPC's public subnets."
+#   value       = module.vpc.public_subnets
+# }
+#
+# output "private_subnet_ids" {
+#   description = "A list of the VPC's private subnets."
+#   value       = module.vpc.private_subnets
+# }
+#
+# output "vpc_id" {
+#   description = "VPC ID"
+#   value       = module.vpc.vpc_id
+# }
+#
+# output "private_subnets_cidr_blocks" {
+#   description = "A list of cidr_blocks of private subnets."
+#   value       = module.vpc.private_subnets_cidr_blocks
+# }

--- a/environments/development/extra-regions/us-east-1/outputs.tf
+++ b/environments/development/extra-regions/us-east-1/outputs.tf
@@ -1,19 +1,19 @@
-# output "public_subnet_ids" {
-#   description = "A list of the VPC's public subnets."
-#   value       = module.vpc.public_subnets
-# }
-#
-# output "private_subnet_ids" {
-#   description = "A list of the VPC's private subnets."
-#   value       = module.vpc.private_subnets
-# }
-#
-# output "vpc_id" {
-#   description = "VPC ID"
-#   value       = module.vpc.vpc_id
-# }
-#
-# output "private_subnets_cidr_blocks" {
-#   description = "A list of cidr_blocks of private subnets."
-#   value       = module.vpc.private_subnets_cidr_blocks
-# }
+output "public_subnet_ids" {
+  description = "A list of the VPC's public subnets."
+  value       = module.vpc.public_subnets
+}
+
+output "private_subnet_ids" {
+  description = "A list of the VPC's private subnets."
+  value       = module.vpc.private_subnets
+}
+
+output "vpc_id" {
+  description = "VPC ID"
+  value       = module.vpc.vpc_id
+}
+
+output "private_subnets_cidr_blocks" {
+  description = "A list of cidr_blocks of private subnets."
+  value       = module.vpc.private_subnets_cidr_blocks
+}

--- a/environments/development/extra-regions/us-east-1/security_groups.tf
+++ b/environments/development/extra-regions/us-east-1/security_groups.tf
@@ -1,0 +1,19 @@
+resource "aws_security_group" "this" {
+  name        = "trade-tariff-fpo-sg"
+  description = "Allow inbound SSH traffic"
+  vpc_id      = module.vpc.vpc_id
+}
+
+resource "aws_vpc_security_group_ingress_rule" "allow_ssh" {
+  security_group_id = aws_security_group.this.id
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "tcp"
+  from_port         = 22
+  to_port           = 22
+}
+
+resource "aws_vpc_security_group_egress_rule" "allow_all_outbound" {
+  security_group_id = aws_security_group.this.id
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "-1"
+}

--- a/environments/development/extra-regions/us-east-1/security_groups.tf
+++ b/environments/development/extra-regions/us-east-1/security_groups.tf
@@ -1,19 +1,19 @@
-# resource "aws_security_group" "ssh" {
-#   name        = "allow-ssh"
-#   description = "Allow inbound SSH traffic"
-#   vpc_id      = module.vpc.vpc_id
-# }
-#
-# resource "aws_vpc_security_group_ingress_rule" "allow_ssh" {
-#   security_group_id = aws_security_group.ssh.id
-#   cidr_ipv4         = "0.0.0.0/0"
-#   ip_protocol       = "tcp"
-#   from_port         = 22
-#   to_port           = 22
-# }
-#
-# resource "aws_vpc_security_group_egress_rule" "allow_all_outbound" {
-#   security_group_id = aws_security_group.ssh.id
-#   cidr_ipv4         = "0.0.0.0/0"
-#   ip_protocol       = "-1"
-# }
+resource "aws_security_group" "ssh" {
+  name        = "allow-ssh"
+  description = "Allow inbound SSH traffic"
+  vpc_id      = module.vpc.vpc_id
+}
+
+resource "aws_vpc_security_group_ingress_rule" "allow_ssh" {
+  security_group_id = aws_security_group.ssh.id
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "tcp"
+  from_port         = 22
+  to_port           = 22
+}
+
+resource "aws_vpc_security_group_egress_rule" "allow_all_outbound" {
+  security_group_id = aws_security_group.ssh.id
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "-1"
+}

--- a/environments/development/extra-regions/us-east-1/security_groups.tf
+++ b/environments/development/extra-regions/us-east-1/security_groups.tf
@@ -1,19 +1,19 @@
-resource "aws_security_group" "ssh" {
-  name        = "allow-ssh"
-  description = "Allow inbound SSH traffic"
-  vpc_id      = module.vpc.vpc_id
-}
-
-resource "aws_vpc_security_group_ingress_rule" "allow_ssh" {
-  security_group_id = aws_security_group.ssh.id
-  cidr_ipv4         = "0.0.0.0/0"
-  ip_protocol       = "tcp"
-  from_port         = 22
-  to_port           = 22
-}
-
-resource "aws_vpc_security_group_egress_rule" "allow_all_outbound" {
-  security_group_id = aws_security_group.ssh.id
-  cidr_ipv4         = "0.0.0.0/0"
-  ip_protocol       = "-1"
-}
+# resource "aws_security_group" "ssh" {
+#   name        = "allow-ssh"
+#   description = "Allow inbound SSH traffic"
+#   vpc_id      = module.vpc.vpc_id
+# }
+#
+# resource "aws_vpc_security_group_ingress_rule" "allow_ssh" {
+#   security_group_id = aws_security_group.ssh.id
+#   cidr_ipv4         = "0.0.0.0/0"
+#   ip_protocol       = "tcp"
+#   from_port         = 22
+#   to_port           = 22
+# }
+#
+# resource "aws_vpc_security_group_egress_rule" "allow_all_outbound" {
+#   security_group_id = aws_security_group.ssh.id
+#   cidr_ipv4         = "0.0.0.0/0"
+#   ip_protocol       = "-1"
+# }

--- a/environments/development/extra-regions/us-east-1/security_groups.tf
+++ b/environments/development/extra-regions/us-east-1/security_groups.tf
@@ -1,5 +1,5 @@
 resource "aws_security_group" "this" {
-  name        = "trade-tariff-fpo-sg"
+  name        = "allow-ssh"
   description = "Allow inbound SSH traffic"
   vpc_id      = module.vpc.vpc_id
 }

--- a/environments/development/extra-regions/us-east-1/security_groups.tf
+++ b/environments/development/extra-regions/us-east-1/security_groups.tf
@@ -1,11 +1,11 @@
-resource "aws_security_group" "this" {
+resource "aws_security_group" "ssh" {
   name        = "allow-ssh"
   description = "Allow inbound SSH traffic"
   vpc_id      = module.vpc.vpc_id
 }
 
 resource "aws_vpc_security_group_ingress_rule" "allow_ssh" {
-  security_group_id = aws_security_group.this.id
+  security_group_id = aws_security_group.ssh.id
   cidr_ipv4         = "0.0.0.0/0"
   ip_protocol       = "tcp"
   from_port         = 22
@@ -13,7 +13,7 @@ resource "aws_vpc_security_group_ingress_rule" "allow_ssh" {
 }
 
 resource "aws_vpc_security_group_egress_rule" "allow_all_outbound" {
-  security_group_id = aws_security_group.this.id
+  security_group_id = aws_security_group.ssh.id
   cidr_ipv4         = "0.0.0.0/0"
   ip_protocol       = "-1"
 }

--- a/environments/development/extra-regions/us-east-1/terragrunt.hcl
+++ b/environments/development/extra-regions/us-east-1/terragrunt.hcl
@@ -1,0 +1,3 @@
+include {
+  path = find_in_parent_folders()
+}

--- a/environments/development/extra-regions/us-east-1/versions.tf
+++ b/environments/development/extra-regions/us-east-1/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = "1.5.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.3"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}

--- a/environments/development/extra-regions/us-east-1/vpc.tf
+++ b/environments/development/extra-regions/us-east-1/vpc.tf
@@ -1,30 +1,29 @@
-# module "vpc" {
-#   source = "github.com/terraform-aws-modules/terraform-aws-vpc?ref=v5.1.2"
-#
-#   name = "trade-tariff-development-vpc"
-#   cidr = "10.0.0.0/16"
-#
-#   azs = [
-#     "${local.region}a",
-#     "${local.region}b",
-#     "${local.region}c"
-#   ]
-#
-#   private_subnets = [
-#     "10.0.4.0/24",
-#     "10.0.5.0/24",
-#     "10.0.6.0/24"
-#   ]
-#
-#   public_subnets = [
-#     "10.0.104.0/24",
-#     "10.0.105.0/24",
-#     "10.0.106.0/24"
-#   ]
-#
-#   enable_dns_hostnames = true
-#   enable_dns_support   = true
-#
-#   enable_nat_gateway = true
-#   single_nat_gateway = true
-# }
+module "vpc" {
+  source = "github.com/terraform-aws-modules/terraform-aws-vpc?ref=v5.1.2"
+
+  name = "trade-tariff-development-vpc"
+  cidr = "10.0.0.0/16"
+
+  azs = [
+    "${local.region}d",
+    "${local.region}f",
+  ]
+
+  private_subnets = [
+    "10.0.4.0/24",
+    "10.0.5.0/24",
+    "10.0.6.0/24"
+  ]
+
+  public_subnets = [
+    "10.0.104.0/24",
+    "10.0.105.0/24",
+    "10.0.106.0/24"
+  ]
+
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  enable_nat_gateway = true
+  single_nat_gateway = true
+}

--- a/environments/development/extra-regions/us-east-1/vpc.tf
+++ b/environments/development/extra-regions/us-east-1/vpc.tf
@@ -1,0 +1,32 @@
+data "aws_region" "current" {}
+
+module "vpc" {
+  source = "github.com/terraform-aws-modules/terraform-aws-vpc?ref=v5.1.2"
+
+  name = "trade-tariff-development-vpc"
+  cidr = "10.0.0.0/16"
+
+  azs = [
+    "${local.region}a",
+    "${local.region}b",
+    "${local.region}c"
+  ]
+
+  private_subnets = [
+    "10.0.4.0/24",
+    "10.0.5.0/24",
+    "10.0.6.0/24"
+  ]
+
+  public_subnets = [
+    "10.0.104.0/24",
+    "10.0.105.0/24",
+    "10.0.106.0/24"
+  ]
+
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  enable_nat_gateway = true
+  single_nat_gateway = true
+}

--- a/environments/development/extra-regions/us-east-1/vpc.tf
+++ b/environments/development/extra-regions/us-east-1/vpc.tf
@@ -1,30 +1,30 @@
-module "vpc" {
-  source = "github.com/terraform-aws-modules/terraform-aws-vpc?ref=v5.1.2"
-
-  name = "trade-tariff-development-vpc"
-  cidr = "10.0.0.0/16"
-
-  azs = [
-    "${local.region}a",
-    "${local.region}b",
-    "${local.region}c"
-  ]
-
-  private_subnets = [
-    "10.0.4.0/24",
-    "10.0.5.0/24",
-    "10.0.6.0/24"
-  ]
-
-  public_subnets = [
-    "10.0.104.0/24",
-    "10.0.105.0/24",
-    "10.0.106.0/24"
-  ]
-
-  enable_dns_hostnames = true
-  enable_dns_support   = true
-
-  enable_nat_gateway = true
-  single_nat_gateway = true
-}
+# module "vpc" {
+#   source = "github.com/terraform-aws-modules/terraform-aws-vpc?ref=v5.1.2"
+#
+#   name = "trade-tariff-development-vpc"
+#   cidr = "10.0.0.0/16"
+#
+#   azs = [
+#     "${local.region}a",
+#     "${local.region}b",
+#     "${local.region}c"
+#   ]
+#
+#   private_subnets = [
+#     "10.0.4.0/24",
+#     "10.0.5.0/24",
+#     "10.0.6.0/24"
+#   ]
+#
+#   public_subnets = [
+#     "10.0.104.0/24",
+#     "10.0.105.0/24",
+#     "10.0.106.0/24"
+#   ]
+#
+#   enable_dns_hostnames = true
+#   enable_dns_support   = true
+#
+#   enable_nat_gateway = true
+#   single_nat_gateway = true
+# }

--- a/environments/development/extra-regions/us-east-1/vpc.tf
+++ b/environments/development/extra-regions/us-east-1/vpc.tf
@@ -1,5 +1,3 @@
-data "aws_region" "current" {}
-
 module "vpc" {
   source = "github.com/terraform-aws-modules/terraform-aws-vpc?ref=v5.1.2"
 

--- a/environments/staging/base/vpc.tf
+++ b/environments/staging/base/vpc.tf
@@ -11,9 +11,8 @@ module "vpc" {
   cidr = "10.0.0.0/16"
 
   azs = [
-    "${local.region}a",
-    "${local.region}b",
-    "${local.region}c"
+    "${local.region}d",
+    "${local.region}f"
   ]
 
   private_subnets = [

--- a/environments/staging/base/vpc.tf
+++ b/environments/staging/base/vpc.tf
@@ -11,8 +11,9 @@ module "vpc" {
   cidr = "10.0.0.0/16"
 
   azs = [
-    "${local.region}d",
-    "${local.region}f"
+    "${local.region}a",
+    "${local.region}b",
+    "${local.region}c"
   ]
 
   private_subnets = [


### PR DESCRIPTION
# Jira link

FPO-201

![image](https://github.com/trade-tariff/trade-tariff-platform-aws-terraform/assets/8156884/4b0917ca-7baf-4637-8fc6-8bd0affbb4ea)


## What?

I have:

- Added VPC for us-east-1

## Why?

I am doing this because:

- The plan for the moment is that this will be configured for use by the FPO
  search training instance. The kinds of AMI/instance type we want to use right
  now for this are only available in this region.
