### PR TITLE
GL-732: Adds development ECR repo for replication lambda

### DIFF
--- a/environments/development/common/locals.tf
+++ b/environments/development/common/locals.tf
@@ -6,6 +6,7 @@ locals {
     "admin",
     "backend",
     "database-backups",
+    "database-replication",
     "duty-calculator",
     "fpo-developer-hub-backend",
     "fpo-developer-hub-frontend",


### PR DESCRIPTION
# Jira link

GL-732

## What?

I have:

- Added an ECR repository for restoring database backups in development

## Why?

I am doing this because:

- This is required for the replication lambda
