### PR TITLE
BAU: Get tea user pool working

### DIFF
--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -220,7 +220,7 @@ No outputs.
 | <a name="input_admin_sentry_dsn"></a> [admin\_sentry\_dsn](#input\_admin\_sentry\_dsn) | Value of Sentry DSN for the admin tool. | `string` | n/a | yes |
 | <a name="input_backend_secret_key_base"></a> [backend\_secret\_key\_base](#input\_backend\_secret\_key\_base) | Value of SECRET\_KEY\_BASE for the backend. | `string` | n/a | yes |
 | <a name="input_backups_basic_auth"></a> [backups\_basic\_auth](#input\_backups\_basic\_auth) | base64 encoded credentials for backups basic auth. | `string` | n/a | yes |
-| <a name="input_commmodi_tea_cookie_signing_secret"></a> [commmodi\_tea\_cookie\_signing\_secret](#input\_commmodi\_tea\_cookie\_signing\_secret) | Value of COOKIE\_SIGNING\_SECRET for the Commodi tea. | `string` | n/a | yes |
+| <a name="input_commodi_tea_cookie_signing_secret"></a> [commodi\_tea\_cookie\_signing\_secret](#input\_commodi\_tea\_cookie\_signing\_secret) | Value of COOKIE\_SIGNING\_SECRET for the Commodi tea. | `string` | n/a | yes |
 | <a name="input_dev_hub_backend_encryption_key"></a> [dev\_hub\_backend\_encryption\_key](#input\_dev\_hub\_backend\_encryption\_key) | Value of ENCRYPTION\_KEY for the dev hub backend. | `string` | n/a | yes |
 | <a name="input_dev_hub_backend_sentry_dsn"></a> [dev\_hub\_backend\_sentry\_dsn](#input\_dev\_hub\_backend\_sentry\_dsn) | Value of SENTRY\_DSN for the dev hub backend. | `string` | n/a | yes |
 | <a name="input_dev_hub_frontend_application_support_email"></a> [dev\_hub\_frontend\_application\_support\_email](#input\_dev\_hub\_frontend\_application\_support\_email) | Value of APPLICATION\_SUPPORT\_EMAIL for the dev hub frontend. | `string` | n/a | yes |

--- a/environments/development/common/cognito.tf
+++ b/environments/development/common/cognito.tf
@@ -72,7 +72,12 @@ module "commodi_tea_cognito" {
   auto_verified_attributes  = ["email"]
   client_oauth_grant_types  = ["code", "implicit"]
   client_oauth_scopes       = ["openid", "email", "profile"]
-  client_callback_urls      = ["https://tea.${var.domain_name}"]
+  client_callback_urls = [
+    "https://tea.${var.domain_name}",
+    "https://tea.${var.domain_name}/auth/redirect",
+    "http://localhost:5003",
+    "http://localhost:5003/auth/redirect",
+  ]
   client_identity_providers = ["COGNITO"]
   client_auth_flows = [
     "ALLOW_CUSTOM_AUTH",
@@ -114,4 +119,18 @@ module "tea_cognito_client_secret" {
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
   recovery_window = 7
   secret_string   = module.commodi_tea_cognito.client_secret
+}
+
+module "tea_cognito_secret" {
+  source          = "../../../modules/secret/"
+  name            = "tea-cognito-secret"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = random_password.tea_cognito_secret.result
+}
+
+resource "random_password" "tea_cognito_secret" {
+  length           = 16
+  special          = true
+  override_special = "!#$%&*()-_=+[]{}<>:?"
 }

--- a/environments/production/common/cognito.tf
+++ b/environments/production/common/cognito.tf
@@ -72,7 +72,10 @@ module "commodi_tea_cognito" {
   auto_verified_attributes  = ["email"]
   client_oauth_grant_types  = ["code", "implicit"]
   client_oauth_scopes       = ["openid", "email", "profile"]
-  client_callback_urls      = ["https://tea.${var.domain_name}"]
+  client_callback_urls = [
+    "https://tea.${var.domain_name}",
+    "https://tea.${var.domain_name}/auth/redirect",
+  ]
   client_identity_providers = ["COGNITO"]
   client_auth_flows = [
     "ALLOW_CUSTOM_AUTH",
@@ -114,4 +117,18 @@ module "tea_cognito_client_secret" {
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
   recovery_window = 7
   secret_string   = module.commodi_tea_cognito.client_secret
+}
+
+module "tea_cognito_secret" {
+  source          = "../../../modules/secret/"
+  name            = "tea-cognito-secret"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = random_password.tea_cognito_secret.result
+}
+
+resource "random_password" "tea_cognito_secret" {
+  length           = 16
+  special          = true
+  override_special = "!#$%&*()-_=+[]{}<>:?"
 }

--- a/environments/staging/common/cognito.tf
+++ b/environments/staging/common/cognito.tf
@@ -72,7 +72,10 @@ module "commodi_tea_cognito" {
   auto_verified_attributes  = ["email"]
   client_oauth_grant_types  = ["code", "implicit"]
   client_oauth_scopes       = ["openid", "email", "profile"]
-  client_callback_urls      = ["https://tea.${var.domain_name}"]
+  client_callback_urls = [
+    "https://tea.${var.domain_name}",
+    "https://tea.${var.domain_name}/auth/redirect",
+  ]
   client_identity_providers = ["COGNITO"]
   client_auth_flows = [
     "ALLOW_CUSTOM_AUTH",
@@ -114,4 +117,18 @@ module "tea_cognito_client_secret" {
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
   recovery_window = 7
   secret_string   = module.commodi_tea_cognito.client_secret
+}
+
+module "tea_cognito_secret" {
+  source          = "../../../modules/secret/"
+  name            = "tea-cognito-secret"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = random_password.tea_cognito_secret.result
+}
+
+resource "random_password" "tea_cognito_secret" {
+  length           = 16
+  special          = true
+  override_special = "!#$%&*()-_=+[]{}<>:?"
 }


### PR DESCRIPTION
# Jira link

BAU

## What?

I have:

- Added localhost as a callback url for the development tea user pool
- Added /auth/redirect as a callback url for the pool in all environments
- Added support for new secret needed by express-openid-connect

## Why?

I am doing this because:

- This enables redirects in the auth middleware in the localhost/development environment
- This is required secret configuration to get the middleware working (see https://github.com/trade-tariff/trade-tariff-commodi-tea/pull/21)
