### PR TITLE
HMRC-731:Update CircleCI pipeline to use OIDC-based role assumption

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  aws-cli: circleci/aws-cli@5.2
+
 deploy-feature-branches: &ignore-main
   filters:
     branches:
@@ -14,9 +17,6 @@ executors:
   default:
     docker:
       - image: 382373577178.dkr.ecr.eu-west-2.amazonaws.com/tariff-terraform-production:latest
-        aws_auth:
-          aws_access_key_id: $AWS_ACCESS_KEY_ID
-          aws_secret_access_key: $AWS_SECRET_ACCESS_KEY
     resource_class: small
     working_directory: "/tmp/terraform"
     environment:
@@ -33,6 +33,9 @@ jobs:
         type: string
     steps:
       - checkout
+      - aws-cli/setup:
+          role_arn: $AWS_ROLE_ARN
+          region: $AWS_DEFAULT_REGION
       - run: terraform fmt
       - run: terragrunt hclfmt
       - run:
@@ -48,6 +51,9 @@ jobs:
         type: string
     steps:
       - checkout
+      - aws-cli/setup:
+          role_arn: $AWS_ROLE_ARN
+          region: $AWS_DEFAULT_REGION
       - run:
           name: Terraform Plan
           command: |
@@ -61,6 +67,9 @@ jobs:
         type: string
     steps:
       - checkout
+      - aws-cli/setup:
+          role_arn: $AWS_ROLE_ARN
+          region: $AWS_DEFAULT_REGION
       - run:
           name: Terraform apply base
           command: |

--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -294,7 +294,7 @@ No outputs.
 | <a name="input_tariff_backend_xi_sync_host"></a> [tariff\_backend\_xi\_sync\_host](#input\_tariff\_backend\_xi\_sync\_host) | Value of Tariff Sync host. | `string` | n/a | yes |
 | <a name="input_tariff_backend_xi_sync_password"></a> [tariff\_backend\_xi\_sync\_password](#input\_tariff\_backend\_xi\_sync\_password) | Value of Tariff Sync password. | `string` | n/a | yes |
 | <a name="input_tariff_backend_xi_sync_username"></a> [tariff\_backend\_xi\_sync\_username](#input\_tariff\_backend\_xi\_sync\_username) | Value of Tariff Sync username. | `string` | n/a | yes |
-| <a name="input_thumbprint_list"></a> [thumbprint\_list](#input\_thumbprint\_list) | List of thumbprints for the OIDC provider. | `list(string)` | <pre>[<br>  "9e99a48a9960b14926bb7f3b02e22da2b0ab7280"<br>]</pre> | no |
+| <a name="input_thumbprint_list"></a> [thumbprint\_list](#input\_thumbprint\_list) | List of thumbprints for the OIDC provider. | `list(string)` | <pre>[<br>  "9e99a48a9960b14926bb7f3b02e22da2b0ab7280",<br>  "06B25927C42A721631C1EFD9431E648FA62E1E39"<br>]</pre> | no |
 | <a name="input_waf_rpm_limit"></a> [waf\_rpm\_limit](#input\_waf\_rpm\_limit) | Request per minute limit for the WAF. This limit applies to our main CDN distribution and applies to all aliases on that CDN. | `number` | `400` | no |
 
 ## Outputs

--- a/environments/development/common/variables.tf
+++ b/environments/development/common/variables.tf
@@ -40,7 +40,7 @@ variable "circleci_organisation_id" {
 variable "thumbprint_list" {
   type        = list(string)
   description = "List of thumbprints for the OIDC provider."
-  default     = ["9e99a48a9960b14926bb7f3b02e22da2b0ab7280"]
+  default     = ["9e99a48a9960b14926bb7f3b02e22da2b0ab7280", "06B25927C42A721631C1EFD9431E648FA62E1E39"]
 }
 
 #

--- a/environments/production/common/README.md
+++ b/environments/production/common/README.md
@@ -279,7 +279,7 @@
 | <a name="input_tariff_backend_xi_sync_host"></a> [tariff\_backend\_xi\_sync\_host](#input\_tariff\_backend\_xi\_sync\_host) | Value of Tariff Sync host. | `string` | n/a | yes |
 | <a name="input_tariff_backend_xi_sync_password"></a> [tariff\_backend\_xi\_sync\_password](#input\_tariff\_backend\_xi\_sync\_password) | Value of Tariff Sync password. | `string` | n/a | yes |
 | <a name="input_tariff_backend_xi_sync_username"></a> [tariff\_backend\_xi\_sync\_username](#input\_tariff\_backend\_xi\_sync\_username) | Value of Tariff Sync username. | `string` | n/a | yes |
-| <a name="input_thumbprint_list"></a> [thumbprint\_list](#input\_thumbprint\_list) | List of thumbprints for the OIDC provider. | `list(string)` | <pre>[<br>  "9e99a48a9960b14926bb7f3b02e22da2b0ab7280"<br>]</pre> | no |
+| <a name="input_thumbprint_list"></a> [thumbprint\_list](#input\_thumbprint\_list) | List of thumbprints for the OIDC provider. | `list(string)` | <pre>[<br>  "9e99a48a9960b14926bb7f3b02e22da2b0ab7280",<br>  "06B25927C42A721631C1EFD9431E648FA62E1E39"<br>]</pre> | no |
 | <a name="input_waf_rpm_limit"></a> [waf\_rpm\_limit](#input\_waf\_rpm\_limit) | Request per minute limit for the WAF. This limit applies to our main CDN distribution and applies to all aliases on that CDN. | `number` | `500` | no |
 
 ## Outputs

--- a/environments/production/common/variables.tf
+++ b/environments/production/common/variables.tf
@@ -40,7 +40,7 @@ variable "circleci_organisation_id" {
 variable "thumbprint_list" {
   type        = list(string)
   description = "List of thumbprints for the OIDC provider."
-  default     = ["9e99a48a9960b14926bb7f3b02e22da2b0ab7280"]
+  default     = ["9e99a48a9960b14926bb7f3b02e22da2b0ab7280", "06B25927C42A721631C1EFD9431E648FA62E1E39"]
 }
 
 #

--- a/environments/staging/common/README.md
+++ b/environments/staging/common/README.md
@@ -266,7 +266,7 @@
 | <a name="input_tariff_backend_xi_sync_host"></a> [tariff\_backend\_xi\_sync\_host](#input\_tariff\_backend\_xi\_sync\_host) | Value of Tariff Sync host. | `string` | n/a | yes |
 | <a name="input_tariff_backend_xi_sync_password"></a> [tariff\_backend\_xi\_sync\_password](#input\_tariff\_backend\_xi\_sync\_password) | Value of Tariff Sync password. | `string` | n/a | yes |
 | <a name="input_tariff_backend_xi_sync_username"></a> [tariff\_backend\_xi\_sync\_username](#input\_tariff\_backend\_xi\_sync\_username) | Value of Tariff Sync username. | `string` | n/a | yes |
-| <a name="input_thumbprint_list"></a> [thumbprint\_list](#input\_thumbprint\_list) | List of thumbprints for the OIDC provider. | `list(string)` | <pre>[<br>  "9e99a48a9960b14926bb7f3b02e22da2b0ab7280"<br>]</pre> | no |
+| <a name="input_thumbprint_list"></a> [thumbprint\_list](#input\_thumbprint\_list) | List of thumbprints for the OIDC provider. | `list(string)` | <pre>[<br>  "9e99a48a9960b14926bb7f3b02e22da2b0ab7280",<br>  "06B25927C42A721631C1EFD9431E648FA62E1E39"<br>]</pre> | no |
 | <a name="input_waf_rpm_limit"></a> [waf\_rpm\_limit](#input\_waf\_rpm\_limit) | Request per minute limit for the WAF. This limit applies to our main CDN distribution and applies to all aliases on that CDN. | `number` | `400` | no |
 
 ## Outputs

--- a/environments/staging/common/variables.tf
+++ b/environments/staging/common/variables.tf
@@ -40,7 +40,7 @@ variable "circleci_organisation_id" {
 variable "thumbprint_list" {
   type        = list(string)
   description = "List of thumbprints for the OIDC provider."
-  default     = ["9e99a48a9960b14926bb7f3b02e22da2b0ab7280"]
+  default     = ["9e99a48a9960b14926bb7f3b02e22da2b0ab7280", "06B25927C42A721631C1EFD9431E648FA62E1E39"]
 }
 
 #


### PR DESCRIPTION
# Jira link
[HMRC-731](https://transformuk.atlassian.net/browse/HMRC-731)

## What?

I have:

- Replaced long-lived AWS credentials with OpenID Connect (OIDC) authentication in the CircleCI pipeline

## Why?

I am doing this because:

- OIDC provides a more secure and scalable way to authenticate without storing long-lived credentials.
-
-
