### PR TITLE
FPO-324: Adds cloudfront aliases for commodi-tea

### DIFF
--- a/environments/development/common/cloudfront.tf
+++ b/environments/development/common/cloudfront.tf
@@ -7,6 +7,7 @@ module "cdn" {
     "beta.${var.domain_name}",
     "hub.${var.domain_name}",
     "signon.${var.domain_name}",
+    "tea.${var.domain_name}",
   ]
 
   create_alias    = true

--- a/environments/production/common/cloudfront.tf
+++ b/environments/production/common/cloudfront.tf
@@ -7,6 +7,7 @@ module "cdn" {
     "beta.${var.domain_name}",
     "hub.${var.domain_name}",
     "signon.${var.domain_name}",
+    "tea.${var.domain_name}",
     "www.${var.domain_name}",
   ]
 

--- a/environments/staging/common/cloudfront.tf
+++ b/environments/staging/common/cloudfront.tf
@@ -3,10 +3,11 @@ module "cdn" {
 
   aliases = [
     var.domain_name,
-    "signon.${var.domain_name}",
     "admin.${var.domain_name}",
-    "hub.${var.domain_name}",
     "beta.${var.domain_name}",
+    "hub.${var.domain_name}",
+    "signon.${var.domain_name}",
+    "tea.${var.domain_name}",
   ]
 
   create_alias    = true

--- a/modules/common/application-load-balancer/locals.tf
+++ b/modules/common/application-load-balancer/locals.tf
@@ -3,27 +3,33 @@ locals {
     admin = {
       host             = ["admin.*"]
       healthcheck_path = "/healthcheckz"
-      priority         = 11
+      priority         = 1
     }
 
     signon = {
       host             = ["signon.*"]
       healthcheck_path = "/healthcheck/live"
-      priority         = 12
+      priority         = 2
     }
 
     hub_backend = {
       host             = ["hub.*"]
       paths            = ["/api/healthcheck"]
       healthcheck_path = "/api/healthcheckz"
-      priority         = 13
+      priority         = 3
     }
 
     hub_frontend = {
       host             = ["hub.*"]
       paths            = ["/*"]
       healthcheck_path = "/healthcheckz"
-      priority         = 14
+      priority         = 4
+    }
+
+    tea = {
+      host             = ["tea.*"]
+      healthcheck_path = "/healthcheckz"
+      priority         = 5
     }
 
     backend_uk = {

--- a/modules/common/application-load-balancer/variables.tf
+++ b/modules/common/application-load-balancer/variables.tf
@@ -8,6 +8,7 @@ variable "application_port" {
   type        = string
   default     = 8080
 }
+
 variable "listening_port" {
   description = "Port on which the load balancer listens to."
   type        = string


### PR DESCRIPTION
# Jira link

FPO-324

## What?

I have:

- Added CDN aliases to cloudfront for tea.* for dev, staging and production
- Added ALB service target group/listener rules for tea.*
- Adjusted priority rules to get the tea. rule in the right position

## Why?

I am doing this because:

- This is required to enable us to deploy the ECS service for the commodi-tea application
