### PR TITLE
BAU: Adds tea to applications in staging

### DIFF
--- a/environments/staging/applications/locals.tf
+++ b/environments/staging/applications/locals.tf
@@ -7,6 +7,7 @@ locals {
     "fpo-developer-hub-backend",
     "fpo-developer-hub-frontend",
     "frontend",
-    "signon"
+    "signon",
+    "tea"
   ]
 }


### PR DESCRIPTION
# Jira link

BAU

## What?

I have:

- Added `tea` application to staging

## Why?

I am doing this because:

- This is needed to deploy the commodi-tea app to staging
