### PR TITLE
HMRC-237: Preview apps ALB

### DIFF
--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -47,6 +47,7 @@ No outputs.
 | <a name="module_acm"></a> [acm](#module\_acm) | ../../../modules/acm/ | n/a |
 | <a name="module_acm_london"></a> [acm\_london](#module\_acm\_london) | ../../../modules/acm/ | n/a |
 | <a name="module_acm_origin"></a> [acm\_origin](#module\_acm\_origin) | ../../../modules/acm | n/a |
+| <a name="module_acm_preview"></a> [acm\_preview](#module\_acm\_preview) | ../../../modules/acm | n/a |
 | <a name="module_admin_bearer_token"></a> [admin\_bearer\_token](#module\_admin\_bearer\_token) | ../../../modules/secret/ | n/a |
 | <a name="module_admin_oauth_id"></a> [admin\_oauth\_id](#module\_admin\_oauth\_id) | ../../../modules/secret/ | n/a |
 | <a name="module_admin_oauth_secret"></a> [admin\_oauth\_secret](#module\_admin\_oauth\_secret) | ../../../modules/secret/ | n/a |
@@ -54,6 +55,7 @@ No outputs.
 | <a name="module_admin_sentry_dsn"></a> [admin\_sentry\_dsn](#module\_admin\_sentry\_dsn) | ../../../modules/secret/ | n/a |
 | <a name="module_alb"></a> [alb](#module\_alb) | ../../../modules/application-load-balancer/ | n/a |
 | <a name="module_alb-security-group"></a> [alb-security-group](#module\_alb-security-group) | ../../../modules/security-group/ | n/a |
+| <a name="module_alb_preview"></a> [alb\_preview](#module\_alb\_preview) | ../../../modules/application-load-balancer/ | n/a |
 | <a name="module_api_cdn"></a> [api\_cdn](#module\_api\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.4.2 |
 | <a name="module_backend_differences_to_emails"></a> [backend\_differences\_to\_emails](#module\_backend\_differences\_to\_emails) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_green_lanes_api_tokens"></a> [backend\_green\_lanes\_api\_tokens](#module\_backend\_green\_lanes\_api\_tokens) | ../../../modules/secret/ | n/a |
@@ -103,6 +105,7 @@ No outputs.
 | <a name="module_postgres"></a> [postgres](#module\_postgres) | ../../../modules/rds | n/a |
 | <a name="module_postgres_admin"></a> [postgres\_admin](#module\_postgres\_admin) | ../../../modules/rds | n/a |
 | <a name="module_postgres_commodi_tea"></a> [postgres\_commodi\_tea](#module\_postgres\_commodi\_tea) | ../../../modules/rds | n/a |
+| <a name="module_preview_cdn"></a> [preview\_cdn](#module\_preview\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.4.2 |
 | <a name="module_read_only_postgres_connection_string"></a> [read\_only\_postgres\_connection\_string](#module\_read\_only\_postgres\_connection\_string) | ../../../modules/secret/ | n/a |
 | <a name="module_redis"></a> [redis](#module\_redis) | ../../../modules/elasticache-redis/ | n/a |
 | <a name="module_reporting_cdn"></a> [reporting\_cdn](#module\_reporting\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.4.2 |

--- a/environments/development/common/acm.tf
+++ b/environments/development/common/acm.tf
@@ -23,3 +23,10 @@ module "acm_origin" {
   environment    = var.environment
   hosted_zone_id = aws_route53_zone.origin.zone_id
 }
+
+module "acm_preview" {
+  source         = "../../../modules/acm"
+  domain_name    = "preview.${var.domain_name}"
+  environment    = var.environment
+  hosted_zone_id = aws_route53_zone.origin.zone_id
+}

--- a/environments/development/common/acm.tf
+++ b/environments/development/common/acm.tf
@@ -10,6 +10,17 @@ module "acm" {
   }
 }
 
+module "acm_preview" {
+  source         = "../../../modules/acm"
+  domain_name    = "preview.${var.domain_name}"
+  environment    = var.environment
+  hosted_zone_id = data.aws_route53_zone.this.zone_id
+
+  providers = {
+    aws = aws.us_east_1
+  }
+}
+
 module "acm_london" {
   source         = "../../../modules/acm/"
   domain_name    = var.domain_name
@@ -20,13 +31,6 @@ module "acm_london" {
 module "acm_origin" {
   source         = "../../../modules/acm"
   domain_name    = "origin.${var.domain_name}"
-  environment    = var.environment
-  hosted_zone_id = aws_route53_zone.origin.zone_id
-}
-
-module "acm_preview" {
-  source         = "../../../modules/acm"
-  domain_name    = "preview.${var.domain_name}"
   environment    = var.environment
   hosted_zone_id = aws_route53_zone.origin.zone_id
 }

--- a/environments/development/common/alb.tf
+++ b/environments/development/common/alb.tf
@@ -78,13 +78,13 @@ module "alb_preview" {
   }
 
   services = {
-    signon = {
+    signon_preview = {
       hosts            = ["signon.*"]
       healthcheck_path = "/healthcheck/live"
       priority         = 20
     }
 
-    hub_backend = {
+    hub_backend_preview = {
       hosts            = ["hub.*"]
       paths            = ["/api/healthcheck"]
       healthcheck_path = "/api/healthcheckz"

--- a/environments/development/common/alb.tf
+++ b/environments/development/common/alb.tf
@@ -68,7 +68,7 @@ module "alb_preview" {
   source                = "../../../modules/application-load-balancer/"
   alb_name              = "alb-preview-${var.environment}"
   alb_security_group_id = module.alb-security-group.alb_security_group_id
-  certificate_arn       = module.acm_preview.validated_certificate_arn
+  certificate_arn       = module.acm_origin.validated_certificate_arn
   public_subnet_ids     = data.terraform_remote_state.base.outputs.public_subnet_ids
   vpc_id                = data.terraform_remote_state.base.outputs.vpc_id
 

--- a/environments/development/common/alb.tf
+++ b/environments/development/common/alb.tf
@@ -63,3 +63,32 @@ module "alb" {
     }
   }
 }
+
+module "alb_preview" {
+  source                = "../../../modules/application-load-balancer/"
+  alb_name              = "alb-preview-${var.environment}"
+  alb_security_group_id = module.alb-security-group.alb_security_group_id
+  certificate_arn       = module.acm_preview.validated_certificate_arn
+  public_subnet_ids     = data.terraform_remote_state.base.outputs.public_subnet_ids
+  vpc_id                = data.terraform_remote_state.base.outputs.vpc_id
+
+  custom_header = {
+    name  = random_password.origin_header[0].result
+    value = random_password.origin_header[1].result
+  }
+
+  services = {
+    signon = {
+      hosts            = ["signon.*"]
+      healthcheck_path = "/healthcheck/live"
+      priority         = 20
+    }
+
+    hub_backend = {
+      hosts            = ["hub.*"]
+      paths            = ["/api/healthcheck"]
+      healthcheck_path = "/api/healthcheckz"
+      priority         = 40
+    }
+  }
+}

--- a/environments/development/common/cloudfront.tf
+++ b/environments/development/common/cloudfront.tf
@@ -507,9 +507,9 @@ module "preview_cdn" {
 
   viewer_certificate = {
     ssl_support_method  = "sni-only"
-    acm_certificate_arn = module.acm.validated_certificate_arn
+    acm_certificate_arn = module.acm_preview.validated_certificate_arn
     depends_on = [
-      module.acm.validated_certificate_arn
+      module.acm_preview.validated_certificate_arn
     ]
   }
 }


### PR DESCRIPTION
# Jira link

[`HMRC-237`](https://transformuk.atlassian.net/browse/HMRC-237)

## What?

I have:

- Added new ALB and CDN for preview apps.

## Why?

I am doing this because:

- We are switching away to preview apps in lower environments, which necessitates creating many of the target groups, listener rules, and assorted load balancer infrastructure at deploy-time.
- To minimise disruption in these environments, a new ALB and CDN are needed so we can test this setup alongside the current environment.
