### PR TITLE
BAU: Update default tag set

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: terragrunt-hclfmt
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.97.0
+    rev: v1.97.3
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/environments/development/applications/versions.tf
+++ b/environments/development/applications/versions.tf
@@ -9,5 +9,15 @@ terraform {
 }
 
 provider "aws" {
-  region = "eu-west-2"
+  region = var.region
+
+  default_tags {
+    tags = {
+      Terraform   = true
+      Project     = "trade-tariff"
+      Environment = var.environment
+      Stack       = basename(path.cwd)
+      Region      = var.region
+    }
+  }
 }

--- a/environments/development/applications/versions.tf
+++ b/environments/development/applications/versions.tf
@@ -18,6 +18,7 @@ provider "aws" {
       Environment = var.environment
       Stack       = basename(path.cwd)
       Region      = var.region
+      BillingCode = "HMR:OTT"
     }
   }
 }

--- a/environments/development/base/versions.tf
+++ b/environments/development/base/versions.tf
@@ -10,4 +10,14 @@ terraform {
 
 provider "aws" {
   region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      Terraform   = true
+      Project     = "trade-tariff"
+      Environment = "development"
+      Stack       = basename(path.cwd)
+      Region      = "eu-west-2"
+    }
+  }
 }

--- a/environments/development/base/versions.tf
+++ b/environments/development/base/versions.tf
@@ -18,6 +18,7 @@ provider "aws" {
       Environment = "development"
       Stack       = basename(path.cwd)
       Region      = "eu-west-2"
+      BillingCode = "HMR:OTT"
     }
   }
 }

--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -259,7 +259,6 @@ No outputs.
 | <a name="input_signon_secret_key_base"></a> [signon\_secret\_key\_base](#input\_signon\_secret\_key\_base) | Value of SECRET\_KEY\_BASE for the signon app. | `string` | n/a | yes |
 | <a name="input_slack_notify_lambda_slack_webhook_url"></a> [slack\_notify\_lambda\_slack\_webhook\_url](#input\_slack\_notify\_lambda\_slack\_webhook\_url) | Value of SLACK\_WEB\_HOOK\_URL for the slack notify lambda. | `string` | n/a | yes |
 | <a name="input_slack_web_hook_url"></a> [slack\_web\_hook\_url](#input\_slack\_web\_hook\_url) | Value of SLACK\_WEB\_HOOK\_URL for the backend. | `string` | n/a | yes |
-| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to resources. | `map(string)` | <pre>{<br/>  "Billing": "TRN.HMR11896",<br/>  "Environment": "development",<br/>  "Project": "trade-tariff",<br/>  "Terraform": true<br/>}</pre> | no |
 | <a name="input_tariff_backend_differences_to_emails"></a> [tariff\_backend\_differences\_to\_emails](#input\_tariff\_backend\_differences\_to\_emails) | Differences report TO email addresses. | `string` | n/a | yes |
 | <a name="input_tariff_backend_green_lanes_api_tokens"></a> [tariff\_backend\_green\_lanes\_api\_tokens](#input\_tariff\_backend\_green\_lanes\_api\_tokens) | Value of GREEN\_LANES\_API\_TOKENS for the tariff backend. | `string` | n/a | yes |
 | <a name="input_tariff_backend_oauth_id"></a> [tariff\_backend\_oauth\_id](#input\_tariff\_backend\_oauth\_id) | Value of Tariff Backend OAuth ID. | `string` | n/a | yes |

--- a/environments/development/common/ecr.tf
+++ b/environments/development/common/ecr.tf
@@ -4,5 +4,4 @@ resource "aws_ssm_parameter" "ecr_url" {
   description = "${title(each.key)} ECR repository URL."
   type        = "SecureString"
   value       = "${var.account_ids["production"]}.dkr.ecr.${var.region}.amazonaws.com/tariff-${each.key}-production"
-  tags        = var.tags
 }

--- a/environments/development/common/redis.tf
+++ b/environments/development/common/redis.tf
@@ -67,7 +67,6 @@ module "redis" {
   ]
 
   apply_immediately = true
-  tags              = var.tags
 }
 
 resource "aws_secretsmanager_secret" "redis_connection_string" {

--- a/environments/development/common/variables.tf
+++ b/environments/development/common/variables.tf
@@ -25,17 +25,6 @@ variable "account_ids" {
   }
 }
 
-variable "tags" {
-  description = "A map of tags to assign to resources."
-  type        = map(string)
-  default = {
-    Terraform   = true
-    Project     = "trade-tariff"
-    Environment = "development"
-    Billing     = "TRN.HMR11896"
-  }
-}
-
 variable "waf_rpm_limit" {
   description = "Request per minute limit for the WAF. This limit applies to our main CDN distribution and applies to all aliases on that CDN. "
   type        = number

--- a/environments/development/common/versions.tf
+++ b/environments/development/common/versions.tf
@@ -24,6 +24,7 @@ provider "aws" {
       Environment = var.environment
       Stack       = basename(path.cwd)
       Region      = var.region
+      BillingCode = "HMR:OTT"
     }
   }
 }
@@ -39,6 +40,7 @@ provider "aws" {
       Environment = var.environment
       Stack       = basename(path.cwd)
       Region      = "us-east-1"
+      BillingCode = "HMR:OTT"
     }
   }
 }

--- a/environments/development/common/versions.tf
+++ b/environments/development/common/versions.tf
@@ -16,9 +16,29 @@ terraform {
 
 provider "aws" {
   region = var.region
+
+  default_tags {
+    tags = {
+      Terraform   = true
+      Project     = "trade-tariff"
+      Environment = var.environment
+      Stack       = basename(path.cwd)
+      Region      = var.region
+    }
+  }
 }
 
 provider "aws" {
   region = "us-east-1"
   alias  = "us_east_1"
+
+  default_tags {
+    tags = {
+      Terraform   = true
+      Project     = "trade-tariff"
+      Environment = var.environment
+      Stack       = basename(path.cwd)
+      Region      = "us-east-1"
+    }
+  }
 }

--- a/environments/production/applications/versions.tf
+++ b/environments/production/applications/versions.tf
@@ -9,5 +9,15 @@ terraform {
 }
 
 provider "aws" {
-  region = "eu-west-2"
+  region = var.region
+
+  default_tags {
+    tags = {
+      Terraform   = true
+      Project     = "trade-tariff"
+      Environment = var.environment
+      Stack       = basename(path.cwd)
+      Region      = var.region
+    }
+  }
 }

--- a/environments/production/applications/versions.tf
+++ b/environments/production/applications/versions.tf
@@ -18,6 +18,7 @@ provider "aws" {
       Environment = var.environment
       Stack       = basename(path.cwd)
       Region      = var.region
+      BillingCode = "HMR:OTT"
     }
   }
 }

--- a/environments/production/base/versions.tf
+++ b/environments/production/base/versions.tf
@@ -18,6 +18,7 @@ provider "aws" {
       Environment = "production"
       Stack       = basename(path.cwd)
       Region      = "eu-west-2"
+      BillingCode = "HMR:OTT"
     }
   }
 }

--- a/environments/production/base/versions.tf
+++ b/environments/production/base/versions.tf
@@ -10,4 +10,14 @@ terraform {
 
 provider "aws" {
   region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      Terraform   = true
+      Project     = "trade-tariff"
+      Environment = "production"
+      Stack       = basename(path.cwd)
+      Region      = "eu-west-2"
+    }
+  }
 }

--- a/environments/production/common/README.md
+++ b/environments/production/common/README.md
@@ -238,7 +238,6 @@
 | <a name="input_region"></a> [region](#input\_region) | AWS Region to use. Defaults to `eu-west-2`. | `string` | `"eu-west-2"` | no |
 | <a name="input_slack_notify_lambda_slack_webhook_url"></a> [slack\_notify\_lambda\_slack\_webhook\_url](#input\_slack\_notify\_lambda\_slack\_webhook\_url) | Value of SLACK\_WEB\_HOOK\_URL for the slack notify lambda. | `string` | n/a | yes |
 | <a name="input_slack_web_hook_url"></a> [slack\_web\_hook\_url](#input\_slack\_web\_hook\_url) | Value of SLACK\_WEB\_HOOK\_URL for the backend. | `string` | n/a | yes |
-| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to resources. | `map(string)` | <pre>{<br/>  "Billing": "TRN.HMR11896",<br/>  "Environment": "production",<br/>  "Project": "trade-tariff",<br/>  "Terraform": true<br/>}</pre> | no |
 | <a name="input_tariff_backend_differences_to_emails"></a> [tariff\_backend\_differences\_to\_emails](#input\_tariff\_backend\_differences\_to\_emails) | Differences report TO email addresses. | `string` | n/a | yes |
 | <a name="input_tariff_backend_green_lanes_api_tokens"></a> [tariff\_backend\_green\_lanes\_api\_tokens](#input\_tariff\_backend\_green\_lanes\_api\_tokens) | Value of GREEN\_LANES\_API\_TOKENS for the tariff backend. | `string` | n/a | yes |
 | <a name="input_tariff_backend_oauth_id"></a> [tariff\_backend\_oauth\_id](#input\_tariff\_backend\_oauth\_id) | Value of Tariff Backend OAuth ID. | `string` | n/a | yes |

--- a/environments/production/common/ecr.tf
+++ b/environments/production/common/ecr.tf
@@ -54,7 +54,6 @@ data "aws_iam_policy_document" "ecr_policy_document" {
 
 module "ecr" {
   source      = "../../../modules/ecr/"
-  tags        = var.tags
   environment = var.environment
 }
 
@@ -64,7 +63,6 @@ resource "aws_ssm_parameter" "ecr_url" {
   description = "${title(each.key)} ECR repository URL."
   type        = "SecureString"
   value       = each.value
-  tags        = var.tags
 }
 
 resource "aws_ecr_repository_policy" "ecr_allow_staging_and_development" {

--- a/environments/production/common/redis.tf
+++ b/environments/production/common/redis.tf
@@ -69,7 +69,6 @@ module "redis" {
   ]
 
   apply_immediately = true
-  tags              = var.tags
 }
 
 resource "aws_secretsmanager_secret" "redis_connection_string" {

--- a/environments/production/common/variables.tf
+++ b/environments/production/common/variables.tf
@@ -25,17 +25,6 @@ variable "account_ids" {
   }
 }
 
-variable "tags" {
-  description = "A map of tags to assign to resources."
-  type        = map(string)
-  default = {
-    Terraform   = true
-    Project     = "trade-tariff"
-    Environment = "production"
-    Billing     = "TRN.HMR11896"
-  }
-}
-
 variable "waf_rpm_limit" {
   description = "Request per minute limit for the WAF. This limit applies to our main CDN distribution and applies to all aliases on that CDN. "
   type        = number

--- a/environments/production/common/versions.tf
+++ b/environments/production/common/versions.tf
@@ -24,6 +24,7 @@ provider "aws" {
       Environment = var.environment
       Stack       = basename(path.cwd)
       Region      = var.region
+      BillingCode = "HMR:OTT"
     }
   }
 }
@@ -39,6 +40,7 @@ provider "aws" {
       Environment = var.environment
       Stack       = basename(path.cwd)
       Region      = "us-east-1"
+      BillingCode = "HMR:OTT"
     }
   }
 }

--- a/environments/production/common/versions.tf
+++ b/environments/production/common/versions.tf
@@ -16,9 +16,29 @@ terraform {
 
 provider "aws" {
   region = var.region
+
+  default_tags {
+    tags = {
+      Terraform   = true
+      Project     = "trade-tariff"
+      Environment = var.environment
+      Stack       = basename(path.cwd)
+      Region      = var.region
+    }
+  }
 }
 
 provider "aws" {
   region = "us-east-1"
   alias  = "us_east_1"
+
+  default_tags {
+    tags = {
+      Terraform   = true
+      Project     = "trade-tariff"
+      Environment = var.environment
+      Stack       = basename(path.cwd)
+      Region      = "us-east-1"
+    }
+  }
 }

--- a/environments/staging/applications/versions.tf
+++ b/environments/staging/applications/versions.tf
@@ -9,5 +9,15 @@ terraform {
 }
 
 provider "aws" {
-  region = "eu-west-2"
+  region = var.region
+
+  default_tags {
+    tags = {
+      Terraform   = true
+      Project     = "trade-tariff"
+      Environment = var.environment
+      Stack       = basename(path.cwd)
+      Region      = var.region
+    }
+  }
 }

--- a/environments/staging/applications/versions.tf
+++ b/environments/staging/applications/versions.tf
@@ -18,6 +18,7 @@ provider "aws" {
       Environment = var.environment
       Stack       = basename(path.cwd)
       Region      = var.region
+      BillingCode = "HMR:OTT"
     }
   }
 }

--- a/environments/staging/base/versions.tf
+++ b/environments/staging/base/versions.tf
@@ -18,6 +18,7 @@ provider "aws" {
       Environment = "staging"
       Stack       = basename(path.cwd)
       Region      = "eu-west-2"
+      BillingCode = "HMR:OTT"
     }
   }
 }

--- a/environments/staging/base/versions.tf
+++ b/environments/staging/base/versions.tf
@@ -10,4 +10,14 @@ terraform {
 
 provider "aws" {
   region = "eu-west-2"
+
+  default_tags {
+    tags = {
+      Terraform   = true
+      Project     = "trade-tariff"
+      Environment = "staging"
+      Stack       = basename(path.cwd)
+      Region      = "eu-west-2"
+    }
+  }
 }

--- a/environments/staging/common/README.md
+++ b/environments/staging/common/README.md
@@ -234,7 +234,6 @@
 | <a name="input_signon_secret_key_base"></a> [signon\_secret\_key\_base](#input\_signon\_secret\_key\_base) | Value of SECRET\_KEY\_BASE for the signon app. | `string` | n/a | yes |
 | <a name="input_slack_notify_lambda_slack_webhook_url"></a> [slack\_notify\_lambda\_slack\_webhook\_url](#input\_slack\_notify\_lambda\_slack\_webhook\_url) | Value of SLACK\_WEB\_HOOK\_URL for the slack notify lambda. | `string` | n/a | yes |
 | <a name="input_slack_web_hook_url"></a> [slack\_web\_hook\_url](#input\_slack\_web\_hook\_url) | Value of SLACK\_WEB\_HOOK\_URL for the backend. | `string` | n/a | yes |
-| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to resources. | `map(string)` | <pre>{<br/>  "Billing": "TRN.HMR11896",<br/>  "Environment": "staging",<br/>  "Project": "trade-tariff",<br/>  "Terraform": true<br/>}</pre> | no |
 | <a name="input_tariff_backend_differences_to_emails"></a> [tariff\_backend\_differences\_to\_emails](#input\_tariff\_backend\_differences\_to\_emails) | Differences report TO email addresses. | `string` | n/a | yes |
 | <a name="input_tariff_backend_green_lanes_api_tokens"></a> [tariff\_backend\_green\_lanes\_api\_tokens](#input\_tariff\_backend\_green\_lanes\_api\_tokens) | Value of GREEN\_LANES\_API\_TOKENS for the tariff backend. | `string` | n/a | yes |
 | <a name="input_tariff_backend_oauth_id"></a> [tariff\_backend\_oauth\_id](#input\_tariff\_backend\_oauth\_id) | Value of Tariff Backend OAuth ID. | `string` | n/a | yes |

--- a/environments/staging/common/ecr.tf
+++ b/environments/staging/common/ecr.tf
@@ -4,5 +4,4 @@ resource "aws_ssm_parameter" "ecr_url" {
   description = "${title(each.key)} ECR repository URL."
   type        = "SecureString"
   value       = "${var.account_ids["production"]}.dkr.ecr.${var.region}.amazonaws.com/tariff-${each.key}-production"
-  tags        = var.tags
 }

--- a/environments/staging/common/redis.tf
+++ b/environments/staging/common/redis.tf
@@ -67,7 +67,6 @@ module "redis" {
   ]
 
   apply_immediately = true
-  tags              = var.tags
 }
 
 resource "aws_secretsmanager_secret" "redis_connection_string" {

--- a/environments/staging/common/variables.tf
+++ b/environments/staging/common/variables.tf
@@ -25,17 +25,6 @@ variable "account_ids" {
   }
 }
 
-variable "tags" {
-  description = "A map of tags to assign to resources."
-  type        = map(string)
-  default = {
-    Terraform   = true
-    Project     = "trade-tariff"
-    Environment = "staging"
-    Billing     = "TRN.HMR11896"
-  }
-}
-
 variable "waf_rpm_limit" {
   description = "Request per minute limit for the WAF. This limit applies to our main CDN distribution and applies to all aliases on that CDN. "
   type        = number

--- a/environments/staging/common/versions.tf
+++ b/environments/staging/common/versions.tf
@@ -24,6 +24,7 @@ provider "aws" {
       Environment = var.environment
       Stack       = basename(path.cwd)
       Region      = var.region
+      BillingCode = "HMR:OTT"
     }
   }
 }
@@ -39,6 +40,7 @@ provider "aws" {
       Environment = var.environment
       Stack       = basename(path.cwd)
       Region      = "us-east-1"
+      BillingCode = "HMR:OTT"
     }
   }
 }

--- a/environments/staging/common/versions.tf
+++ b/environments/staging/common/versions.tf
@@ -16,9 +16,29 @@ terraform {
 
 provider "aws" {
   region = var.region
+
+  default_tags {
+    tags = {
+      Terraform   = true
+      Project     = "trade-tariff"
+      Environment = var.environment
+      Stack       = basename(path.cwd)
+      Region      = var.region
+    }
+  }
 }
 
 provider "aws" {
   region = "us-east-1"
   alias  = "us_east_1"
+
+  default_tags {
+    tags = {
+      Terraform   = true
+      Project     = "trade-tariff"
+      Environment = var.environment
+      Stack       = basename(path.cwd)
+      Region      = "us-east-1"
+    }
+  }
 }

--- a/modules/ecr/ecr.tf
+++ b/modules/ecr/ecr.tf
@@ -13,7 +13,6 @@ resource "aws_ecr_repository" "this" {
   name                 = "tariff-${each.key}-${var.environment}"
   image_tag_mutability = "MUTABLE"
   force_delete         = false
-  tags                 = var.tags
 
   image_scanning_configuration {
     scan_on_push = true

--- a/modules/ecr/variables.tf
+++ b/modules/ecr/variables.tf
@@ -1,8 +1,3 @@
-variable "tags" {
-  description = "A map of tags to assign to the resource"
-  type        = map(string)
-}
-
 variable "environment" {
   description = "Build environment"
   type        = string


### PR DESCRIPTION
## What?

I have:

- Added `default_tags` for all stacks.

## Why?

I am doing this because:

- Lots of our infrastructure isn't tagged with anything; we should use a default tag set to ensure that each part of the stack is tagged with its cost code, environment, and region for use in the cost explorer.
