### PR TITLE
BAU: Filter alarms by target group

### DIFF
--- a/environments/development/common/slack-notify.tf
+++ b/environments/development/common/slack-notify.tf
@@ -17,7 +17,7 @@ module "notify_slack" {
 resource "aws_cloudwatch_metric_alarm" "high_5xx_codes" {
   for_each = module.alb.target_groups
 
-  alarm_name          = "High-5xx-errors-${each.key}"
+  alarm_name          = "High-5xx-errors-${each.value.name}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
   metric_name         = "HTTPCode_Target_5XX_Count"
@@ -41,7 +41,7 @@ resource "aws_cloudwatch_metric_alarm" "high_5xx_codes" {
 resource "aws_cloudwatch_metric_alarm" "long_response_times" {
   for_each = module.alb.target_groups
 
-  alarm_name          = "Long-response-times-${each.key}"
+  alarm_name          = "Long-response-times-${each.value.name}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "2"
   metric_name         = "TargetResponseTime"

--- a/environments/development/common/slack-notify.tf
+++ b/environments/development/common/slack-notify.tf
@@ -15,16 +15,18 @@ module "notify_slack" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "high_5xx_codes" {
-  alarm_name          = "High-5xx-errors"
+  for_each = module.alb.target_groups
+
+  alarm_name          = "High-5xx-errors-${each.key}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
-  metric_name         = "HTTPCode_ELB_5XX_Count"
+  metric_name         = "HTTPCode_Target_5XX_Count"
   namespace           = "AWS/ApplicationELB"
   period              = "300"
   statistic           = "Average"
   unit                = "Count"
   threshold           = 10
-  alarm_description   = "Too many HTTP 5xx errors in ${var.environment} environment"
+  alarm_description   = "Too many HTTP 5xx errors in ${var.environment} environment for target group ${each.value.name}"
   treat_missing_data  = "notBreaching"
 
   alarm_actions = [module.notify_slack.slack_topic_arn]
@@ -32,11 +34,14 @@ resource "aws_cloudwatch_metric_alarm" "high_5xx_codes" {
 
   dimensions = {
     LoadBalancer = module.alb.arn_suffix
+    TargetGroup  = each.value.arn
   }
 }
 
 resource "aws_cloudwatch_metric_alarm" "long_response_times" {
-  alarm_name          = "Long-response-times"
+  for_each = module.alb.target_groups
+
+  alarm_name          = "Long-response-times-${each.key}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "2"
   metric_name         = "TargetResponseTime"
@@ -45,7 +50,7 @@ resource "aws_cloudwatch_metric_alarm" "long_response_times" {
   statistic           = "Average"
   unit                = "Seconds"
   threshold           = 2.5 # Development is under resource constraints
-  alarm_description   = "Long response times in ${var.environment} environment"
+  alarm_description   = "Long response times in ${var.environment} environment for target group ${each.value.name}"
   treat_missing_data  = "notBreaching"
 
   alarm_actions = [module.notify_slack.slack_topic_arn]
@@ -53,5 +58,6 @@ resource "aws_cloudwatch_metric_alarm" "long_response_times" {
 
   dimensions = {
     LoadBalancer = module.alb.arn_suffix
+    TargetGroup  = each.value.arn
   }
 }

--- a/environments/production/common/slack-notify.tf
+++ b/environments/production/common/slack-notify.tf
@@ -17,7 +17,7 @@ module "notify_slack" {
 resource "aws_cloudwatch_metric_alarm" "high_5xx_codes" {
   for_each = module.alb.target_groups
 
-  alarm_name          = "High-5xx-errors-${each.key}"
+  alarm_name          = "High-5xx-errors-${each.value.name}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
   metric_name         = "HTTPCode_Target_5XX_Count"
@@ -41,7 +41,7 @@ resource "aws_cloudwatch_metric_alarm" "high_5xx_codes" {
 resource "aws_cloudwatch_metric_alarm" "long_response_times" {
   for_each = module.alb.target_groups
 
-  alarm_name          = "Long-response-times-${each.key}"
+  alarm_name          = "Long-response-times-${each.value.name}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "2"
   metric_name         = "TargetResponseTime"

--- a/environments/staging/common/slack-notify.tf
+++ b/environments/staging/common/slack-notify.tf
@@ -17,7 +17,7 @@ module "notify_slack" {
 resource "aws_cloudwatch_metric_alarm" "high_5xx_codes" {
   for_each = module.alb.target_groups
 
-  alarm_name          = "High-5xx-errors-${each.key}"
+  alarm_name          = "High-5xx-errors-${each.value.name}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
   metric_name         = "HTTPCode_Target_5XX_Count"
@@ -41,7 +41,7 @@ resource "aws_cloudwatch_metric_alarm" "high_5xx_codes" {
 resource "aws_cloudwatch_metric_alarm" "long_response_times" {
   for_each = module.alb.target_groups
 
-  alarm_name          = "Long-response-times-${each.key}"
+  alarm_name          = "Long-response-times-${each.value.name}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "2"
   metric_name         = "TargetResponseTime"

--- a/modules/common/application-load-balancer/outputs.tf
+++ b/modules/common/application-load-balancer/outputs.tf
@@ -12,3 +12,14 @@ output "arn_suffix" {
   description = "arn_suffix of the load balancer."
   value       = aws_lb.application_load_balancer.arn_suffix
 }
+
+output "target_groups" {
+  description = "List of target groups."
+  value = [
+    for tg in aws_lb_target_group.trade_tariff_target_groups :
+    {
+      name = tg.name,
+      arn  = tg.arn
+    }
+  ]
+}

--- a/modules/common/application-load-balancer/outputs.tf
+++ b/modules/common/application-load-balancer/outputs.tf
@@ -15,11 +15,11 @@ output "arn_suffix" {
 
 output "target_groups" {
   description = "List of target groups."
-  value = [
+  value = {
     for tg in aws_lb_target_group.trade_tariff_target_groups :
-    {
+    tg.name => {
       name = tg.name,
       arn  = tg.arn
     }
-  ]
+  }
 }


### PR DESCRIPTION
# Jira link

BAU

## What?

I have:

- Filter specific alarms by their target group

## Why?

I am doing this because:

- This gives us a clearer picture on which apps are affected
