### PR TITLE
HMRC-635 Add more content to CF Cache

### DIFF
--- a/environments/production/common/cloudfront.tf
+++ b/environments/production/common/cloudfront.tf
@@ -105,6 +105,154 @@ module "cdn" {
         "HEAD"
       ]
     }
+
+    xi_api = {
+      target_origin_id       = "frontend"
+      viewer_protocol_policy = "redirect-to-https"
+
+      path_pattern = "/xi/api/*"
+
+      cache_policy_id            = aws_cloudfront_cache_policy.cache_api.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+
+      min_ttl     = 1
+      default_ttl = 1800
+      max_ttl     = 1800
+
+      compress = true
+
+      allowed_methods = [
+        "GET",
+        "HEAD",
+        "OPTIONS",
+        "PUT",
+        "POST",
+        "PATCH",
+        "DELETE"
+      ]
+
+      cached_methods = [
+        "GET",
+        "HEAD"
+      ]
+    }
+
+    uk_api = {
+      target_origin_id       = "frontend"
+      viewer_protocol_policy = "redirect-to-https"
+
+      path_pattern = "/uk/api/*"
+
+      cache_policy_id            = aws_cloudfront_cache_policy.cache_api.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+
+      min_ttl     = 1
+      default_ttl = 1800
+      max_ttl     = 1800
+
+      compress = true
+
+      allowed_methods = [
+        "GET",
+        "HEAD",
+        "OPTIONS",
+        "PUT",
+        "POST",
+        "PATCH",
+        "DELETE"
+      ]
+
+      cached_methods = [
+        "GET",
+        "HEAD"
+      ]
+    }
+
+    assets = {
+      target_origin_id       = "frontend"
+      viewer_protocol_policy = "redirect-to-https"
+
+      path_pattern = "/assets/*"
+
+      cache_policy_id            = aws_cloudfront_cache_policy.cache_api.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+
+      min_ttl     = 1
+      default_ttl = 86400
+      max_ttl     = 86400
+
+      compress = true
+
+      allowed_methods = [
+        "GET",
+        "HEAD",
+        "OPTIONS"
+      ]
+
+      cached_methods = [
+        "GET",
+        "HEAD"
+      ]
+    }
+
+    packs = {
+      target_origin_id       = "frontend"
+      viewer_protocol_policy = "redirect-to-https"
+
+      path_pattern = "/packs/*"
+
+      cache_policy_id            = aws_cloudfront_cache_policy.cache_api.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+
+      min_ttl     = 1
+      default_ttl = 86400
+      max_ttl     = 86400
+
+      compress = true
+
+      allowed_methods = [
+        "GET",
+        "HEAD",
+        "OPTIONS"
+      ]
+
+      cached_methods = [
+        "GET",
+        "HEAD"
+      ]
+    }
+
+    images = {
+      target_origin_id       = "frontend"
+      viewer_protocol_policy = "redirect-to-https"
+
+      path_pattern = "/images/*"
+
+      cache_policy_id            = aws_cloudfront_cache_policy.cache_api.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+
+      min_ttl     = 1
+      default_ttl = 86400
+      max_ttl     = 86400
+
+      compress = true
+
+      allowed_methods = [
+        "GET",
+        "HEAD",
+        "OPTIONS"
+      ]
+
+      cached_methods = [
+        "GET",
+        "HEAD"
+      ]
+    }
   }
 
   viewer_certificate = {


### PR DESCRIPTION
# Jira link

HMRC-635

## What?

We can cache more than we are in Cloudfront.  This PR adds:

```
/images
/packs
/assets
```
at a TTL of a day, plus

```
/uk/api
/xi/api
```
at 30 minutes
