### PR TITLE
Fix rds engine version error. Upgrade from 13.13 to 13.15

### DIFF
--- a/environments/development/common/rds.tf
+++ b/environments/development/common/rds.tf
@@ -5,7 +5,7 @@ module "postgres" {
   environment    = var.environment
   name           = "TradeTariffPostgres${title(var.environment)}"
   engine         = "postgres"
-  engine_version = "13.13"
+  engine_version = "13.15"
 
   deletion_protection = false # while configuring
 
@@ -43,7 +43,7 @@ module "postgres_admin" {
   environment    = var.environment
   name           = "PostgresAdmin"
   engine         = "postgres"
-  engine_version = "13.13"
+  engine_version = "13.15"
 
   deletion_protection = false # while configuring
 

--- a/environments/production/common/rds.tf
+++ b/environments/production/common/rds.tf
@@ -5,7 +5,7 @@ module "postgres" {
   environment    = var.environment
   name           = "TradeTariffPostgres${title(var.environment)}"
   engine         = "postgres"
-  engine_version = "13.13"
+  engine_version = "13.15"
 
   deletion_protection = true
 
@@ -47,7 +47,7 @@ module "postgres_admin" {
   environment    = var.environment
   name           = "PostgresAdmin"
   engine         = "postgres"
-  engine_version = "13.13"
+  engine_version = "13.15"
 
   deletion_protection = true
 

--- a/environments/staging/common/rds.tf
+++ b/environments/staging/common/rds.tf
@@ -5,7 +5,7 @@ module "postgres" {
   environment    = var.environment
   name           = "TradeTariffPostgres${title(var.environment)}"
   engine         = "postgres"
-  engine_version = "13.13"
+  engine_version = "13.15"
 
   deletion_protection = true
 
@@ -44,7 +44,7 @@ module "postgres_admin" {
   environment    = var.environment
   name           = "PostgresAdmin"
   engine         = "postgres"
-  engine_version = "13.13"
+  engine_version = "13.15"
 
   deletion_protection = true
 


### PR DESCRIPTION
# Jira link

## What?

I have: 

- Updated the PostgreSQL engine version from 13.13 to 13.15 in the Terraform configuration.

## Why?

I am doing this because:

- AWS RDS no longer supports PostgreSQL version 13.13, and the lowest available version is 13.15. This mismatch was causing version-related errors during RDS instance updates.
