### PR TITLE
FPO-335: Create Tea Cognito User Pool and add DB Parameter Group

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+terraform 1.8.4

--- a/environments/development/common/.terraform.lock.hcl
+++ b/environments/development/common/.terraform.lock.hcl
@@ -4,6 +4,7 @@
 provider "registry.terraform.io/hashicorp/archive" {
   version = "2.4.1"
   hashes = [
+    "h1:3mCpFxc6HwDIETCFHNENlxBUgKdsW2S1EmVHARn9Lgk=",
     "h1:AABk7Bon/bM1LKziIsGG78d97c9IhEqh/EWJs1J0rLo=",
     "h1:JgIo+nNySG8svjXevfoTRi0jzgHbLMDrnr55WBeRupw=",
     "zh:00240c042740d18d6ba545b211ff7ed5a9e8490d30be3f865e71dba90d7a34cf",
@@ -27,6 +28,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   hashes = [
     "h1:2eauBmfftzGMpzFQn9aHSXiyaO3Ve5cnihmXcKGGpgU=",
     "h1:WwgMbMOhZblxZTdjHeJf9XB2/hcSHHmpuywLxuTWYw0=",
+    "h1:ltxyuBWIy9cq0kIKDJH1jeWJy/y7XJLjS4QrsQK4plA=",
     "zh:0cdb9c2083bf0902442384f7309367791e4640581652dda456f2d6d7abf0de8d",
     "zh:2fe4884cb9642f48a5889f8dff8f5f511418a18537a9dfa77ada3bcdad391e4e",
     "zh:36d8bdd72fe61d816d0049c179f495bc6f1e54d8d7b07c45b62e5e1696882a89",
@@ -50,6 +52,7 @@ provider "registry.terraform.io/hashicorp/external" {
   constraints = ">= 1.0.0"
   hashes = [
     "h1:H+3QlVPs/7CDa3I4KU/a23wYeGeJxeBlgvR7bfK1t1w=",
+    "h1:gShzO1rJtADK9tDZMvMgjciVAzsBh39LNjtThCwX1Hg=",
     "zh:03d81462f9578ec91ce8e26f887e34151eda0e100f57e9772dbea86363588239",
     "zh:37ec2a20f6a3ec3a0fd95d3f3de26da6cb9534b30488bc45723e118a0911c0d8",
     "zh:4eb5b119179539f2749ce9de0e1b9629d025990f062f4f4dddc161562bb89d37",
@@ -69,6 +72,7 @@ provider "registry.terraform.io/hashicorp/local" {
   version     = "2.5.1"
   constraints = ">= 1.0.0"
   hashes = [
+    "h1:/GAVA/xheGQcbOZEq0qxANOg+KVLCA7Wv8qluxhTjhU=",
     "h1:8oTPe2VUL6E2d3OcrvqyjI4Nn/Y/UEQN26WLk5O/B0g=",
     "zh:0af29ce2b7b5712319bf6424cb58d13b852bf9a777011a545fac99c7fdcdf561",
     "zh:126063ea0d79dad1f68fa4e4d556793c0108ce278034f101d1dbbb2463924561",
@@ -89,6 +93,7 @@ provider "registry.terraform.io/hashicorp/null" {
   version     = "3.2.2"
   constraints = ">= 2.0.0, >= 3.0.0"
   hashes = [
+    "h1:IMVAUHKoydFrlPrl9OzasDnw/8ntZFerCC9iXw1rXQY=",
     "h1:vWAsYRd7MjYr3adj8BVKRohVfHpWQdvkIwUQ2Jf5FVM=",
     "h1:zT1ZbegaAYHwQa+QwIFugArWikRJI9dqohj8xb0GY88=",
     "zh:3248aae6a2198f3ec8394218d05bd5e42be59f43a3a7c0b71c66ec0df08b69e7",
@@ -110,6 +115,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.6.0"
   constraints = ">= 3.0.0, >= 3.5.1, 3.6.0"
   hashes = [
+    "h1:I8MBeauYA8J8yheLJ8oSMWqB0kovn16dF/wKZ1QTdkk=",
     "h1:R5Ucn26riKIEijcsiOMBR3uOAjuOMfI1x7XvH4P6B1w=",
     "h1:p6WG1IPHnqx1fnJVKNjv733FBaArIugqy58HRZnpPCk=",
     "zh:03360ed3ecd31e8c5dac9c95fe0858be50f3e9a0d0c654b5e504109c2159287d",

--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -76,6 +76,7 @@ No outputs.
 | <a name="module_cloudwatch-logs-exporter"></a> [cloudwatch-logs-exporter](#module\_cloudwatch-logs-exporter) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudwatch_log_exporter | aws/cloudwatch_log_exporter-v1.0.0 |
 | <a name="module_cognito_client_id"></a> [cognito\_client\_id](#module\_cognito\_client\_id) | ../../../modules/common/secret/ | n/a |
 | <a name="module_cognito_client_secret"></a> [cognito\_client\_secret](#module\_cognito\_client\_secret) | ../../../modules/common/secret/ | n/a |
+| <a name="module_commodi_tea_cognito"></a> [commodi\_tea\_cognito](#module\_commodi\_tea\_cognito) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cognito | aws/cognito-v1.1.1 |
 | <a name="module_dev_hub_backend_encryption_key"></a> [dev\_hub\_backend\_encryption\_key](#module\_dev\_hub\_backend\_encryption\_key) | ../../../modules/common/secret/ | n/a |
 | <a name="module_dev_hub_backend_sentry_dsn"></a> [dev\_hub\_backend\_sentry\_dsn](#module\_dev\_hub\_backend\_sentry\_dsn) | ../../../modules/common/secret/ | n/a |
 | <a name="module_dev_hub_cognito"></a> [dev\_hub\_cognito](#module\_dev\_hub\_cognito) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cognito | aws/cognito-v1.1.1 |
@@ -115,6 +116,8 @@ No outputs.
 | <a name="module_slack_notify_lambda_slack_webhook_url"></a> [slack\_notify\_lambda\_slack\_webhook\_url](#module\_slack\_notify\_lambda\_slack\_webhook\_url) | ../../../modules/common/secret/ | n/a |
 | <a name="module_slack_web_hook_url"></a> [slack\_web\_hook\_url](#module\_slack\_web\_hook\_url) | ../../../modules/common/secret/ | n/a |
 | <a name="module_status_checks_cdn"></a> [status\_checks\_cdn](#module\_status\_checks\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.4.2 |
+| <a name="module_tea_cognito_client_id"></a> [tea\_cognito\_client\_id](#module\_tea\_cognito\_client\_id) | ../../../modules/common/secret/ | n/a |
+| <a name="module_tea_cognito_client_secret"></a> [tea\_cognito\_client\_secret](#module\_tea\_cognito\_client\_secret) | ../../../modules/common/secret/ | n/a |
 | <a name="module_tech_docs_cdn"></a> [tech\_docs\_cdn](#module\_tech\_docs\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.4.2 |
 | <a name="module_waf"></a> [waf](#module\_waf) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/waf | aws/waf-v1.2.3 |
 
@@ -133,6 +136,7 @@ No outputs.
 | [aws_cloudwatch_log_group.redis_slow_lg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_metric_alarm.high_5xx_codes](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
 | [aws_cloudwatch_metric_alarm.long_response_times](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_db_parameter_group.tea](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_parameter_group) | resource |
 | [aws_elasticache_subnet_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_subnet_group) | resource |
 | [aws_iam_policy.ci_appendix5a_persistence_readwrite_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.ci_fpo_models_secrets_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
@@ -171,6 +175,7 @@ No outputs.
 | [aws_route53_record.origin_ns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.origin_root](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.origin_wildcard](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.tea_cognito_custom_domain](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_zone.origin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
 | [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_policy.api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
@@ -187,6 +192,7 @@ No outputs.
 | [aws_secretsmanager_secret_version.redis_reader_connection_string_value](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_ssm_parameter.cognito_public_keys](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.ecr_url](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.tea_cognito_public_keys](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [random_password.origin_header](https://registry.terraform.io/providers/hashicorp/random/3.6.0/docs/resources/password) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_cloudfront_cache_policy.caching_disabled](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudfront_cache_policy) | data source |
@@ -243,6 +249,7 @@ No outputs.
 | <a name="input_signon_secret_key_base"></a> [signon\_secret\_key\_base](#input\_signon\_secret\_key\_base) | Value of SECRET\_KEY\_BASE for the signon app. | `string` | n/a | yes |
 | <a name="input_slack_notify_lambda_slack_webhook_url"></a> [slack\_notify\_lambda\_slack\_webhook\_url](#input\_slack\_notify\_lambda\_slack\_webhook\_url) | Value of SLACK\_WEB\_HOOK\_URL for the slack notify lambda. | `string` | n/a | yes |
 | <a name="input_slack_web_hook_url"></a> [slack\_web\_hook\_url](#input\_slack\_web\_hook\_url) | Value of SLACK\_WEB\_HOOK\_URL for the backend. | `string` | n/a | yes |
+| <a name="input_subject_alternative_names"></a> [subject\_alternative\_names](#input\_subject\_alternative\_names) | List of additional domains to be added to the certificate. | `list(string)` | <pre>[<br>  "auth.tea.dev.trade-tariff.service.gov.uk"<br>]</pre> | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to resources. | `map(string)` | <pre>{<br>  "Billing": "TRN.HMR11896",<br>  "Environment": "development",<br>  "Project": "trade-tariff",<br>  "Terraform": true<br>}</pre> | no |
 | <a name="input_tariff_backend_differences_to_emails"></a> [tariff\_backend\_differences\_to\_emails](#input\_tariff\_backend\_differences\_to\_emails) | Differences report TO email addresses. | `string` | n/a | yes |
 | <a name="input_tariff_backend_green_lanes_api_tokens"></a> [tariff\_backend\_green\_lanes\_api\_tokens](#input\_tariff\_backend\_green\_lanes\_api\_tokens) | Value of GREEN\_LANES\_API\_TOKENS for the tariff backend. | `string` | n/a | yes |

--- a/environments/development/common/acm.tf
+++ b/environments/development/common/acm.tf
@@ -1,8 +1,9 @@
 module "acm" {
-  source         = "../../../modules/common/acm/"
-  domain_name    = var.domain_name
-  environment    = var.environment
-  hosted_zone_id = data.aws_route53_zone.this.zone_id
+  source                    = "../../../modules/common/acm/"
+  domain_name               = var.domain_name
+  environment               = var.environment
+  hosted_zone_id            = data.aws_route53_zone.this.zone_id
+  subject_alternative_names = var.subject_alternative_names
 
   providers = {
     aws = aws.us_east_1

--- a/environments/development/common/cognito.tf
+++ b/environments/development/common/cognito.tf
@@ -55,3 +55,61 @@ module "cognito_client_secret" {
   recovery_window = 7
   secret_string   = module.dev_hub_cognito.client_secret
 }
+
+module "commodi_tea_cognito" {
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cognito?ref=aws/cognito-v1.1.1"
+
+  pool_name              = "commodi-tea-user-pool"
+  domain                 = "auth.tea.${var.domain_name}"
+  domain_certificate_arn = module.acm.validated_certificate_arn
+
+  client_name            = "tea-client"
+  client_generate_secret = true
+
+  client_oauth_flow_allowed = true
+  allow_user_registration   = true
+  alias_attributes          = ["email", "preferred_username"]
+  client_oauth_grant_types  = ["code", "implicit"]
+  client_oauth_scopes       = ["openid", "email", "profile"]
+  client_callback_urls      = ["https://tea.${var.domain_name}"]
+  client_auth_flows = [
+    "ALLOW_CUSTOM_AUTH",
+    "ALLOW_USER_SRP_AUTH",
+    "ALLOW_REFRESH_TOKEN_AUTH",
+  ]
+}
+
+resource "aws_route53_record" "tea_cognito_custom_domain" {
+  name    = "auth.tea.${var.domain_name}"
+  type    = "A"
+  zone_id = data.aws_route53_zone.this.zone_id
+
+  alias {
+    evaluate_target_health = false
+    name                   = module.commodi_tea_cognito.cloudfront_distribution_arn
+    zone_id                = module.commodi_tea_cognito.cloudfront_distribution_zone_id
+  }
+}
+
+resource "aws_ssm_parameter" "tea_cognito_public_keys" {
+  name        = "/${var.environment}/COMMODI_TEA_COGNITO_PUBLIC_USER_URL"
+  description = "Commodi-Tea Cognito public keys URL."
+  type        = "SecureString"
+  value       = module.commodi_tea_cognito.user_pool_public_keys_url
+}
+
+module "tea_cognito_client_id" {
+  source          = "../../../modules/common/secret/"
+  name            = "tea-cognito-client-id"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = module.commodi_tea_cognito.client_id
+}
+
+module "tea_cognito_client_secret" {
+  source          = "../../../modules/common/secret/"
+  name            = "tea-cognito-client-secret"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = module.commodi_tea_cognito.client_secret
+}

--- a/environments/development/common/rds.tf
+++ b/environments/development/common/rds.tf
@@ -20,6 +20,8 @@ module "postgres" {
 
   secret_kms_key_arn = aws_kms_key.secretsmanager_kms_key.arn
 
+  parameter_group_name = "default.postgres13"
+
   depends_on = [
     module.alb-security-group
   ]
@@ -59,6 +61,8 @@ module "postgres_admin" {
 
   secret_kms_key_arn = aws_kms_key.secretsmanager_kms_key.arn
 
+  parameter_group_name = "default.postgres13"
+
   depends_on = [
     module.alb-security-group
   ]
@@ -90,6 +94,8 @@ module "mysql" {
 
   secret_kms_key_arn = aws_kms_key.secretsmanager_kms_key.arn
 
+  parameter_group_name = "default.mysql8.0"
+
   tags = {
     Name = "TradeTariffMySQL${title(var.environment)}"
   }
@@ -117,12 +123,31 @@ module "postgres_commodi_tea" {
 
   secret_kms_key_arn = aws_kms_key.secretsmanager_kms_key.arn
 
+  parameter_group_name = aws_db_parameter_group.tea.name
+
   depends_on = [
     module.alb-security-group
   ]
 
   tags = {
     Name     = "PostgresCommodiTea"
+    customer = "fpo"
+  }
+}
+
+resource "aws_db_parameter_group" "tea" {
+  name        = "postgres16-with-md5-password-encryption"
+  family      = "postgres16"
+  description = "Managed by Terraform"
+
+  parameter {
+    name         = "password_encryption"
+    value        = "md5"
+    apply_method = "immediate"
+  }
+
+  tags = {
+    Name     = "PostgresCommodiTea Parameter Group"
     customer = "fpo"
   }
 }

--- a/environments/development/common/variables.tf
+++ b/environments/development/common/variables.tf
@@ -42,6 +42,12 @@ variable "waf_rpm_limit" {
   default     = 2000
 }
 
+variable "subject_alternative_names" {
+  description = "List of additional domains to be added to the certificate."
+  type        = list(string)
+  default     = ["auth.tea.dev.trade-tariff.service.gov.uk"]
+}
+
 #
 # super secret stuff
 #

--- a/environments/production/common/README.md
+++ b/environments/production/common/README.md
@@ -53,6 +53,7 @@
 | <a name="module_cloudwatch-logs-exporter"></a> [cloudwatch-logs-exporter](#module\_cloudwatch-logs-exporter) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudwatch_log_exporter | aws/cloudwatch_log_exporter-v1.0.0 |
 | <a name="module_cognito_client_id"></a> [cognito\_client\_id](#module\_cognito\_client\_id) | ../../../modules/common/secret/ | n/a |
 | <a name="module_cognito_client_secret"></a> [cognito\_client\_secret](#module\_cognito\_client\_secret) | ../../../modules/common/secret/ | n/a |
+| <a name="module_commodi_tea_cognito"></a> [commodi\_tea\_cognito](#module\_commodi\_tea\_cognito) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cognito | aws/cognito-v1.1.1 |
 | <a name="module_dev_hub_backend_encryption_key"></a> [dev\_hub\_backend\_encryption\_key](#module\_dev\_hub\_backend\_encryption\_key) | ../../../modules/common/secret/ | n/a |
 | <a name="module_dev_hub_backend_sentry_dsn"></a> [dev\_hub\_backend\_sentry\_dsn](#module\_dev\_hub\_backend\_sentry\_dsn) | ../../../modules/common/secret/ | n/a |
 | <a name="module_dev_hub_cognito"></a> [dev\_hub\_cognito](#module\_dev\_hub\_cognito) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cognito | aws/cognito-v1.1.1 |
@@ -85,6 +86,8 @@
 | <a name="module_slack_notify_lambda_slack_webhook_url"></a> [slack\_notify\_lambda\_slack\_webhook\_url](#module\_slack\_notify\_lambda\_slack\_webhook\_url) | ../../../modules/common/secret/ | n/a |
 | <a name="module_slack_web_hook_url"></a> [slack\_web\_hook\_url](#module\_slack\_web\_hook\_url) | ../../../modules/common/secret/ | n/a |
 | <a name="module_status_checks_cdn"></a> [status\_checks\_cdn](#module\_status\_checks\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.4.2 |
+| <a name="module_tea_cognito_client_id"></a> [tea\_cognito\_client\_id](#module\_tea\_cognito\_client\_id) | ../../../modules/common/secret/ | n/a |
+| <a name="module_tea_cognito_client_secret"></a> [tea\_cognito\_client\_secret](#module\_tea\_cognito\_client\_secret) | ../../../modules/common/secret/ | n/a |
 | <a name="module_tech_docs_cdn"></a> [tech\_docs\_cdn](#module\_tech\_docs\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.4.2 |
 | <a name="module_waf"></a> [waf](#module\_waf) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/waf | aws/waf-v1.2.3 |
 
@@ -154,6 +157,7 @@
 | [aws_route53_record.origin_root](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.origin_wildcard](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.staging_name_servers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.tea_cognito_custom_domain](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_zone.origin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
 | [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_policy.api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
@@ -171,6 +175,7 @@
 | [aws_secretsmanager_secret_version.redis_reader_connection_string_value](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_ssm_parameter.cognito_public_keys](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.ecr_url](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.tea_cognito_public_keys](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [random_password.origin_header](https://registry.terraform.io/providers/hashicorp/random/3.6.0/docs/resources/password) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_cloudfront_cache_policy.caching_disabled](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudfront_cache_policy) | data source |
@@ -224,6 +229,7 @@
 | <a name="input_search_query_parser_sentry_dsn"></a> [search\_query\_parser\_sentry\_dsn](#input\_search\_query\_parser\_sentry\_dsn) | Value of SENTRY\_DSN for the search query parser. | `string` | n/a | yes |
 | <a name="input_slack_notify_lambda_slack_webhook_url"></a> [slack\_notify\_lambda\_slack\_webhook\_url](#input\_slack\_notify\_lambda\_slack\_webhook\_url) | Value of SLACK\_WEB\_HOOK\_URL for the slack notify lambda. | `string` | n/a | yes |
 | <a name="input_slack_web_hook_url"></a> [slack\_web\_hook\_url](#input\_slack\_web\_hook\_url) | Value of SLACK\_WEB\_HOOK\_URL for the backend. | `string` | n/a | yes |
+| <a name="input_subject_alternative_names"></a> [subject\_alternative\_names](#input\_subject\_alternative\_names) | List of additional domains to be added to the certificate. | `list(string)` | <pre>[<br>  "auth.tea.trade-tariff.service.gov.uk"<br>]</pre> | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to resources. | `map(string)` | <pre>{<br>  "Billing": "TRN.HMR11896",<br>  "Environment": "production",<br>  "Project": "trade-tariff",<br>  "Terraform": true<br>}</pre> | no |
 | <a name="input_tariff_backend_differences_to_emails"></a> [tariff\_backend\_differences\_to\_emails](#input\_tariff\_backend\_differences\_to\_emails) | Differences report TO email addresses. | `string` | n/a | yes |
 | <a name="input_tariff_backend_green_lanes_api_tokens"></a> [tariff\_backend\_green\_lanes\_api\_tokens](#input\_tariff\_backend\_green\_lanes\_api\_tokens) | Value of GREEN\_LANES\_API\_TOKENS for the tariff backend. | `string` | n/a | yes |

--- a/environments/production/common/acm.tf
+++ b/environments/production/common/acm.tf
@@ -1,8 +1,9 @@
 module "acm" {
-  source         = "../../../modules/common/acm/"
-  domain_name    = var.domain_name
-  environment    = var.environment
-  hosted_zone_id = data.aws_route53_zone.this.zone_id
+  source                    = "../../../modules/common/acm/"
+  domain_name               = var.domain_name
+  environment               = var.environment
+  hosted_zone_id            = data.aws_route53_zone.this.zone_id
+  subject_alternative_names = var.subject_alternative_names
 
   providers = {
     aws = aws.us_east_1

--- a/environments/production/common/cognito.tf
+++ b/environments/production/common/cognito.tf
@@ -55,3 +55,61 @@ module "cognito_client_secret" {
   recovery_window = 7
   secret_string   = module.dev_hub_cognito.client_secret
 }
+
+module "commodi_tea_cognito" {
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cognito?ref=aws/cognito-v1.1.1"
+
+  pool_name              = "commodi-tea-user-pool"
+  domain                 = "auth.tea.${var.domain_name}"
+  domain_certificate_arn = module.acm.validated_certificate_arn
+
+  client_name            = "tea-client"
+  client_generate_secret = true
+
+  client_oauth_flow_allowed = true
+  allow_user_registration   = true
+  alias_attributes          = ["email", "preferred_username"]
+  client_oauth_grant_types  = ["code", "implicit"]
+  client_oauth_scopes       = ["openid", "email", "profile"]
+  client_callback_urls      = ["https://tea.${var.domain_name}"]
+  client_auth_flows = [
+    "ALLOW_CUSTOM_AUTH",
+    "ALLOW_USER_SRP_AUTH",
+    "ALLOW_REFRESH_TOKEN_AUTH",
+  ]
+}
+
+resource "aws_route53_record" "tea_cognito_custom_domain" {
+  name    = "auth.tea.${var.domain_name}"
+  type    = "A"
+  zone_id = data.aws_route53_zone.this.zone_id
+
+  alias {
+    evaluate_target_health = false
+    name                   = module.commodi_tea_cognito.cloudfront_distribution_arn
+    zone_id                = module.commodi_tea_cognito.cloudfront_distribution_zone_id
+  }
+}
+
+resource "aws_ssm_parameter" "tea_cognito_public_keys" {
+  name        = "/${var.environment}/COMMODI_TEA_COGNITO_PUBLIC_USER_URL"
+  description = "Commodi-Tea Cognito public keys URL."
+  type        = "SecureString"
+  value       = module.commodi_tea_cognito.user_pool_public_keys_url
+}
+
+module "tea_cognito_client_id" {
+  source          = "../../../modules/common/secret/"
+  name            = "tea-cognito-client-id"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = module.commodi_tea_cognito.client_id
+}
+
+module "tea_cognito_client_secret" {
+  source          = "../../../modules/common/secret/"
+  name            = "tea-cognito-client-secret"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = module.commodi_tea_cognito.client_secret
+}

--- a/environments/production/common/rds.tf
+++ b/environments/production/common/rds.tf
@@ -22,6 +22,8 @@ module "postgres" {
 
   secret_kms_key_arn = aws_kms_key.secretsmanager_kms_key.arn
 
+  parameter_group_name = "default.postgres13"
+
   depends_on = [
     module.alb-security-group
   ]
@@ -62,6 +64,8 @@ module "postgres_admin" {
 
   secret_kms_key_arn = aws_kms_key.secretsmanager_kms_key.arn
 
+  parameter_group_name = "default.postgres13"
+
   depends_on = [
     module.alb-security-group
   ]
@@ -93,6 +97,8 @@ module "postgres_commodi_tea" {
 
   secret_kms_key_arn = aws_kms_key.secretsmanager_kms_key.arn
 
+  parameter_group_name = "default.postgres16"
+
   depends_on = [
     module.alb-security-group
   ]
@@ -102,3 +108,20 @@ module "postgres_commodi_tea" {
     customer = "fpo"
   }
 }
+
+# resource "aws_db_parameter_group" "tea" {
+#   name        = "postgres16-with-md5-password-encryption"
+#   family      = "postgres16"
+#   description = "Managed by Terraform"
+
+#   parameter {
+#     name         = "password_encryption"
+#     value        = "md5"
+#     apply_method = "immediate"
+#   }
+
+#   tags = {
+#     Name     = "PostgresCommodiTea Parameter Group"
+#     customer = "fpo"
+#   }
+# }

--- a/environments/production/common/variables.tf
+++ b/environments/production/common/variables.tf
@@ -42,6 +42,12 @@ variable "waf_rpm_limit" {
   default     = 5000
 }
 
+variable "subject_alternative_names" {
+  description = "List of additional domains to be added to the certificate."
+  type        = list(string)
+  default     = ["auth.tea.trade-tariff.service.gov.uk"]
+}
+
 #
 # super secret stuff
 #

--- a/environments/staging/common/README.md
+++ b/environments/staging/common/README.md
@@ -53,6 +53,7 @@
 | <a name="module_cloudwatch-logs-exporter"></a> [cloudwatch-logs-exporter](#module\_cloudwatch-logs-exporter) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudwatch_log_exporter | aws/cloudwatch_log_exporter-v1.0.0 |
 | <a name="module_cognito_client_id"></a> [cognito\_client\_id](#module\_cognito\_client\_id) | ../../../modules/common/secret/ | n/a |
 | <a name="module_cognito_client_secret"></a> [cognito\_client\_secret](#module\_cognito\_client\_secret) | ../../../modules/common/secret/ | n/a |
+| <a name="module_commodi_tea_cognito"></a> [commodi\_tea\_cognito](#module\_commodi\_tea\_cognito) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cognito | aws/cognito-v1.1.1 |
 | <a name="module_dev_hub_backend_encryption_key"></a> [dev\_hub\_backend\_encryption\_key](#module\_dev\_hub\_backend\_encryption\_key) | ../../../modules/common/secret/ | n/a |
 | <a name="module_dev_hub_backend_sentry_dsn"></a> [dev\_hub\_backend\_sentry\_dsn](#module\_dev\_hub\_backend\_sentry\_dsn) | ../../../modules/common/secret/ | n/a |
 | <a name="module_dev_hub_cognito"></a> [dev\_hub\_cognito](#module\_dev\_hub\_cognito) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cognito | aws/cognito-v1.1.1 |
@@ -91,6 +92,8 @@
 | <a name="module_slack_notify_lambda_slack_webhook_url"></a> [slack\_notify\_lambda\_slack\_webhook\_url](#module\_slack\_notify\_lambda\_slack\_webhook\_url) | ../../../modules/common/secret/ | n/a |
 | <a name="module_slack_web_hook_url"></a> [slack\_web\_hook\_url](#module\_slack\_web\_hook\_url) | ../../../modules/common/secret/ | n/a |
 | <a name="module_status_checks_cdn"></a> [status\_checks\_cdn](#module\_status\_checks\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.4.2 |
+| <a name="module_tea_cognito_client_id"></a> [tea\_cognito\_client\_id](#module\_tea\_cognito\_client\_id) | ../../../modules/common/secret/ | n/a |
+| <a name="module_tea_cognito_client_secret"></a> [tea\_cognito\_client\_secret](#module\_tea\_cognito\_client\_secret) | ../../../modules/common/secret/ | n/a |
 | <a name="module_tech_docs_cdn"></a> [tech\_docs\_cdn](#module\_tech\_docs\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.4.2 |
 | <a name="module_waf"></a> [waf](#module\_waf) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/waf | aws/waf-v1.2.3 |
 
@@ -147,6 +150,7 @@
 | [aws_route53_record.origin_ns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.origin_root](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.origin_wildcard](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.tea_cognito_custom_domain](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_zone.origin](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
 | [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_policy.api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
@@ -163,6 +167,7 @@
 | [aws_secretsmanager_secret_version.redis_reader_connection_string_value](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_ssm_parameter.cognito_public_keys](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.ecr_url](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.tea_cognito_public_keys](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [random_password.origin_header](https://registry.terraform.io/providers/hashicorp/random/3.6.0/docs/resources/password) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_cloudfront_cache_policy.caching_disabled](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudfront_cache_policy) | data source |
@@ -218,6 +223,7 @@
 | <a name="input_signon_secret_key_base"></a> [signon\_secret\_key\_base](#input\_signon\_secret\_key\_base) | Value of SECRET\_KEY\_BASE for the signon app. | `string` | n/a | yes |
 | <a name="input_slack_notify_lambda_slack_webhook_url"></a> [slack\_notify\_lambda\_slack\_webhook\_url](#input\_slack\_notify\_lambda\_slack\_webhook\_url) | Value of SLACK\_WEB\_HOOK\_URL for the slack notify lambda. | `string` | n/a | yes |
 | <a name="input_slack_web_hook_url"></a> [slack\_web\_hook\_url](#input\_slack\_web\_hook\_url) | Value of SLACK\_WEB\_HOOK\_URL for the backend. | `string` | n/a | yes |
+| <a name="input_subject_alternative_names"></a> [subject\_alternative\_names](#input\_subject\_alternative\_names) | List of additional domains to be added to the certificate. | `list(string)` | <pre>[<br>  "auth.tea.staging.trade-tariff.service.gov.uk"<br>]</pre> | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to resources. | `map(string)` | <pre>{<br>  "Billing": "TRN.HMR11896",<br>  "Environment": "staging",<br>  "Project": "trade-tariff",<br>  "Terraform": true<br>}</pre> | no |
 | <a name="input_tariff_backend_differences_to_emails"></a> [tariff\_backend\_differences\_to\_emails](#input\_tariff\_backend\_differences\_to\_emails) | Differences report TO email addresses. | `string` | n/a | yes |
 | <a name="input_tariff_backend_green_lanes_api_tokens"></a> [tariff\_backend\_green\_lanes\_api\_tokens](#input\_tariff\_backend\_green\_lanes\_api\_tokens) | Value of GREEN\_LANES\_API\_TOKENS for the tariff backend. | `string` | n/a | yes |

--- a/environments/staging/common/acm.tf
+++ b/environments/staging/common/acm.tf
@@ -1,8 +1,9 @@
 module "acm" {
-  source         = "../../../modules/common/acm/"
-  domain_name    = var.domain_name
-  environment    = var.environment
-  hosted_zone_id = data.aws_route53_zone.this.zone_id
+  source                    = "../../../modules/common/acm/"
+  domain_name               = var.domain_name
+  environment               = var.environment
+  hosted_zone_id            = data.aws_route53_zone.this.zone_id
+  subject_alternative_names = var.subject_alternative_names
 
   providers = {
     aws = aws.us_east_1

--- a/environments/staging/common/cognito.tf
+++ b/environments/staging/common/cognito.tf
@@ -55,3 +55,61 @@ module "cognito_client_secret" {
   recovery_window = 7
   secret_string   = module.dev_hub_cognito.client_secret
 }
+
+module "commodi_tea_cognito" {
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cognito?ref=aws/cognito-v1.1.1"
+
+  pool_name              = "commodi-tea-user-pool"
+  domain                 = "auth.tea.${var.domain_name}"
+  domain_certificate_arn = module.acm.validated_certificate_arn
+
+  client_name            = "tea-client"
+  client_generate_secret = true
+
+  client_oauth_flow_allowed = true
+  allow_user_registration   = true
+  alias_attributes          = ["email", "preferred_username"]
+  client_oauth_grant_types  = ["code", "implicit"]
+  client_oauth_scopes       = ["openid", "email", "profile"]
+  client_callback_urls      = ["https://tea.${var.domain_name}"]
+  client_auth_flows = [
+    "ALLOW_CUSTOM_AUTH",
+    "ALLOW_USER_SRP_AUTH",
+    "ALLOW_REFRESH_TOKEN_AUTH",
+  ]
+}
+
+resource "aws_route53_record" "tea_cognito_custom_domain" {
+  name    = "auth.tea.${var.domain_name}"
+  type    = "A"
+  zone_id = data.aws_route53_zone.this.zone_id
+
+  alias {
+    evaluate_target_health = false
+    name                   = module.commodi_tea_cognito.cloudfront_distribution_arn
+    zone_id                = module.commodi_tea_cognito.cloudfront_distribution_zone_id
+  }
+}
+
+resource "aws_ssm_parameter" "tea_cognito_public_keys" {
+  name        = "/${var.environment}/COMMODI_TEA_COGNITO_PUBLIC_USER_URL"
+  description = "Commodi-Tea Cognito public keys URL."
+  type        = "SecureString"
+  value       = module.commodi_tea_cognito.user_pool_public_keys_url
+}
+
+module "tea_cognito_client_id" {
+  source          = "../../../modules/common/secret/"
+  name            = "tea-cognito-client-id"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = module.commodi_tea_cognito.client_id
+}
+
+module "tea_cognito_client_secret" {
+  source          = "../../../modules/common/secret/"
+  name            = "tea-cognito-client-secret"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = module.commodi_tea_cognito.client_secret
+}

--- a/environments/staging/common/rds.tf
+++ b/environments/staging/common/rds.tf
@@ -20,6 +20,8 @@ module "postgres" {
 
   secret_kms_key_arn = aws_kms_key.secretsmanager_kms_key.arn
 
+  parameter_group_name = "default.postgres13"
+
   depends_on = [
     module.alb-security-group
   ]
@@ -59,6 +61,8 @@ module "postgres_admin" {
 
   secret_kms_key_arn = aws_kms_key.secretsmanager_kms_key.arn
 
+  parameter_group_name = "default.postgres13"
+
   depends_on = [
     module.alb-security-group
   ]
@@ -89,6 +93,8 @@ module "mysql" {
   security_group_ids    = [module.alb-security-group.be_to_rds_security_group_id]
 
   secret_kms_key_arn = aws_kms_key.secretsmanager_kms_key.arn
+
+  parameter_group_name = "default.mysql8.0"
 
   depends_on = [
     module.alb-security-group
@@ -121,6 +127,8 @@ module "postgres_commodi_tea" {
 
   secret_kms_key_arn = aws_kms_key.secretsmanager_kms_key.arn
 
+  parameter_group_name = "default.postgres16"
+
   depends_on = [
     module.alb-security-group
   ]
@@ -130,3 +138,20 @@ module "postgres_commodi_tea" {
     customer = "fpo"
   }
 }
+
+# resource "aws_db_parameter_group" "tea" {
+#   name        = "postgres16-with-md5-password-encryption"
+#   family      = "postgres16"
+#   description = "Managed by Terraform"
+
+#   parameter {
+#     name         = "password_encryption"
+#     value        = "md5"
+#     apply_method = "immediate"
+#   }
+
+#   tags = {
+#     Name     = "PostgresCommodiTea Parameter Group"
+#     customer = "fpo"
+#   }
+# }

--- a/environments/staging/common/variables.tf
+++ b/environments/staging/common/variables.tf
@@ -42,6 +42,12 @@ variable "waf_rpm_limit" {
   default     = 5000
 }
 
+variable "subject_alternative_names" {
+  description = "List of additional domains to be added to the certificate."
+  type        = list(string)
+  default     = ["auth.tea.staging.trade-tariff.service.gov.uk"]
+}
+
 #
 # super secret stuff
 #

--- a/modules/common/rds/rds.tf
+++ b/modules/common/rds/rds.tf
@@ -32,6 +32,8 @@ resource "aws_db_instance" "this" {
 
   vpc_security_group_ids = var.security_group_ids
 
+  parameter_group_name = var.parameter_group_name
+
   tags = local.tags
 }
 

--- a/modules/common/rds/variables.tf
+++ b/modules/common/rds/variables.tf
@@ -90,3 +90,8 @@ variable "multi_az" {
   type        = bool
   default     = false
 }
+
+variable "parameter_group_name" {
+  description = "Name of the parameter group to use for the RDS instance."
+  type        = string
+}


### PR DESCRIPTION
# Jira link
[FPO-335](https://transformuk.atlassian.net/jira/software/projects/FPO/boards/116?selectedIssue=FPO-335)
## What?

I have:

- Added a new resource `aws_db_parameter_group` named `tea` to the codebase.
- Added `parameter_group_name` to `aws_db_instance` resource.
- Added the subdomain name in the ACM `subject_alternative_names`.
- Removed the resource server configuration and updated client OAuth configs.
- Altered staging and production configurations to include the `aws_db_parameter_group` resource, but commented it out for now.

## Why?

I am doing this because:

- We need to set up secure user authentication and authorization for the commodi-tea application using Amazon Cognito
- The `postgres16-with-md5-password-encryption` parameter group was present in the AWS development console but missing from the repository code, leading to errors during resource destruction attempts.

