### PR TITLE
Delete pg name

### DIFF
--- a/environments/development/applications/.terraform.lock.hcl
+++ b/environments/development/applications/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.41.0"
   constraints = ">= 4.55.0, >= 5.3.0"
   hashes = [
+    "h1:DiX7N35G2NUQRyRGy90+gyePnhP4w77f8LrJUronotE=",
     "h1:SgIWBDBA1uNB/Y7CaLFeNX/Ju2xboSSQmRv35Vbi46M=",
     "h1:uNln7837/ZTVgQBk+hhfgB9Y87icES6X0lMSOfK5c7g=",
     "zh:0553331a6287c146353b6daf6f71987d8c000f407b5e29d6e004ea88faec2e67",

--- a/environments/development/common/rds.tf
+++ b/environments/development/common/rds.tf
@@ -20,8 +20,6 @@ module "postgres" {
 
   secret_kms_key_arn = aws_kms_key.secretsmanager_kms_key.arn
 
-  parameter_group_name = "default.postgres13"
-
   depends_on = [
     module.alb-security-group
   ]
@@ -61,8 +59,6 @@ module "postgres_admin" {
 
   secret_kms_key_arn = aws_kms_key.secretsmanager_kms_key.arn
 
-  parameter_group_name = "default.postgres13"
-
   depends_on = [
     module.alb-security-group
   ]
@@ -94,8 +90,6 @@ module "mysql" {
 
   secret_kms_key_arn = aws_kms_key.secretsmanager_kms_key.arn
 
-  parameter_group_name = "default.mysql8.0"
-
   tags = {
     Name = "TradeTariffMySQL${title(var.environment)}"
   }
@@ -123,31 +117,12 @@ module "postgres_commodi_tea" {
 
   secret_kms_key_arn = aws_kms_key.secretsmanager_kms_key.arn
 
-  parameter_group_name = aws_db_parameter_group.tea.name
-
   depends_on = [
     module.alb-security-group
   ]
 
   tags = {
     Name     = "PostgresCommodiTea"
-    customer = "fpo"
-  }
-}
-
-resource "aws_db_parameter_group" "tea" {
-  name        = "postgres16-with-md5-password-encryption"
-  family      = "postgres16"
-  description = "Managed by Terraform"
-
-  parameter {
-    name         = "password_encryption"
-    value        = "md5"
-    apply_method = "immediate"
-  }
-
-  tags = {
-    Name     = "PostgresCommodiTea Parameter Group"
     customer = "fpo"
   }
 }

--- a/environments/production/common/rds.tf
+++ b/environments/production/common/rds.tf
@@ -22,8 +22,6 @@ module "postgres" {
 
   secret_kms_key_arn = aws_kms_key.secretsmanager_kms_key.arn
 
-  parameter_group_name = "default.postgres13"
-
   depends_on = [
     module.alb-security-group
   ]
@@ -64,8 +62,6 @@ module "postgres_admin" {
 
   secret_kms_key_arn = aws_kms_key.secretsmanager_kms_key.arn
 
-  parameter_group_name = "default.postgres13"
-
   depends_on = [
     module.alb-security-group
   ]
@@ -97,8 +93,6 @@ module "postgres_commodi_tea" {
 
   secret_kms_key_arn = aws_kms_key.secretsmanager_kms_key.arn
 
-  parameter_group_name = "default.postgres16"
-
   depends_on = [
     module.alb-security-group
   ]
@@ -108,20 +102,3 @@ module "postgres_commodi_tea" {
     customer = "fpo"
   }
 }
-
-# resource "aws_db_parameter_group" "tea" {
-#   name        = "postgres16-with-md5-password-encryption"
-#   family      = "postgres16"
-#   description = "Managed by Terraform"
-
-#   parameter {
-#     name         = "password_encryption"
-#     value        = "md5"
-#     apply_method = "immediate"
-#   }
-
-#   tags = {
-#     Name     = "PostgresCommodiTea Parameter Group"
-#     customer = "fpo"
-#   }
-# }

--- a/environments/staging/common/rds.tf
+++ b/environments/staging/common/rds.tf
@@ -20,8 +20,6 @@ module "postgres" {
 
   secret_kms_key_arn = aws_kms_key.secretsmanager_kms_key.arn
 
-  parameter_group_name = "default.postgres13"
-
   depends_on = [
     module.alb-security-group
   ]
@@ -61,8 +59,6 @@ module "postgres_admin" {
 
   secret_kms_key_arn = aws_kms_key.secretsmanager_kms_key.arn
 
-  parameter_group_name = "default.postgres13"
-
   depends_on = [
     module.alb-security-group
   ]
@@ -93,8 +89,6 @@ module "mysql" {
   security_group_ids    = [module.alb-security-group.be_to_rds_security_group_id]
 
   secret_kms_key_arn = aws_kms_key.secretsmanager_kms_key.arn
-
-  parameter_group_name = "default.mysql8.0"
 
   depends_on = [
     module.alb-security-group
@@ -127,8 +121,6 @@ module "postgres_commodi_tea" {
 
   secret_kms_key_arn = aws_kms_key.secretsmanager_kms_key.arn
 
-  parameter_group_name = "default.postgres16"
-
   depends_on = [
     module.alb-security-group
   ]
@@ -138,20 +130,3 @@ module "postgres_commodi_tea" {
     customer = "fpo"
   }
 }
-
-# resource "aws_db_parameter_group" "tea" {
-#   name        = "postgres16-with-md5-password-encryption"
-#   family      = "postgres16"
-#   description = "Managed by Terraform"
-
-#   parameter {
-#     name         = "password_encryption"
-#     value        = "md5"
-#     apply_method = "immediate"
-#   }
-
-#   tags = {
-#     Name     = "PostgresCommodiTea Parameter Group"
-#     customer = "fpo"
-#   }
-# }

--- a/modules/rds/rds.tf
+++ b/modules/rds/rds.tf
@@ -32,8 +32,6 @@ resource "aws_db_instance" "this" {
 
   vpc_security_group_ids = var.security_group_ids
 
-  parameter_group_name = var.parameter_group_name
-
   tags = local.tags
 }
 

--- a/modules/rds/variables.tf
+++ b/modules/rds/variables.tf
@@ -90,8 +90,3 @@ variable "multi_az" {
   type        = bool
   default     = false
 }
-
-variable "parameter_group_name" {
-  description = "Name of the parameter group to use for the RDS instance."
-  type        = string
-}


### PR DESCRIPTION
# Jira link

## What?
I have: 
- Removed the "postgres16-with-md5-password-encryption" parameter group: This custom parameter group has been deleted as it is no longer needed.
- Updated commodi-tea DB instances: That instance has been reassigned to use the default default.postgres16 parameter group instead of the custom one.
- Updated Terraform configuration: The Terraform configuration has been updated to reflect the removal of the postgres16-with-md5-password-encryption parameter group resource.


## Why?

I am doing this because:

After discussing with Will, I found out that the custom parameter group he created (postgres16-with-md5-password-encryption) was no longer needed so i.
