### PR TITLE
GL-603: Remove GL Caching Exception

### DIFF
--- a/environments/development/common/cloudfront.tf
+++ b/environments/development/common/cloudfront.tf
@@ -73,38 +73,6 @@ module "cdn" {
       ]
     }
 
-    green_lanes = {
-      target_origin_id       = "frontend"
-      viewer_protocol_policy = "redirect-to-https"
-
-      path_pattern = "/xi/api/v2/green_lanes/*"
-
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-
-      min_ttl     = 0
-      default_ttl = 0
-      max_ttl     = 0
-
-      compress = true
-
-      allowed_methods = [
-        "GET",
-        "HEAD",
-        "OPTIONS",
-        "PUT",
-        "POST",
-        "PATCH",
-        "DELETE"
-      ]
-
-      cached_methods = [
-        "GET",
-        "HEAD"
-      ]
-    }
-
     api = {
       target_origin_id       = "frontend"
       viewer_protocol_policy = "redirect-to-https"

--- a/environments/production/common/cloudfront.tf
+++ b/environments/production/common/cloudfront.tf
@@ -74,38 +74,6 @@ module "cdn" {
       ]
     }
 
-    green_lanes = {
-      target_origin_id       = "frontend"
-      viewer_protocol_policy = "redirect-to-https"
-
-      path_pattern = "/xi/api/v2/green_lanes/*"
-
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-
-      min_ttl     = 0
-      default_ttl = 0
-      max_ttl     = 0
-
-      compress = true
-
-      allowed_methods = [
-        "GET",
-        "HEAD",
-        "OPTIONS",
-        "PUT",
-        "POST",
-        "PATCH",
-        "DELETE"
-      ]
-
-      cached_methods = [
-        "GET",
-        "HEAD"
-      ]
-    }
-
     api = {
       target_origin_id       = "frontend"
       viewer_protocol_policy = "redirect-to-https"

--- a/environments/staging/common/cloudfront.tf
+++ b/environments/staging/common/cloudfront.tf
@@ -73,38 +73,6 @@ module "cdn" {
       ]
     }
 
-    green_lanes = {
-      target_origin_id       = "frontend"
-      viewer_protocol_policy = "redirect-to-https"
-
-      path_pattern = "/xi/api/v2/green_lanes/*"
-
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-
-      min_ttl     = 0
-      default_ttl = 0
-      max_ttl     = 0
-
-      compress = true
-
-      allowed_methods = [
-        "GET",
-        "HEAD",
-        "OPTIONS",
-        "PUT",
-        "POST",
-        "PATCH",
-        "DELETE"
-      ]
-
-      cached_methods = [
-        "GET",
-        "HEAD"
-      ]
-    }
-
     api = {
       target_origin_id       = "frontend"
       viewer_protocol_policy = "redirect-to-https"


### PR DESCRIPTION
# Jira link

[`GL-603`](https://transformuk.atlassian.net/browse/GL-603)

## What?

I have:

- Removed the CDN caching exception for `/xi/api/v2/green_lanes/*` routes.

## Why?

I am doing this because:

- Currently there is an exception in the CDN config for green lanes api endpoints to avoid those being cached (because we don’t want the CDN to cache an authenticated response, then serve it to a non-authenticated user). We should instead remove the exception and start caching the green lanes endpoints.
