### PR TITLE
BAU: Revert separation of the backend/frontend

### DIFF
--- a/environments/production/common/alb.tf
+++ b/environments/production/common/alb.tf
@@ -51,13 +51,13 @@ module "alb" {
     }
 
     backend_uk = {
-      paths            = ["/api/*", "/uk/api/*"]
+      paths            = ["/new/api/*", "/new/uk/api/*"]
       healthcheck_path = "/healthcheckz"
       priority         = 20
     }
 
     backend_xi = {
-      paths            = ["/xi/api/*"]
+      paths            = ["/new/xi/api/*"]
       healthcheck_path = "/healthcheckz"
       priority         = 21
     }


### PR DESCRIPTION
# Jira link

BAU

## What?

I have:

- Reverted separation of the backend/frontend listeners

## Why?

I am doing this because:

- This can get closed once we're happy the separation was successful
