### PR TITLE
HMRC-657: Adds route to uk and xi backend apps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ executors:
     environment:
       TF_INPUT: 0
       TF_IN_AUTOMATION: 1
-      TERRAGRUNT_VERSION: "0.50.15"
+      TERRAGRUNT_VERSION: "0.73.0"
 
 commands:
   install-terragrunt:

--- a/environments/development/common/alb.tf
+++ b/environments/development/common/alb.tf
@@ -50,11 +50,17 @@ module "alb" {
       priority         = 17
     }
 
-    # frontend_beta = {
-    #   hosts            = ["beta.*"]
-    #   healthcheck_path = "/healthcheckz"
-    #   priority         = 19
-    # }
+    backend_uk = {
+      paths            = ["/api", "/uk/api"]
+      healthcheck_path = "/healthcheckz"
+      priority         = 20
+    }
+
+    backend_xi = {
+      paths            = ["/xi/api"]
+      healthcheck_path = "/healthcheckz"
+      priority         = 21
+    }
 
     frontend = {
       paths            = ["/*"]

--- a/environments/development/common/cloudwatch.tf
+++ b/environments/development/common/cloudwatch.tf
@@ -93,7 +93,7 @@ resource "aws_kms_key_policy" "logs_bucket_kms_key_policy" {
 }
 
 module "logs" {
-  source = "git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git?ref=v3.14.0"
+  source = "git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git?ref=v4.5.0"
 
   bucket = "trade-tariff-logs-${local.account_id}"
   acl    = "log-delivery-write"

--- a/environments/development/common/cloudwatch.tf
+++ b/environments/development/common/cloudwatch.tf
@@ -120,8 +120,7 @@ module "logs" {
       enabled = true
 
       expiration = {
-        days                         = 7
-        expired_object_delete_marker = true
+        days = 7
       }
     }
   ]

--- a/environments/development/common/versions.tf
+++ b/environments/development/common/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.7"
+      version = "~> 5.86"
     }
 
     random = {

--- a/environments/production/common/README.md
+++ b/environments/production/common/README.md
@@ -253,7 +253,7 @@
 | <a name="input_tariff_backend_xi_sync_host"></a> [tariff\_backend\_xi\_sync\_host](#input\_tariff\_backend\_xi\_sync\_host) | Value of Tariff Sync host. | `string` | n/a | yes |
 | <a name="input_tariff_backend_xi_sync_password"></a> [tariff\_backend\_xi\_sync\_password](#input\_tariff\_backend\_xi\_sync\_password) | Value of Tariff Sync password. | `string` | n/a | yes |
 | <a name="input_tariff_backend_xi_sync_username"></a> [tariff\_backend\_xi\_sync\_username](#input\_tariff\_backend\_xi\_sync\_username) | Value of Tariff Sync username. | `string` | n/a | yes |
-| <a name="input_waf_rpm_limit"></a> [waf\_rpm\_limit](#input\_waf\_rpm\_limit) | Request per minute limit for the WAF. This limit applies to our main CDN distribution and applies to all aliases on that CDN. | `number` | `5000` | no |
+| <a name="input_waf_rpm_limit"></a> [waf\_rpm\_limit](#input\_waf\_rpm\_limit) | Request per minute limit for the WAF. This limit applies to our main CDN distribution and applies to all aliases on that CDN. | `number` | `2500` | no |
 
 ## Outputs
 

--- a/environments/production/common/cloudwatch.tf
+++ b/environments/production/common/cloudwatch.tf
@@ -120,8 +120,7 @@ module "logs" {
       enabled = true
 
       expiration = {
-        days                         = 30
-        expired_object_delete_marker = true
+        days = 30
       }
     }
   ]

--- a/environments/production/common/versions.tf
+++ b/environments/production/common/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.7"
+      version = "~> 5.86"
     }
 
     random = {

--- a/environments/staging/common/alb.tf
+++ b/environments/staging/common/alb.tf
@@ -50,11 +50,17 @@ module "alb" {
       priority         = 17
     }
 
-    # frontend_beta = {
-    #   hosts            = ["beta.*"]
-    #   healthcheck_path = "/healthcheckz"
-    #   priority         = 19
-    # }
+    backend_uk = {
+      paths            = ["/api", "/uk/api"]
+      healthcheck_path = "/healthcheckz"
+      priority         = 20
+    }
+
+    backend_xi = {
+      paths            = ["/xi/api"]
+      healthcheck_path = "/healthcheckz"
+      priority         = 21
+    }
 
     frontend = {
       paths            = ["/*"]

--- a/environments/staging/common/cloudwatch.tf
+++ b/environments/staging/common/cloudwatch.tf
@@ -120,8 +120,7 @@ module "logs" {
       enabled = true
 
       expiration = {
-        days                         = 7
-        expired_object_delete_marker = true
+        days = 7
       }
     }
   ]

--- a/environments/staging/common/versions.tf
+++ b/environments/staging/common/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.7"
+      version = "~> 5.86"
     }
 
     random = {


### PR DESCRIPTION
# Jira link

## What?

I have:

- [x] Added route direct to backend_uk/backend_xi apps in development
- [x] Added route direct to backend_uk/backend_xi apps in staging
- [ ] ~Added route direct to backend_uk/backend_xi apps in production~
- [x] Removed the expired_object_delete_marker value from cloudwatch log bucket lifecycle policy in all environments

## Why?

I am doing this because:

- This is required to separate out the backend api requests from the frontend
- The lifecycle policy can't have both days and expired_object_delete_marker and these contradictory values must have changed in how they behind in the AWS apis (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration)