### PR TITLE
BAU: Adds tariff-terraform repo

### DIFF
--- a/modules/common/ecr/locals.tf
+++ b/modules/common/ecr/locals.tf
@@ -29,6 +29,9 @@ locals {
     },
     "signon" = {
       lifecycle_policy = true
-    }
+    },
+    "terraform" = {
+      lifecycle_policy = false
+    },
   }
 }


### PR DESCRIPTION
# Jira link

BAU

## What?

I have:

- Added terraform repo for terraform docker images

## Why?

I am doing this because:

- This is required since the current ECR repo is named after an image not a repo
