### PR TITLE
FPO-233: Adds permissions to FPO GC execution roles to the model bucket

### DIFF
--- a/environments/production/common/iam.tf
+++ b/environments/production/common/iam.tf
@@ -594,9 +594,10 @@ data "aws_iam_policy_document" "fpo_model_access" {
 
     principals {
       type = "AWS"
-      identifiers = [
-        for account_id in values(var.account_ids) : "arn:aws:iam::${account_id}:user/fpo-models-ci"
-      ]
+      identifiers = concat(
+        [for account_id in values(var.account_ids) : "arn:aws:iam::${account_id}:user/fpo-models-ci"],
+        [for account_id in values(var.account_ids) : "arn:aws:iam::${account_id}:role/fpo-model-garbage-collection-*"]
+      )
     }
   }
 }


### PR DESCRIPTION
# Jira link

FPO-233

## What?

I have:

- Added cross-account permissions to manage the model bucket to the garbage collection lambda execution role

## Why?

I am doing this because:

- This is needed to enable running this lambda in dev/staging and production accounts
