### PR TITLE
BAU: Adds a parameter group for the tea db instance in development

### DIFF
--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -133,6 +133,7 @@ No outputs.
 | [aws_cloudwatch_log_group.redis_slow_lg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_metric_alarm.high_5xx_codes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.long_response_times](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_db_parameter_group.tea](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_parameter_group) | resource |
 | [aws_elasticache_subnet_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_subnet_group) | resource |
 | [aws_iam_policy.ci_appendix5a_persistence_readwrite_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.ci_fpo_models_secrets_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |

--- a/environments/development/common/rds.tf
+++ b/environments/development/common/rds.tf
@@ -121,8 +121,20 @@ module "postgres_commodi_tea" {
     module.alb-security-group
   ]
 
+  parameter_group_name = aws_db_parameter_group.tea.name
+
   tags = {
     Name     = "PostgresCommodiTea"
     customer = "fpo"
+  }
+}
+
+resource "aws_db_parameter_group" "tea" {
+  name   = "postgres16-with-md5-password-encryption"
+  family = "postgres16"
+
+  parameter {
+    name  = "password_encryption"
+    value = "md5"
   }
 }

--- a/modules/common/rds/rds.tf
+++ b/modules/common/rds/rds.tf
@@ -32,6 +32,8 @@ resource "aws_db_instance" "this" {
 
   vpc_security_group_ids = var.security_group_ids
 
+  parameter_group_name = var.parameter_group_name
+
   tags = local.tags
 }
 

--- a/modules/common/rds/variables.tf
+++ b/modules/common/rds/variables.tf
@@ -90,3 +90,9 @@ variable "multi_az" {
   type        = bool
   default     = false
 }
+
+variable "parameter_group_name" {
+  description = "The name of the parameter group to associate with this RDS instance."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
# Jira link

BAU

## What?

I have:

- [x] Added parameter group for the tea database in development
- [ ] Added parameter group for the tea database in staging
- [ ] Added parameter group for the tea database in production

## Why?

I am doing this because:

- We believe this is required to get sequelize to work
