### PR TITLE
FPO-201: Explicitly enable access to the production model bucket

### DIFF
--- a/environments/development/common/iam.tf
+++ b/environments/development/common/iam.tf
@@ -452,6 +452,7 @@ resource "aws_iam_policy" "ci_fpo_models_secrets_policy" {
           "ec2:DescribeSecurityGroups",
           "ec2:WaitInstanceRunning",
           "ec2:DescribeInstanceStatus",
+          "ec2:CreateTags"
         ],
         Resource = ["*"]
       }

--- a/environments/development/common/iam.tf
+++ b/environments/development/common/iam.tf
@@ -426,6 +426,20 @@ resource "aws_iam_policy" "ci_fpo_models_secrets_policy" {
         Resource = [
           aws_kms_key.secretsmanager_kms_key.arn
         ]
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "s3:DeleteObject",
+          "s3:GetBucketLocation",
+          "s3:GetObject",
+          "s3:ListBucket",
+          "s3:PutObject",
+        ],
+        Resource = [
+          "arn:aws:s3:::trade-tariff-models-382373577178",
+          "arn:aws:s3:::trade-tariff-models-382373577178/*"
+        ]
       }
     ]
   })

--- a/environments/development/common/iam.tf
+++ b/environments/development/common/iam.tf
@@ -444,6 +444,17 @@ resource "aws_iam_policy" "ci_fpo_models_secrets_policy" {
       {
         Effect = "Allow",
         Action = [
+          "kms:GenerateDataKey",
+          "kms:Decrypt"
+        ],
+        Resource = [
+          # Production S3 KMS key
+          "arn:aws:kms:eu-west-2:382373577178:key/7fc9fd19-e970-4877-9b56-3869a02c7b85"
+        ]
+      },
+      {
+        Effect = "Allow",
+        Action = [
           "ec2:RunInstances",
           "ec2:DescribeInstances",
           "ec2:TerminateInstances",
@@ -455,8 +466,7 @@ resource "aws_iam_policy" "ci_fpo_models_secrets_policy" {
           "ec2:CreateTags"
         ],
         Resource = ["*"]
-      }
-
+      },
     ]
   })
 }

--- a/environments/development/common/iam.tf
+++ b/environments/development/common/iam.tf
@@ -440,7 +440,22 @@ resource "aws_iam_policy" "ci_fpo_models_secrets_policy" {
           "arn:aws:s3:::trade-tariff-models-382373577178",
           "arn:aws:s3:::trade-tariff-models-382373577178/*"
         ]
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "ec2:RunInstances",
+          "ec2:DescribeInstances",
+          "ec2:TerminateInstances",
+          "ec2:DescribeImages",
+          "ec2:DescribeSubnets",
+          "ec2:DescribeSecurityGroups",
+          "ec2:WaitInstanceRunning",
+          "ec2:DescribeInstanceStatus",
+        ],
+        Resource = ["*"]
       }
+
     ]
   })
 }

--- a/environments/production/common/s3.tf
+++ b/environments/production/common/s3.tf
@@ -32,6 +32,23 @@ data "aws_iam_policy_document" "s3_kms_key_policy" {
   }
 
   statement {
+    sid       = "Enable Cross Account User Permissions"
+    effect    = "Allow"
+    actions   = [
+      "kms:GenerateDataKey",
+      "kms:Decrypt",
+    ]
+    resources = ["*"]
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        for account_id in values(var.account_ids) : "arn:aws:iam::${account_id}:user/fpo-models-ci"
+      ]
+    }
+  }
+
+  statement {
     sid       = "Allow use of the key for CloudFront OAC"
     effect    = "Allow"
     actions   = ["kms:Decrypt"]

--- a/environments/staging/common/iam.tf
+++ b/environments/staging/common/iam.tf
@@ -375,7 +375,9 @@ resource "aws_iam_policy" "ci_status_checks_persistence_readwrite_policy" {
           "kms:Decrypt"
         ],
         Resource = [
-          aws_kms_alias.s3_kms_alias.target_key_arn
+          aws_kms_alias.s3_kms_alias.target_key_arn,
+          # Production S3 KMS key
+          "arn:aws:kms:eu-west-2:382373577178:key/7fc9fd19-e970-4877-9b56-3869a02c7b85"
         ]
       },
       {

--- a/environments/staging/common/iam.tf
+++ b/environments/staging/common/iam.tf
@@ -377,6 +377,20 @@ resource "aws_iam_policy" "ci_status_checks_persistence_readwrite_policy" {
         Resource = [
           aws_kms_alias.s3_kms_alias.target_key_arn
         ]
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "s3:DeleteObject",
+          "s3:GetBucketLocation",
+          "s3:GetObject",
+          "s3:ListBucket",
+          "s3:PutObject",
+        ],
+        Resource = [
+          "arn:aws:s3:::trade-tariff-models-382373577178",
+          "arn:aws:s3:::trade-tariff-models-382373577178/*"
+        ]
       }
     ]
   })


### PR DESCRIPTION
# Jira link

FPO-201

## What?

I have:

- Added explicit permissions to enable production model bucket access for the dev and staging ci user
- Added permissions for ci user to create, tag, delete, etc, ec2 instances and amis

## Why?

I am doing this because:

- These are needed for CI to work
