### PR TITLE
HMRC-366: Reduce noise in WAF log group

### DIFF
--- a/environments/development/common/waf.tf
+++ b/environments/development/common/waf.tf
@@ -34,18 +34,34 @@ resource "aws_wafv2_web_acl_logging_configuration" "waf_logs" {
   logging_filter {
     default_behavior = "DROP"
 
+    # to remove noise in log group, since we are not blocking for no user agent
+    # header and instead COUNTing, drop all NoUserAgent_Header logs where rule
+    # action is COUNT.
+
     filter {
-      behavior = "KEEP"
+      behavior = "DROP"
 
       condition {
-        action_condition {
-          action = "BLOCK"
+        label_name_condition {
+          label_name = "awswaf:managed:aws:core-rule-set:NoUserAgent_Header"
         }
       }
 
       condition {
         action_condition {
           action = "COUNT"
+        }
+      }
+
+      requirement = "MEETS_ALL"
+    }
+
+    filter {
+      behavior = "KEEP"
+
+      condition {
+        action_condition {
+          action = "BLOCK"
         }
       }
 

--- a/environments/production/common/waf.tf
+++ b/environments/production/common/waf.tf
@@ -34,18 +34,34 @@ resource "aws_wafv2_web_acl_logging_configuration" "waf_logs" {
   logging_filter {
     default_behavior = "DROP"
 
+    # to remove noise in log group, since we are not blocking for no user agent
+    # header and instead COUNTing, drop all NoUserAgent_Header logs where rule
+    # action is COUNT.
+
     filter {
-      behavior = "KEEP"
+      behavior = "DROP"
 
       condition {
-        action_condition {
-          action = "BLOCK"
+        label_name_condition {
+          label_name = "awswaf:managed:aws:core-rule-set:NoUserAgent_Header"
         }
       }
 
       condition {
         action_condition {
           action = "COUNT"
+        }
+      }
+
+      requirement = "MEETS_ALL"
+    }
+
+    filter {
+      behavior = "KEEP"
+
+      condition {
+        action_condition {
+          action = "BLOCK"
         }
       }
 

--- a/environments/staging/common/waf.tf
+++ b/environments/staging/common/waf.tf
@@ -34,18 +34,34 @@ resource "aws_wafv2_web_acl_logging_configuration" "waf_logs" {
   logging_filter {
     default_behavior = "DROP"
 
+    # to remove noise in log group, since we are not blocking for no user agent
+    # header and instead COUNTing, drop all NoUserAgent_Header logs where rule
+    # action is COUNT.
+
     filter {
-      behavior = "KEEP"
+      behavior = "DROP"
 
       condition {
-        action_condition {
-          action = "BLOCK"
+        label_name_condition {
+          label_name = "awswaf:managed:aws:core-rule-set:NoUserAgent_Header"
         }
       }
 
       condition {
         action_condition {
           action = "COUNT"
+        }
+      }
+
+      requirement = "MEETS_ALL"
+    }
+
+    filter {
+      behavior = "KEEP"
+
+      condition {
+        action_condition {
+          action = "BLOCK"
         }
       }
 


### PR DESCRIPTION
# Jira link

## What?

I have:

- Updated the WAF logging configuration to drop all logs from the `NoUserAgent_Header` rule that are bypassed with a `COUNT` action.

## Why?

I am doing this because:

- We get a lot of requests to the service where users have not set a user agent header, meaning we get a lot of noise in our log group.