### PR TITLE
HMRC-490 Remove beta routes

### DIFF
--- a/environments/development/common/alb.tf
+++ b/environments/development/common/alb.tf
@@ -50,11 +50,11 @@ module "alb" {
       priority         = 17
     }
 
-    frontend_beta = {
-      hosts            = ["beta.*"]
-      healthcheck_path = "/healthcheckz"
-      priority         = 19
-    }
+    # frontend_beta = {
+    #   hosts            = ["beta.*"]
+    #   healthcheck_path = "/healthcheckz"
+    #   priority         = 19
+    # }
 
     frontend = {
       paths            = ["/*"]

--- a/environments/production/common/alb.tf
+++ b/environments/production/common/alb.tf
@@ -50,11 +50,11 @@ module "alb" {
       priority         = 17
     }
 
-    frontend_beta = {
-      hosts            = ["beta.*"]
-      healthcheck_path = "/healthcheckz"
-      priority         = 19
-    }
+    # frontend_beta = {
+    #   hosts            = ["beta.*"]
+    #   healthcheck_path = "/healthcheckz"
+    #   priority         = 19
+    # }
 
     frontend = {
       paths            = ["/*"]

--- a/environments/staging/common/alb.tf
+++ b/environments/staging/common/alb.tf
@@ -50,11 +50,11 @@ module "alb" {
       priority         = 17
     }
 
-    frontend_beta = {
-      hosts            = ["beta.*"]
-      healthcheck_path = "/healthcheckz"
-      priority         = 19
-    }
+    # frontend_beta = {
+    #   hosts            = ["beta.*"]
+    #   healthcheck_path = "/healthcheckz"
+    #   priority         = 19
+    # }
 
     frontend = {
       paths            = ["/*"]


### PR DESCRIPTION
# Jira link

HMRC-490 

## What?

I have:

- Removed the routes to `beta.*` as this is not used.  Commented out in case we want it back in the future.  All `beta.*` traffic thus is routed to the main production app for now.

## Why?

Beta is not used at the moment.