### PR TITLE
HMRC-670 Deprecate CHIEF Guidance from Infrastructure

### DIFF
--- a/environments/development/common/iam.tf
+++ b/environments/development/common/iam.tf
@@ -285,7 +285,8 @@ resource "aws_iam_policy" "ci_appendix5a_persistence_readwrite_policy" {
 
         Resource = [
           "arn:aws:s3:::${aws_s3_bucket.this["persistence"].id}",
-          "arn:aws:s3:::${aws_s3_bucket.this["persistence"].id}/config/chief_cds_guidance.json"
+          "arn:aws:s3:::${aws_s3_bucket.this["persistence"].id}/config/chief_cds_guidance.json",
+          "arn:aws:s3:::${aws_s3_bucket.this["persistence"].id}/config/cds_guidance.json"
         ]
       },
       {

--- a/environments/production/common/iam.tf
+++ b/environments/production/common/iam.tf
@@ -275,7 +275,8 @@ resource "aws_iam_policy" "ci_appendix5a_persistence_readwrite_policy" {
 
         Resource = [
           "arn:aws:s3:::${aws_s3_bucket.this["persistence"].id}",
-          "arn:aws:s3:::${aws_s3_bucket.this["persistence"].id}/config/chief_cds_guidance.json"
+          "arn:aws:s3:::${aws_s3_bucket.this["persistence"].id}/config/chief_cds_guidance.json",
+          "arn:aws:s3:::${aws_s3_bucket.this["persistence"].id}/config/cds_guidance.json"
         ]
       },
       {

--- a/environments/staging/common/iam.tf
+++ b/environments/staging/common/iam.tf
@@ -275,7 +275,8 @@ resource "aws_iam_policy" "ci_appendix5a_persistence_readwrite_policy" {
 
         Resource = [
           "arn:aws:s3:::${aws_s3_bucket.this["persistence"].id}",
-          "arn:aws:s3:::${aws_s3_bucket.this["persistence"].id}/config/chief_cds_guidance.json"
+          "arn:aws:s3:::${aws_s3_bucket.this["persistence"].id}/config/chief_cds_guidance.json",
+          "arn:aws:s3:::${aws_s3_bucket.this["persistence"].id}/config/cds_guidance.json"
         ]
       },
       {


### PR DESCRIPTION
# Jira link

https://transformuk.atlassian.net/browse/HMRC-670

## What?

I have Updated Access to S3 persistence/config for cds_guidance.json for all environments

## Why?

I am doing this because:

- the chief_cds_guidance.json file is being deprecated
