### PR TITLE
Fpo 425 update cognito user pool

### DIFF
--- a/environments/development/common/cognito.tf
+++ b/environments/development/common/cognito.tf
@@ -107,10 +107,6 @@ module "commodi_tea_cognito" {
     "http://localhost:5003/auth/redirect",
   ]
 
-  # client_logout_urls = [
-  #   "https://auth.tea.${var.domain_name}/logout",
-  # ]
-
   client_identity_providers = ["COGNITO"]
 
   client_auth_flows = [

--- a/environments/development/common/cognito.tf
+++ b/environments/development/common/cognito.tf
@@ -107,9 +107,9 @@ module "commodi_tea_cognito" {
     "http://localhost:5003/auth/redirect",
   ]
 
-  client_logout_urls = [
-    "https://auth.tea.${var.domain_name}/logout",
-  ]
+  # client_logout_urls = [
+  #   "https://auth.tea.${var.domain_name}/logout",
+  # ]
 
   client_identity_providers = ["COGNITO"]
 

--- a/environments/development/common/cognito.tf
+++ b/environments/development/common/cognito.tf
@@ -63,22 +63,56 @@ module "commodi_tea_cognito" {
   domain                 = "auth.tea.${var.domain_name}"
   domain_certificate_arn = module.acm.validated_certificate_arn
 
+  allow_user_registration  = true
+  username_attributes      = ["email"]
+  auto_verified_attributes = ["email"]
+
+  schemata = [
+    {
+      name      = "email"
+      required  = true
+      data_type = "String"
+    },
+    {
+      name      = "name"
+      required  = true
+      data_type = "String"
+    },
+    {
+      name      = "family_name"
+      required  = true
+      data_type = "String"
+    },
+  ]
+
   client_name            = "tea-client"
   client_generate_secret = true
 
   client_oauth_flow_allowed = true
-  allow_user_registration   = true
-  username_attributes       = ["email"]
-  auto_verified_attributes  = ["email"]
-  client_oauth_grant_types  = ["code", "implicit"]
-  client_oauth_scopes       = ["openid", "email", "profile"]
+  client_oauth_grant_types = [
+    "code",
+    "implicit"
+  ]
+
+  client_oauth_scopes = [
+    "openid",
+    "email",
+    "profile"
+  ]
+
   client_callback_urls = [
     "https://tea.${var.domain_name}",
     "https://tea.${var.domain_name}/auth/redirect",
     "http://localhost:5003",
     "http://localhost:5003/auth/redirect",
   ]
+
+  client_logout_urls = [
+    "https://auth.tea.${var.domain_name}/logout",
+  ]
+
   client_identity_providers = ["COGNITO"]
+
   client_auth_flows = [
     "ALLOW_CUSTOM_AUTH",
     "ALLOW_USER_SRP_AUTH",

--- a/environments/production/common/cognito.tf
+++ b/environments/production/common/cognito.tf
@@ -63,20 +63,50 @@ module "commodi_tea_cognito" {
   domain                 = "auth.tea.${var.domain_name}"
   domain_certificate_arn = module.acm.validated_certificate_arn
 
+  allow_user_registration  = true
+  username_attributes      = ["email"]
+  auto_verified_attributes = ["email"]
+
+  schemata = [
+    {
+      name      = "email"
+      required  = true
+      data_type = "String"
+    },
+    {
+      name      = "name"
+      required  = true
+      data_type = "String"
+    },
+    {
+      name      = "family_name"
+      required  = true
+      data_type = "String"
+    },
+  ]
+
   client_name            = "tea-client"
   client_generate_secret = true
 
   client_oauth_flow_allowed = true
-  allow_user_registration   = true
-  username_attributes       = ["email"]
-  auto_verified_attributes  = ["email"]
-  client_oauth_grant_types  = ["code", "implicit"]
-  client_oauth_scopes       = ["openid", "email", "profile"]
+  client_oauth_grant_types = [
+    "code",
+    "implicit"
+  ]
+
+  client_oauth_scopes = [
+    "openid",
+    "email",
+    "profile"
+  ]
+
   client_callback_urls = [
     "https://tea.${var.domain_name}",
     "https://tea.${var.domain_name}/auth/redirect",
   ]
+
   client_identity_providers = ["COGNITO"]
+
   client_auth_flows = [
     "ALLOW_CUSTOM_AUTH",
     "ALLOW_USER_SRP_AUTH",

--- a/environments/production/common/secrets.tf
+++ b/environments/production/common/secrets.tf
@@ -304,8 +304,9 @@ module "commodi_tea_cookie_signing_secret" {
 }
 
 module "download_cds_files_to_emails_secret" {
-  source          = "../../../modules/secret/"
-  name            = "download-cds-files-to-emails-secret"
-  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window = 7
+  source                = "../../../modules/secret/"
+  name                  = "download-cds-files-to-emails-secret"
+  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window       = 7
+  create_secret_version = false
 }

--- a/environments/staging/common/cognito.tf
+++ b/environments/staging/common/cognito.tf
@@ -63,20 +63,50 @@ module "commodi_tea_cognito" {
   domain                 = "auth.tea.${var.domain_name}"
   domain_certificate_arn = module.acm.validated_certificate_arn
 
+  allow_user_registration  = true
+  username_attributes      = ["email"]
+  auto_verified_attributes = ["email"]
+
+  schemata = [
+    {
+      name      = "email"
+      required  = true
+      data_type = "String"
+    },
+    {
+      name      = "name"
+      required  = true
+      data_type = "String"
+    },
+    {
+      name      = "family_name"
+      required  = true
+      data_type = "String"
+    },
+  ]
+
   client_name            = "tea-client"
   client_generate_secret = true
 
   client_oauth_flow_allowed = true
-  allow_user_registration   = true
-  username_attributes       = ["email"]
-  auto_verified_attributes  = ["email"]
-  client_oauth_grant_types  = ["code", "implicit"]
-  client_oauth_scopes       = ["openid", "email", "profile"]
+  client_oauth_grant_types = [
+    "code",
+    "implicit"
+  ]
+
+  client_oauth_scopes = [
+    "openid",
+    "email",
+    "profile"
+  ]
+
   client_callback_urls = [
     "https://tea.${var.domain_name}",
     "https://tea.${var.domain_name}/auth/redirect",
   ]
+
   client_identity_providers = ["COGNITO"]
+
   client_auth_flows = [
     "ALLOW_CUSTOM_AUTH",
     "ALLOW_USER_SRP_AUTH",

--- a/modules/secret/main.tf
+++ b/modules/secret/main.tf
@@ -5,7 +5,7 @@ resource "aws_secretsmanager_secret" "this" {
 }
 
 resource "aws_secretsmanager_secret_version" "this" {
-  count         = var.secret_string != null ? 1 : 0
+  count         = var.secret_string == null ? 0 : 1
   secret_id     = aws_secretsmanager_secret.this.id
   secret_string = var.secret_string
 }

--- a/modules/secret/main.tf
+++ b/modules/secret/main.tf
@@ -11,7 +11,7 @@ resource "aws_secretsmanager_secret" "this" {
 # }
 
 resource "aws_secretsmanager_secret_version" "this" {
-  for_each      = var.secret_string != null ? tomap(var.secret_string) : {}
+  for_each      = var.secret_string != null ? tomap([var.secret_string]) : {}
   secret_id     = aws_secretsmanager_secret.this.id
   secret_string = sensitive(each.value)
 }

--- a/modules/secret/main.tf
+++ b/modules/secret/main.tf
@@ -4,8 +4,14 @@ resource "aws_secretsmanager_secret" "this" {
   name                    = var.name
 }
 
+# resource "aws_secretsmanager_secret_version" "this" {
+#   count         = var.secret_string == null ? 0 : 1
+#   secret_id     = aws_secretsmanager_secret.this.id
+#   secret_string = var.secret_string
+# }
+
 resource "aws_secretsmanager_secret_version" "this" {
-  count         = var.secret_string == null ? 0 : 1
+  for_each      = var.secret_string != null ? tomap(var.secret_string) : {}
   secret_id     = aws_secretsmanager_secret.this.id
-  secret_string = var.secret_string
+  secret_string = sensitive(each.value)
 }

--- a/modules/secret/main.tf
+++ b/modules/secret/main.tf
@@ -5,7 +5,7 @@ resource "aws_secretsmanager_secret" "this" {
 }
 
 resource "aws_secretsmanager_secret_version" "this" {
-  # count         = var.secret_string == null ? 0 : 1
+  count         = var.secret_string == null ? 0 : 1
   secret_id     = aws_secretsmanager_secret.this.id
   secret_string = var.secret_string
 }

--- a/modules/secret/main.tf
+++ b/modules/secret/main.tf
@@ -4,14 +4,8 @@ resource "aws_secretsmanager_secret" "this" {
   name                    = var.name
 }
 
-# resource "aws_secretsmanager_secret_version" "this" {
-#   count         = var.secret_string == null ? 0 : 1
-#   secret_id     = aws_secretsmanager_secret.this.id
-#   secret_string = var.secret_string
-# }
-
 resource "aws_secretsmanager_secret_version" "this" {
-  for_each      = var.secret_string != null ? tomap([var.secret_string]) : {}
+  count         = var.create_secret_version ? 1 : 0
   secret_id     = aws_secretsmanager_secret.this.id
-  secret_string = sensitive(each.value)
+  secret_string = var.secret_string
 }

--- a/modules/secret/main.tf
+++ b/modules/secret/main.tf
@@ -5,7 +5,7 @@ resource "aws_secretsmanager_secret" "this" {
 }
 
 resource "aws_secretsmanager_secret_version" "this" {
-  count         = var.secret_string == null ? 0 : 1
+  # count         = var.secret_string == null ? 0 : 1
   secret_id     = aws_secretsmanager_secret.this.id
   secret_string = var.secret_string
 }

--- a/modules/secret/variables.tf
+++ b/modules/secret/variables.tf
@@ -7,7 +7,7 @@
 
 variable "secret_string" {
   description = "Value of the secret. Pass null to not populate a version"
-  type        = list(string)
+  type        = string
   default     = null
 }
 

--- a/modules/secret/variables.tf
+++ b/modules/secret/variables.tf
@@ -1,7 +1,13 @@
+# variable "secret_string" {
+#   description = "Value of the secret. Pass null to not populate a version"
+#   type        = string
+#   sensitive   = true
+#   default     = null
+# }
+
 variable "secret_string" {
   description = "Value of the secret. Pass null to not populate a version"
-  type        = string
-  sensitive   = true
+  type        = list(string)
   default     = null
 }
 

--- a/modules/secret/variables.tf
+++ b/modules/secret/variables.tf
@@ -1,14 +1,8 @@
-# variable "secret_string" {
-#   description = "Value of the secret. Pass null to not populate a version"
-#   type        = string
-#   sensitive   = true
-#   default     = null
-# }
-
 variable "secret_string" {
   description = "Value of the secret. Pass null to not populate a version"
   type        = string
-  default     = null
+  sensitive   = true
+  default     = ""
 }
 
 variable "name" {
@@ -24,4 +18,10 @@ variable "kms_key_arn" {
 variable "recovery_window" {
   description = "Recovery window in days for the secret."
   type        = string
+}
+
+variable "create_secret_version" {
+  description = "Whether to create a secret version. Set to false to create a secret without a version."
+  type        = bool
+  default     = true
 }


### PR DESCRIPTION
# Jira link
[FPO-425](https://transformuk.atlassian.net/jira/software/projects/FPO/boards/116?selectedIssue=FPO-425)
## What?

I have:

- Fixed the invalid count argument in `aws_secretsmanager_secret_version` by updating the conditional check for var.secret_string (!= null to == null ? 0 : 1).
- Updated the Cognito user pool schema to include `name`, `family_name`, and `email `attributes as required fields.

## Why?

I am doing this because:

- The secrets manager configuration was causing an error during the plan phase due to improper handling of the `count` argument when `secret_string` was `null`.
- We needed the `name` (first name) and `family_name` (last name) attributes in the Cognito user pool to support user data for a leaderboard feature in our app.