### PR TITLE
BAU: Removes admin redis service

### DIFF
--- a/environments/development/common/redis.tf
+++ b/environments/development/common/redis.tf
@@ -3,7 +3,6 @@ locals {
     "frontend",
     "backend-uk",
     "backend-xi",
-    "admin",
     "signon"
   ])
 }

--- a/environments/production/common/redis.tf
+++ b/environments/production/common/redis.tf
@@ -3,7 +3,6 @@ locals {
     "frontend",
     "backend-uk",
     "backend-xi",
-    "admin",
     "signon"
   ])
 }

--- a/environments/staging/common/redis.tf
+++ b/environments/staging/common/redis.tf
@@ -3,7 +3,6 @@ locals {
     "frontend",
     "backend-uk",
     "backend-xi",
-    "admin",
     "signon"
   ])
 }

--- a/modules/acm/README.md
+++ b/modules/acm/README.md
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.65.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.67.0 |
 
 ## Modules
 

--- a/modules/application-load-balancer/README.md
+++ b/modules/application-load-balancer/README.md
@@ -35,7 +35,7 @@ No outputs.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.65.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.67.0 |
 
 ## Modules
 

--- a/modules/cloudwatch/README.md
+++ b/modules/cloudwatch/README.md
@@ -11,7 +11,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.65.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.67.0 |
 
 ## Modules
 

--- a/modules/ecr/README.md
+++ b/modules/ecr/README.md
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.65.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.67.0 |
 
 ## Modules
 

--- a/modules/elasticache-redis/README.md
+++ b/modules/elasticache-redis/README.md
@@ -13,8 +13,8 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.65.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.6.2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.67.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.6.3 |
 
 ## Modules
 

--- a/modules/rds/README.md
+++ b/modules/rds/README.md
@@ -15,8 +15,8 @@ Creates an AWS RDS instance.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.65.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.6.2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.67.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.6.3 |
 
 ## Modules
 

--- a/modules/rds_cluster/README.md
+++ b/modules/rds_cluster/README.md
@@ -13,7 +13,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.84.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.86.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.6.3 |
 
 ## Modules

--- a/modules/secret/README.md
+++ b/modules/secret/README.md
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.65.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.67.0 |
 
 ## Modules
 

--- a/modules/security-group/README.md
+++ b/modules/security-group/README.md
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.65.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.67.0 |
 
 ## Modules
 

--- a/modules/ses/README.md
+++ b/modules/ses/README.md
@@ -13,7 +13,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.65.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.67.0 |
 
 ## Modules
 


### PR DESCRIPTION
# Jira link

## What?

I have:

- Remove admin redis in development
- Remove admin redis in staging
- Remove admin redis in production
- Updates docs

## Why?

I am doing this because:

- Admin doesn't require redis anymore https://github.com/trade-tariff/trade-tariff-admin/pull/832
