### PR TITLE
OTT-384: Removes unused target groups/listener rules

### DIFF
--- a/environments/development/applications/locals.tf
+++ b/environments/development/applications/locals.tf
@@ -5,7 +5,6 @@ locals {
     "backend",
     "duty-calculator",
     "frontend",
-    "search-query-parser",
     "signon"
   ]
 }

--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -103,7 +103,6 @@ No outputs.
 | <a name="module_redis"></a> [redis](#module\_redis) | ../../../modules/common/elasticache-redis/ | n/a |
 | <a name="module_reporting_cdn"></a> [reporting\_cdn](#module\_reporting\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.4.2 |
 | <a name="module_search_configuration_bucket"></a> [search\_configuration\_bucket](#module\_search\_configuration\_bucket) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v3.14.0 |
-| <a name="module_search_query_parser_sentry_dsn"></a> [search\_query\_parser\_sentry\_dsn](#module\_search\_query\_parser\_sentry\_dsn) | ../../../modules/common/secret/ | n/a |
 | <a name="module_ses"></a> [ses](#module\_ses) | ../../../modules/common/ses | n/a |
 | <a name="module_signon_derivation_key"></a> [signon\_derivation\_key](#module\_signon\_derivation\_key) | ../../../modules/common/secret/ | n/a |
 | <a name="module_signon_derivation_salt"></a> [signon\_derivation\_salt](#module\_signon\_derivation\_salt) | ../../../modules/common/secret/ | n/a |

--- a/environments/development/common/locals.tf
+++ b/environments/development/common/locals.tf
@@ -12,7 +12,6 @@ locals {
     "fpo-developer-hub-frontend",
     "fpo-search",
     "frontend",
-    "search-query-parser",
     "signon",
     "tea"
   ]

--- a/environments/development/common/secrets.tf
+++ b/environments/development/common/secrets.tf
@@ -246,14 +246,6 @@ module "signon_derivation_key" {
   secret_string   = var.signon_derivation_key
 }
 
-module "search_query_parser_sentry_dsn" {
-  source          = "../../../modules/common/secret/"
-  name            = "search-query-parser-sentry-dsn"
-  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window = 7
-  secret_string   = var.search_query_parser_sentry_dsn
-}
-
 module "dev_hub_backend_encryption_key" {
   source          = "../../../modules/common/secret/"
   name            = "dev-hub-backend-encryption-key"

--- a/environments/production/applications/locals.tf
+++ b/environments/production/applications/locals.tf
@@ -9,7 +9,6 @@ locals {
     "fpo-developer-hub-frontend",
     "fpo-search",
     "frontend",
-    "search-query-parser",
     "signon",
     "terraform-1.5.5-python3",
   ]

--- a/environments/production/common/README.md
+++ b/environments/production/common/README.md
@@ -79,7 +79,6 @@
 | <a name="module_redis"></a> [redis](#module\_redis) | ../../../modules/common/elasticache-redis/ | n/a |
 | <a name="module_reporting_cdn"></a> [reporting\_cdn](#module\_reporting\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.4.2 |
 | <a name="module_search_configuration_bucket"></a> [search\_configuration\_bucket](#module\_search\_configuration\_bucket) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v3.14.0 |
-| <a name="module_search_query_parser_sentry_dsn"></a> [search\_query\_parser\_sentry\_dsn](#module\_search\_query\_parser\_sentry\_dsn) | ../../../modules/common/secret/ | n/a |
 | <a name="module_ses"></a> [ses](#module\_ses) | ../../../modules/common/ses | n/a |
 | <a name="module_slack_notify_lambda_slack_webhook_url"></a> [slack\_notify\_lambda\_slack\_webhook\_url](#module\_slack\_notify\_lambda\_slack\_webhook\_url) | ../../../modules/common/secret/ | n/a |
 | <a name="module_slack_web_hook_url"></a> [slack\_web\_hook\_url](#module\_slack\_web\_hook\_url) | ../../../modules/common/secret/ | n/a |

--- a/environments/production/common/secrets.tf
+++ b/environments/production/common/secrets.tf
@@ -199,14 +199,6 @@ module "backend_xe_api_password" {
   secret_string   = var.tariff_backend_xe_api_password
 }
 
-module "search_query_parser_sentry_dsn" {
-  source          = "../../../modules/common/secret/"
-  name            = "search-query-parser-sentry-dsn"
-  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window = 7
-  secret_string   = var.search_query_parser_sentry_dsn
-}
-
 module "dev_hub_backend_encryption_key" {
   source          = "../../../modules/common/secret/"
   name            = "dev-hub-backend-encryption-key"

--- a/environments/staging/applications/locals.tf
+++ b/environments/staging/applications/locals.tf
@@ -7,7 +7,6 @@ locals {
     "fpo-developer-hub-backend",
     "fpo-developer-hub-frontend",
     "frontend",
-    "search-query-parser",
     "signon"
   ]
 }

--- a/environments/staging/common/README.md
+++ b/environments/staging/common/README.md
@@ -79,7 +79,6 @@
 | <a name="module_redis"></a> [redis](#module\_redis) | ../../../modules/common/elasticache-redis/ | n/a |
 | <a name="module_reporting_cdn"></a> [reporting\_cdn](#module\_reporting\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.4.2 |
 | <a name="module_search_configuration_bucket"></a> [search\_configuration\_bucket](#module\_search\_configuration\_bucket) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v3.14.0 |
-| <a name="module_search_query_parser_sentry_dsn"></a> [search\_query\_parser\_sentry\_dsn](#module\_search\_query\_parser\_sentry\_dsn) | ../../../modules/common/secret/ | n/a |
 | <a name="module_ses"></a> [ses](#module\_ses) | ../../../modules/common/ses | n/a |
 | <a name="module_signon_derivation_key"></a> [signon\_derivation\_key](#module\_signon\_derivation\_key) | ../../../modules/common/secret/ | n/a |
 | <a name="module_signon_derivation_salt"></a> [signon\_derivation\_salt](#module\_signon\_derivation\_salt) | ../../../modules/common/secret/ | n/a |

--- a/environments/staging/common/locals.tf
+++ b/environments/staging/common/locals.tf
@@ -12,7 +12,6 @@ locals {
     "fpo-developer-hub-frontend",
     "fpo-search",
     "frontend",
-    "search-query-parser",
     "signon",
     "tea"
   ]

--- a/environments/staging/common/secrets.tf
+++ b/environments/staging/common/secrets.tf
@@ -246,14 +246,6 @@ module "signon_derivation_key" {
   secret_string   = var.signon_derivation_key
 }
 
-module "search_query_parser_sentry_dsn" {
-  source          = "../../../modules/common/secret/"
-  name            = "search-query-parser-sentry-dsn"
-  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window = 7
-  secret_string   = var.search_query_parser_sentry_dsn
-}
-
 module "dev_hub_backend_encryption_key" {
   source          = "../../../modules/common/secret/"
   name            = "dev-hub-backend-encryption-key"

--- a/modules/common/application-load-balancer/locals.tf
+++ b/modules/common/application-load-balancer/locals.tf
@@ -32,28 +32,10 @@ locals {
       priority         = 5
     }
 
-    backend_uk = {
-      paths            = ["/uk/api/beta/*"]
-      healthcheck_path = "/healthcheckz"
-      priority         = 15
-    }
-
-    backend_xi = {
-      paths            = ["/xi/api/beta/*"]
-      healthcheck_path = "/healthcheckz"
-      priority         = 16
-    }
-
     duty_calculator = {
       paths            = ["/duty-calculator/*"]
       healthcheck_path = "/healthcheckz"
       priority         = 17
-    }
-
-    search_query_parser = {
-      paths            = ["/api/search/*"]
-      healthcheck_path = "/healthcheckz"
-      priority         = 18
     }
 
     frontend_beta = {

--- a/modules/common/ecr/locals.tf
+++ b/modules/common/ecr/locals.tf
@@ -27,9 +27,6 @@ locals {
     "frontend" = {
       lifecycle_policy = true
     },
-    "search-query-parser" = {
-      lifecycle_policy = true
-    },
     "signon" = {
       lifecycle_policy = true
     },


### PR DESCRIPTION
# Jira link

OTT-384

## What?

I have:

- Removed unused ALB target groups and listeners

## Why?

I am doing this because:

- `search_query_parser` has gone away since we're not doing beta search anymore
- `backend_xi`/ `backend_uk` gone away for the same reason since this was a holepunch to the backend just for beta search

