### PR TITLE
BAU: Reduce Aurora min ACU

### DIFF
--- a/environments/production/common/rds.tf
+++ b/environments/production/common/rds.tf
@@ -124,7 +124,7 @@ module "postgres_aurora" {
   encryption_at_rest = true
 
   # TODO: monitor capacity in production
-  min_capacity = 16
+  min_capacity = 2
   max_capacity = 64
 
   security_group_ids = [module.alb-security-group.be_to_rds_security_group_id]


### PR DESCRIPTION
# Jira link

BAU

I have reduced the min ACU for Aurora.  From looking at the stats and manually playing with the settings it seems 16 ACU was way high for what we want.  This PR reduces it to 2 so in reality the DB should sit at a lower level and relying on autoscaling.