### PR TITLE
FPO-404: Adds permissions to describe keypair

### DIFF
--- a/environments/development/common/iam.tf
+++ b/environments/development/common/iam.tf
@@ -463,6 +463,7 @@ resource "aws_iam_policy" "ci_fpo_models_secrets_policy" {
           "ec2:DescribeInstanceStatus",
           "ec2:DescribeInstanceTypeOfferings",
           "ec2:DescribeInstances",
+          "ec2:DescribeKeyPairs",
           "ec2:DescribeRegions",
           "ec2:DescribeSecurityGroups",
           "ec2:DescribeSubnets",


### PR DESCRIPTION
# Jira link

FPO-404

## What?

I have:

- Added permission to describe keypairs

## Why?

I am doing this because:

- This is needed for the ci user
