### PR TITLE
BAU: Creates a tea lock in production

### DIFF
--- a/environments/production/applications/locals.tf
+++ b/environments/production/applications/locals.tf
@@ -10,6 +10,6 @@ locals {
     "fpo-search",
     "frontend",
     "signon",
-    "terraform-1.5.5-python3",
+    "tea"
   ]
 }


### PR DESCRIPTION
# Jira link

BAU

## What?

I have:

- Added tea application lock in dynamodb in production

## Why?

I am doing this because:

- This is required to constrain the apply step for the commodi-tea application
