### PR TITLE
OTT-398: Root and branch review of the ECR lifecycle rules

### DIFF
--- a/modules/common/ecr/ecr.tf
+++ b/modules/common/ecr/ecr.tf
@@ -37,13 +37,12 @@ resource "aws_ecr_lifecycle_policy" "expire_untagged_images_policy" {
     rules = [
       {
         rulePriority = 1
-        description  = "Keep 6 months of production images."
+        description  = "Keep last ${each.value.production_images_to_keep} production images."
         selection = {
           tagStatus     = "tagged"
           tagPrefixList = ["release"]
-          countType     = "sinceImagePushed"
-          countUnit     = "days"
-          countNumber   = 180
+          countType     = "imageCountMoreThan"
+          countNumber   = v.production_images_to_keep
         }
         action = {
           type = "expire"
@@ -51,12 +50,11 @@ resource "aws_ecr_lifecycle_policy" "expire_untagged_images_policy" {
       },
       {
         rulePriority = 2
-        description  = "Keep 1 month of development images."
+        description  = "Keep last ${each.value.development_images_to_keep} development images."
         selection = {
           tagStatus   = "any"
-          countType   = "sinceImagePushed"
-          countUnit   = "days"
-          countNumber = 30
+          countType   = "imageCountMoreThan"
+          countNumber = v.development_images_to_keep
         }
         action = {
           type = "expire"

--- a/modules/common/ecr/ecr.tf
+++ b/modules/common/ecr/ecr.tf
@@ -42,7 +42,7 @@ resource "aws_ecr_lifecycle_policy" "expire_untagged_images_policy" {
           tagStatus     = "tagged"
           tagPrefixList = ["release"]
           countType     = "imageCountMoreThan"
-          countNumber   = v.production_images_to_keep
+          countNumber   = each.value.production_images_to_keep
         }
         action = {
           type = "expire"
@@ -54,7 +54,7 @@ resource "aws_ecr_lifecycle_policy" "expire_untagged_images_policy" {
         selection = {
           tagStatus   = "any"
           countType   = "imageCountMoreThan"
-          countNumber = v.development_images_to_keep
+          countNumber = each.value.development_images_to_keep
         }
         action = {
           type = "expire"

--- a/modules/common/ecr/locals.tf
+++ b/modules/common/ecr/locals.tf
@@ -1,40 +1,93 @@
 locals {
+  # We have a mixture of release-prefixed tagged images and untagged images.
+  #
+  # Untagged images are considered "development" images but this is not always the
+  # case since some applications don't cut a release tag to identify a
+  # deployment as released to production (e.g. for different classes of lambda or applications owned
+  # by a different upstream - think signon).
+  #
+  # The main case, though, is that we keep 5 production images and 30
+  # development images (with the production image prioritised higher and
+  # therefore taking precedence).
+  #
+  # Production releases happen 2 times per week (until we move to continuous
+  # deployment) so 5 production images is equivalent to keeping the last 2.5 weeks of images.
+  #
+  # We have a higher number of development images to reflect the fact that there
+  # can be a lot of concurrently built images across different branches and
+  # developers aren't always incentivised to clean up after themselves and have
+  # long-lived branches.
+  #
+  # In the case of continous deployment, we would likely want to keep more just
+  # to be safe (e.g. the hub-backend and hub-frontend applications and fpo
+  # search lambda).
+  #
+  # The lifecycle policy is just a convenience to disable application lifecycles
+  # in an emergency.
   applications = {
+    # Manually deployed typical applications
     "admin" = {
-      lifecycle_policy = true
+      lifecycle_policy           = true
+      production_images_to_keep  = 5
+      development_images_to_keep = 30
     },
     "backend" = {
-      lifecycle_policy = true
-    },
-    "database-backups" = {
-      lifecycle_policy = false
-    },
-    "database-replication" = {
-      lifecycle_policy = false
+      lifecycle_policy           = true
+      production_images_to_keep  = 5
+      development_images_to_keep = 30
     },
     "duty-calculator" = {
-      lifecycle_policy = true
+      lifecycle_policy           = true
+      production_images_to_keep  = 30
+      development_images_to_keep = 30
     },
+    "frontend" = {
+      lifecycle_policy           = true
+      production_images_to_keep  = 5
+      development_images_to_keep = 30
+    },
+    # Scheduled lambdas
+    "database-backups" = {
+      lifecycle_policy           = true
+      production_images_to_keep  = 5
+      development_images_to_keep = 5
+    },
+    "database-replication" = {
+      lifecycle_policy           = true
+      production_images_to_keep  = 5
+      development_images_to_keep = 5
+    },
+    # Continuous deployment applications
     "fpo-search" = {
-      lifecycle_policy = false
+      lifecycle_policy           = true
+      production_images_to_keep  = 10
+      development_images_to_keep = 30
     },
     "fpo-developer-hub-backend" = {
-      lifecycle_policy = true
+      lifecycle_policy           = true
+      production_images_to_keep  = 10
+      development_images_to_keep = 30
     }
     "fpo-developer-hub-frontend" = {
-      lifecycle_policy = true
+      lifecycle_policy           = true
+      production_images_to_keep  = 10
+      development_images_to_keep = 30
     }
-    "frontend" = {
-      lifecycle_policy = true
+    "tea" = {
+      lifecycle_policy           = true
+      production_images_to_keep  = 10
+      development_images_to_keep = 30
     },
+    # Special snowflake cases
     "signon" = {
-      lifecycle_policy = true
+      lifecycle_policy           = true
+      production_images_to_keep  = 5
+      development_images_to_keep = 5
     },
     "terraform" = {
-      lifecycle_policy = false
-    },
-    "tea" = {
-      lifecycle_policy = true
+      lifecycle_policy           = true
+      production_images_to_keep  = 5
+      development_images_to_keep = 5
     },
   }
 }


### PR DESCRIPTION
# Jira link

OTT-398

## What?

I've ran these rules in the ECR test rule simulator for the admin repo and am comfortable that these are working as expected

I have:

- Added a comment explaining some of the hidden aspects of our lifecycle rules
- Altered the existing rules to move us to a count-oriented approach
- Altered the existing rules to reflect the types of deployment we have (manual, continuous)

## Why?

I am doing this because:

- Date-oriented rotations don't fit our model of infrequently deployed applications (think duty calculator/signon)
- The rules themselves weren't super clear about what the intent was
- And weren't customisable
