### PR TITLE
FPO-185: Removes redundant references to a single usage plan

### DIFF
--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -78,7 +78,6 @@ No outputs.
 | <a name="module_cognito_client_secret"></a> [cognito\_client\_secret](#module\_cognito\_client\_secret) | ../../../modules/common/secret/ | n/a |
 | <a name="module_dev_hub_backend_encryption_key"></a> [dev\_hub\_backend\_encryption\_key](#module\_dev\_hub\_backend\_encryption\_key) | ../../../modules/common/secret/ | n/a |
 | <a name="module_dev_hub_backend_sentry_dsn"></a> [dev\_hub\_backend\_sentry\_dsn](#module\_dev\_hub\_backend\_sentry\_dsn) | ../../../modules/common/secret/ | n/a |
-| <a name="module_dev_hub_backend_usage_plan_id"></a> [dev\_hub\_backend\_usage\_plan\_id](#module\_dev\_hub\_backend\_usage\_plan\_id) | ../../../modules/common/secret/ | n/a |
 | <a name="module_dev_hub_cognito"></a> [dev\_hub\_cognito](#module\_dev\_hub\_cognito) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cognito | aws/cognito-v1.1.1 |
 | <a name="module_dev_hub_frontend_sentry_dsn"></a> [dev\_hub\_frontend\_sentry\_dsn](#module\_dev\_hub\_frontend\_sentry\_dsn) | ../../../modules/common/secret/ | n/a |
 | <a name="module_duty_calculator_secret_key_base"></a> [duty\_calculator\_secret\_key\_base](#module\_duty\_calculator\_secret\_key\_base) | ../../../modules/common/secret/ | n/a |

--- a/environments/development/common/secrets.tf
+++ b/environments/development/common/secrets.tf
@@ -262,14 +262,6 @@ module "dev_hub_backend_encryption_key" {
   secret_string   = var.dev_hub_backend_encryption_key
 }
 
-module "dev_hub_backend_usage_plan_id" {
-  source          = "../../../modules/common/secret/"
-  name            = "dev-hub-backend-usage-plan-id"
-  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window = 7
-  secret_string   = var.dev_hub_backend_usage_plan_id
-}
-
 module "dev_hub_backend_sentry_dsn" {
   source          = "../../../modules/common/secret/"
   name            = "dev-hub-backend-sentry-dsn"

--- a/environments/production/common/README.md
+++ b/environments/production/common/README.md
@@ -55,7 +55,6 @@
 | <a name="module_cognito_client_secret"></a> [cognito\_client\_secret](#module\_cognito\_client\_secret) | ../../../modules/common/secret/ | n/a |
 | <a name="module_dev_hub_backend_encryption_key"></a> [dev\_hub\_backend\_encryption\_key](#module\_dev\_hub\_backend\_encryption\_key) | ../../../modules/common/secret/ | n/a |
 | <a name="module_dev_hub_backend_sentry_dsn"></a> [dev\_hub\_backend\_sentry\_dsn](#module\_dev\_hub\_backend\_sentry\_dsn) | ../../../modules/common/secret/ | n/a |
-| <a name="module_dev_hub_backend_usage_plan_id"></a> [dev\_hub\_backend\_usage\_plan\_id](#module\_dev\_hub\_backend\_usage\_plan\_id) | ../../../modules/common/secret/ | n/a |
 | <a name="module_dev_hub_cognito"></a> [dev\_hub\_cognito](#module\_dev\_hub\_cognito) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cognito | aws/cognito-v1.1.1 |
 | <a name="module_dev_hub_frontend_sentry_dsn"></a> [dev\_hub\_frontend\_sentry\_dsn](#module\_dev\_hub\_frontend\_sentry\_dsn) | ../../../modules/common/secret/ | n/a |
 | <a name="module_duty_calculator_secret_key_base"></a> [duty\_calculator\_secret\_key\_base](#module\_duty\_calculator\_secret\_key\_base) | ../../../modules/common/secret/ | n/a |

--- a/environments/production/common/secrets.tf
+++ b/environments/production/common/secrets.tf
@@ -215,14 +215,6 @@ module "dev_hub_backend_encryption_key" {
   secret_string   = var.dev_hub_backend_encryption_key
 }
 
-module "dev_hub_backend_usage_plan_id" {
-  source          = "../../../modules/common/secret/"
-  name            = "dev-hub-backend-usage-plan-id"
-  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window = 7
-  secret_string   = var.dev_hub_backend_usage_plan_id
-}
-
 module "dev_hub_backend_sentry_dsn" {
   source          = "../../../modules/common/secret/"
   name            = "dev-hub-backend-sentry-dsn"

--- a/environments/staging/common/README.md
+++ b/environments/staging/common/README.md
@@ -55,7 +55,6 @@
 | <a name="module_cognito_client_secret"></a> [cognito\_client\_secret](#module\_cognito\_client\_secret) | ../../../modules/common/secret/ | n/a |
 | <a name="module_dev_hub_backend_encryption_key"></a> [dev\_hub\_backend\_encryption\_key](#module\_dev\_hub\_backend\_encryption\_key) | ../../../modules/common/secret/ | n/a |
 | <a name="module_dev_hub_backend_sentry_dsn"></a> [dev\_hub\_backend\_sentry\_dsn](#module\_dev\_hub\_backend\_sentry\_dsn) | ../../../modules/common/secret/ | n/a |
-| <a name="module_dev_hub_backend_usage_plan_id"></a> [dev\_hub\_backend\_usage\_plan\_id](#module\_dev\_hub\_backend\_usage\_plan\_id) | ../../../modules/common/secret/ | n/a |
 | <a name="module_dev_hub_cognito"></a> [dev\_hub\_cognito](#module\_dev\_hub\_cognito) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cognito | aws/cognito-v1.1.1 |
 | <a name="module_dev_hub_frontend_sentry_dsn"></a> [dev\_hub\_frontend\_sentry\_dsn](#module\_dev\_hub\_frontend\_sentry\_dsn) | ../../../modules/common/secret/ | n/a |
 | <a name="module_duty_calculator_secret_key_base"></a> [duty\_calculator\_secret\_key\_base](#module\_duty\_calculator\_secret\_key\_base) | ../../../modules/common/secret/ | n/a |

--- a/environments/staging/common/secrets.tf
+++ b/environments/staging/common/secrets.tf
@@ -262,14 +262,6 @@ module "dev_hub_backend_encryption_key" {
   secret_string   = var.dev_hub_backend_encryption_key
 }
 
-module "dev_hub_backend_usage_plan_id" {
-  source          = "../../../modules/common/secret/"
-  name            = "dev-hub-backend-usage-plan-id"
-  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window = 7
-  secret_string   = var.dev_hub_backend_usage_plan_id
-}
-
 module "dev_hub_backend_sentry_dsn" {
   source          = "../../../modules/common/secret/"
   name            = "dev-hub-backend-sentry-dsn"


### PR DESCRIPTION
# Jira link

FPO-185

## What?

I have:

- Removed redundant usage plan secrets

## Why?

I am doing this because:

- These are no longer required
