### PR TITLE
GL-502: Add CDN alias for beta app

### DIFF
--- a/environments/development/common/cloudfront.tf
+++ b/environments/development/common/cloudfront.tf
@@ -3,9 +3,10 @@ module "cdn" {
 
   aliases = [
     var.domain_name,
-    "signon.${var.domain_name}",
     "admin.${var.domain_name}",
-    "hub.${var.domain_name}"
+    "beta.${var.domain_name}",
+    "hub.${var.domain_name}",
+    "signon.${var.domain_name}",
   ]
 
   create_alias    = true

--- a/environments/production/common/cloudfront.tf
+++ b/environments/production/common/cloudfront.tf
@@ -3,10 +3,11 @@ module "cdn" {
 
   aliases = [
     var.domain_name,
-    "signon.${var.domain_name}",
     "admin.${var.domain_name}",
-    "www.${var.domain_name}",
+    "beta.${var.domain_name}",
     "hub.${var.domain_name}",
+    "signon.${var.domain_name}",
+    "www.${var.domain_name}",
   ]
 
   create_alias    = true

--- a/environments/staging/common/cloudfront.tf
+++ b/environments/staging/common/cloudfront.tf
@@ -6,6 +6,7 @@ module "cdn" {
     "signon.${var.domain_name}",
     "admin.${var.domain_name}",
     "hub.${var.domain_name}",
+    "beta.${var.domain_name}",
   ]
 
   create_alias    = true


### PR DESCRIPTION
# Jira link

## What?

I have:

- Added the `beta.` alias for all CDNs.

## Why?

I am doing this because:

- I missed this and traffic won't route correctly without it.
