### PR TITLE
HMRC-689: Separate frontend/backend in production

### DIFF
--- a/environments/production/common/alb.tf
+++ b/environments/production/common/alb.tf
@@ -51,17 +51,16 @@ module "alb" {
     }
 
     backend_uk = {
-      paths            = ["/new/api/*", "/new/uk/api/*"]
+      paths            = ["/api/*", "/uk/api/*"]
       healthcheck_path = "/healthcheckz"
       priority         = 20
     }
 
     backend_xi = {
-      paths            = ["/new/xi/api/*"]
+      paths            = ["/xi/api/*"]
       healthcheck_path = "/healthcheckz"
       priority         = 21
     }
-
 
     frontend = {
       paths            = ["/*"]


### PR DESCRIPTION
# Jira link

HMRC-689

## What?

I have:

- Separated backend/frontend via ALB in production

## Why?

I am doing this because:

- This is an architectural change that simplifies all of our API-only routes whilst protecting the admin ones
