### PR TITLE
HMRC-582: Disable user registration on Commodi-tea

### DIFF
--- a/environments/development/common/cognito.tf
+++ b/environments/development/common/cognito.tf
@@ -63,7 +63,7 @@ module "commodi_tea_cognito" {
   domain                 = "auth.tea.${var.domain_name}"
   domain_certificate_arn = module.acm.validated_certificate_arn
 
-  allow_user_registration  = true
+  allow_user_registration  = false
   username_attributes      = ["email"]
   auto_verified_attributes = ["email"]
 

--- a/environments/production/common/cognito.tf
+++ b/environments/production/common/cognito.tf
@@ -63,7 +63,7 @@ module "commodi_tea_cognito" {
   domain                 = "auth.tea.${var.domain_name}"
   domain_certificate_arn = module.acm.validated_certificate_arn
 
-  allow_user_registration  = true
+  allow_user_registration  = false
   username_attributes      = ["email"]
   auto_verified_attributes = ["email"]
 

--- a/environments/staging/common/cognito.tf
+++ b/environments/staging/common/cognito.tf
@@ -63,7 +63,7 @@ module "commodi_tea_cognito" {
   domain                 = "auth.tea.${var.domain_name}"
   domain_certificate_arn = module.acm.validated_certificate_arn
 
-  allow_user_registration  = true
+  allow_user_registration  = false
   username_attributes      = ["email"]
   auto_verified_attributes = ["email"]
 


### PR DESCRIPTION
# Jira link
HMRC-582

## What?

I have:
- Altered the Commodi-tea cognito configuration to disallow user registration. 

## Why?

I am doing this because:
- Users should be invited rather than being able to sign themselves up.
