### PR TITLE
BAU: Roles need to be exact and they need to exist

### DIFF
--- a/environments/production/common/iam.tf
+++ b/environments/production/common/iam.tf
@@ -594,10 +594,14 @@ data "aws_iam_policy_document" "fpo_model_access" {
 
     principals {
       type = "AWS"
-      identifiers = concat(
-        [for account_id in values(var.account_ids) : "arn:aws:iam::${account_id}:user/fpo-models-ci"],
-        [for account_id in values(var.account_ids) : "arn:aws:iam::${account_id}:role/fpo-model-garbage-collection-*"]
-      )
+      identifiers = [
+        "arn:aws:iam::844815912454:role/fpo-model-garbage-collection-development-eu-west-2-lambdaRole",
+        "arn:aws:iam::844815912454:user/fpo-models-ci",
+        "arn:aws:iam::451934005581:role/fpo-model-garbage-collection-staging-eu-west-2-lambdaRole",
+        "arn:aws:iam::451934005581:user/fpo-models-ci",
+        "arn:aws:iam::382373577178:role/fpo-model-garbage-collection-production-eu-west-2-lambdaRole",
+        "arn:aws:iam::382373577178:user/fpo-models-ci"
+      ]
     }
   }
 }


### PR DESCRIPTION
# Jira link

BAU

## What?

I have:

- Fixed broken references to what were non-existing roles

## Why?

I am doing this because:

- These roles had to be created to be referenced
- These references needed to be the exact arns of the existing roles
- Since the exact roles included the account stage it made more sense to just create them explicitly
