### PR TITLE
BAU: Adds ECR repo for the commodi-tea application

### DIFF
--- a/environments/development/common/locals.tf
+++ b/environments/development/common/locals.tf
@@ -14,6 +14,7 @@ locals {
     "frontend",
     "search-query-parser",
     "signon",
+    "tea"
   ]
 
   cloudfront_auth = templatefile("../../../modules/common/cloudfront-auth.js.tpl", { base64 = var.backups_basic_auth })

--- a/environments/staging/common/locals.tf
+++ b/environments/staging/common/locals.tf
@@ -14,6 +14,7 @@ locals {
     "frontend",
     "search-query-parser",
     "signon",
+    "tea"
   ]
 
   cloudfront_auth = templatefile("../../../modules/common/cloudfront-auth.js.tpl", { base64 = var.backups_basic_auth })

--- a/modules/common/ecr/locals.tf
+++ b/modules/common/ecr/locals.tf
@@ -36,5 +36,8 @@ locals {
     "terraform" = {
       lifecycle_policy = false
     },
+    "tea" = {
+      lifecycle_policy = true
+    },
   }
 }


### PR DESCRIPTION
# Jira link

BAU

## What?

I have:

- Added ECR repo to production
- Added SSM parameter pointing at the repo in production
- Added SSM parameter pointing at the repo in staging
- Added SSM parameter pointing at the repo in development

## Why?

I am doing this because:

- This is needed for the commodi-tea application in each environment 
