### PR TITLE
GL-502: Add Frontend Beta Target

### DIFF
--- a/modules/common/application-load-balancer/locals.tf
+++ b/modules/common/application-load-balancer/locals.tf
@@ -50,6 +50,12 @@ locals {
       priority         = 18
     }
 
+    frontend_beta = {
+      host             = ["beta.*"]
+      healthcheck_path = "/healthcheckz"
+      priority         = 19
+    }
+
     frontend = {
       paths            = ["/*"]
       healthcheck_path = "/healthcheckz"


### PR DESCRIPTION
# Jira link

[GL-502](https://transformuk.atlassian.net/browse/GL-502)

## What?

I have:

- Added target group and listener rule for `beta.*` for beta frontend.

## Why?

I am doing this because:

- We want to capture traffic for the beta frontend application.