### PR TITLE
BAU: Configure a more aggressive rate limit in staging and production

### DIFF
--- a/environments/production/common/variables.tf
+++ b/environments/production/common/variables.tf
@@ -39,7 +39,7 @@ variable "tags" {
 variable "waf_rpm_limit" {
   description = "Request per minute limit for the WAF. This limit applies to our main CDN distribution and applies to all aliases on that CDN. "
   type        = number
-  default     = 5000
+  default     = 2500
 }
 
 #

--- a/environments/staging/common/variables.tf
+++ b/environments/staging/common/variables.tf
@@ -39,7 +39,7 @@ variable "tags" {
 variable "waf_rpm_limit" {
   description = "Request per minute limit for the WAF. This limit applies to our main CDN distribution and applies to all aliases on that CDN. "
   type        = number
-  default     = 5000
+  default     = 2500
 }
 
 #


### PR DESCRIPTION
# Jira link

BAU

## What?

I have:

- Altered rpm limit on the staging waf from 5000 to 2500
- Altered rpm limit on the production waf from 5000 to 2500

## Why?

I am doing this because:

- This is a more sensible configuration based on looking at API usage
