### PR TITLE
HMRC-814: Simplify secrets management

### DIFF
--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -50,6 +50,7 @@ No outputs.
 | <a name="module_acm_origin"></a> [acm\_origin](#module\_acm\_origin) | ../../../modules/acm | n/a |
 | <a name="module_acm_preview"></a> [acm\_preview](#module\_acm\_preview) | ../../../modules/acm | n/a |
 | <a name="module_admin_bearer_token"></a> [admin\_bearer\_token](#module\_admin\_bearer\_token) | ../../../modules/secret/ | n/a |
+| <a name="module_admin_configuration"></a> [admin\_configuration](#module\_admin\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_admin_connection_string"></a> [admin\_connection\_string](#module\_admin\_connection\_string) | ../../../modules/secret/ | n/a |
 | <a name="module_admin_oauth_id"></a> [admin\_oauth\_id](#module\_admin\_oauth\_id) | ../../../modules/secret/ | n/a |
 | <a name="module_admin_oauth_secret"></a> [admin\_oauth\_secret](#module\_admin\_oauth\_secret) | ../../../modules/secret/ | n/a |
@@ -66,14 +67,18 @@ No outputs.
 | <a name="module_backend_secret_key_base"></a> [backend\_secret\_key\_base](#module\_backend\_secret\_key\_base) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_sentry_dsn"></a> [backend\_sentry\_dsn](#module\_backend\_sentry\_dsn) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_sync_email"></a> [backend\_sync\_email](#module\_backend\_sync\_email) | ../../../modules/secret/ | n/a |
+| <a name="module_backend_uk_api_configuration"></a> [backend\_uk\_api\_configuration](#module\_backend\_uk\_api\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_uk_sync_host"></a> [backend\_uk\_sync\_host](#module\_backend\_uk\_sync\_host) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_uk_sync_password"></a> [backend\_uk\_sync\_password](#module\_backend\_uk\_sync\_password) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_uk_sync_username"></a> [backend\_uk\_sync\_username](#module\_backend\_uk\_sync\_username) | ../../../modules/secret/ | n/a |
+| <a name="module_backend_uk_worker_configuration"></a> [backend\_uk\_worker\_configuration](#module\_backend\_uk\_worker\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_xe_api_password"></a> [backend\_xe\_api\_password](#module\_backend\_xe\_api\_password) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_xe_api_username"></a> [backend\_xe\_api\_username](#module\_backend\_xe\_api\_username) | ../../../modules/secret/ | n/a |
+| <a name="module_backend_xi_api_configuration"></a> [backend\_xi\_api\_configuration](#module\_backend\_xi\_api\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_xi_sync_host"></a> [backend\_xi\_sync\_host](#module\_backend\_xi\_sync\_host) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_xi_sync_password"></a> [backend\_xi\_sync\_password](#module\_backend\_xi\_sync\_password) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_xi_sync_username"></a> [backend\_xi\_sync\_username](#module\_backend\_xi\_sync\_username) | ../../../modules/secret/ | n/a |
+| <a name="module_backend_xi_worker_configuration"></a> [backend\_xi\_worker\_configuration](#module\_backend\_xi\_worker\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_backups_cdn"></a> [backups\_cdn](#module\_backups\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.4.2 |
 | <a name="module_cdn"></a> [cdn](#module\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.4.2 |
 | <a name="module_cloudwatch"></a> [cloudwatch](#module\_cloudwatch) | ../../../modules/cloudwatch/ | n/a |
@@ -81,6 +86,7 @@ No outputs.
 | <a name="module_cognito_client_id"></a> [cognito\_client\_id](#module\_cognito\_client\_id) | ../../../modules/secret/ | n/a |
 | <a name="module_cognito_client_secret"></a> [cognito\_client\_secret](#module\_cognito\_client\_secret) | ../../../modules/secret/ | n/a |
 | <a name="module_commodi_tea_cognito"></a> [commodi\_tea\_cognito](#module\_commodi\_tea\_cognito) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cognito | aws/cognito-v1.1.1 |
+| <a name="module_commodi_tea_configuration"></a> [commodi\_tea\_configuration](#module\_commodi\_tea\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_commodi_tea_cookie_signing_secret"></a> [commodi\_tea\_cookie\_signing\_secret](#module\_commodi\_tea\_cookie\_signing\_secret) | ../../../modules/secret/ | n/a |
 | <a name="module_commodi_tea_fpo_search_api_key"></a> [commodi\_tea\_fpo\_search\_api\_key](#module\_commodi\_tea\_fpo\_search\_api\_key) | ../../../modules/secret/ | n/a |
 | <a name="module_dev_hub_backend_encryption_key"></a> [dev\_hub\_backend\_encryption\_key](#module\_dev\_hub\_backend\_encryption\_key) | ../../../modules/secret/ | n/a |
@@ -94,10 +100,13 @@ No outputs.
 | <a name="module_dev_hub_frontend_scp_open_id_client_secret"></a> [dev\_hub\_frontend\_scp\_open\_id\_client\_secret](#module\_dev\_hub\_frontend\_scp\_open\_id\_client\_secret) | ../../../modules/secret/ | n/a |
 | <a name="module_dev_hub_frontend_scp_open_id_secret"></a> [dev\_hub\_frontend\_scp\_open\_id\_secret](#module\_dev\_hub\_frontend\_scp\_open\_id\_secret) | ../../../modules/secret/ | n/a |
 | <a name="module_dev_hub_frontend_sentry_dsn"></a> [dev\_hub\_frontend\_sentry\_dsn](#module\_dev\_hub\_frontend\_sentry\_dsn) | ../../../modules/secret/ | n/a |
+| <a name="module_developer_hub_configuration"></a> [developer\_hub\_configuration](#module\_developer\_hub\_configuration) | ../../../modules/secret/ | n/a |
+| <a name="module_duty_calculator_configuration"></a> [duty\_calculator\_configuration](#module\_duty\_calculator\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_duty_calculator_secret_key_base"></a> [duty\_calculator\_secret\_key\_base](#module\_duty\_calculator\_secret\_key\_base) | ../../../modules/secret/ | n/a |
 | <a name="module_duty_calculator_sentry_dsn"></a> [duty\_calculator\_sentry\_dsn](#module\_duty\_calculator\_sentry\_dsn) | ../../../modules/secret/ | n/a |
 | <a name="module_fpo_search_sentry_dsn"></a> [fpo\_search\_sentry\_dsn](#module\_fpo\_search\_sentry\_dsn) | ../../../modules/secret/ | n/a |
 | <a name="module_fpo_search_training_pem"></a> [fpo\_search\_training\_pem](#module\_fpo\_search\_training\_pem) | ../../../modules/secret/ | n/a |
+| <a name="module_frontend_configuration"></a> [frontend\_configuration](#module\_frontend\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_frontend_secret_key_base"></a> [frontend\_secret\_key\_base](#module\_frontend\_secret\_key\_base) | ../../../modules/secret/ | n/a |
 | <a name="module_frontend_sentry_dsn"></a> [frontend\_sentry\_dsn](#module\_frontend\_sentry\_dsn) | ../../../modules/secret/ | n/a |
 | <a name="module_logs"></a> [logs](#module\_logs) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v4.5.0 |
@@ -108,6 +117,7 @@ No outputs.
 | <a name="module_postgres_admin_aurora"></a> [postgres\_admin\_aurora](#module\_postgres\_admin\_aurora) | ../../../modules/rds_cluster | n/a |
 | <a name="module_postgres_aurora"></a> [postgres\_aurora](#module\_postgres\_aurora) | ../../../modules/rds_cluster | n/a |
 | <a name="module_postgres_commodi_tea"></a> [postgres\_commodi\_tea](#module\_postgres\_commodi\_tea) | ../../../modules/rds | n/a |
+| <a name="module_postgres_developer_hub"></a> [postgres\_developer\_hub](#module\_postgres\_developer\_hub) | ../../../modules/rds | n/a |
 | <a name="module_preview_cdn"></a> [preview\_cdn](#module\_preview\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.4.2 |
 | <a name="module_redis"></a> [redis](#module\_redis) | ../../../modules/elasticache-redis/ | n/a |
 | <a name="module_reporting_cdn"></a> [reporting\_cdn](#module\_reporting\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.4.2 |
@@ -242,7 +252,7 @@ No outputs.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_account_ids"></a> [account\_ids](#input\_account\_ids) | n/a | `map(string)` | <pre>{<br>  "development": "844815912454",<br>  "production": "382373577178",<br>  "staging": "451934005581"<br>}</pre> | no |
+| <a name="input_account_ids"></a> [account\_ids](#input\_account\_ids) | n/a | `map(string)` | <pre>{<br/>  "development": "844815912454",<br/>  "production": "382373577178",<br/>  "staging": "451934005581"<br/>}</pre> | no |
 | <a name="input_admin_bearer_token"></a> [admin\_bearer\_token](#input\_admin\_bearer\_token) | Value of BEARER\_TOKEN for the admin tool. | `string` | n/a | yes |
 | <a name="input_admin_oauth_id"></a> [admin\_oauth\_id](#input\_admin\_oauth\_id) | Value of TARIFF\_ADMIN\_OAUTH\_ID for the admin tool. | `string` | n/a | yes |
 | <a name="input_admin_oauth_secret"></a> [admin\_oauth\_secret](#input\_admin\_oauth\_secret) | Value of TARIFF\_ADMIN\_OAUTH\_SECRET for the admin tool. | `string` | n/a | yes |
@@ -294,7 +304,7 @@ No outputs.
 | <a name="input_tariff_backend_xi_sync_host"></a> [tariff\_backend\_xi\_sync\_host](#input\_tariff\_backend\_xi\_sync\_host) | Value of Tariff Sync host. | `string` | n/a | yes |
 | <a name="input_tariff_backend_xi_sync_password"></a> [tariff\_backend\_xi\_sync\_password](#input\_tariff\_backend\_xi\_sync\_password) | Value of Tariff Sync password. | `string` | n/a | yes |
 | <a name="input_tariff_backend_xi_sync_username"></a> [tariff\_backend\_xi\_sync\_username](#input\_tariff\_backend\_xi\_sync\_username) | Value of Tariff Sync username. | `string` | n/a | yes |
-| <a name="input_thumbprint_list"></a> [thumbprint\_list](#input\_thumbprint\_list) | List of thumbprints for the OIDC provider. | `list(string)` | <pre>[<br>  "9e99a48a9960b14926bb7f3b02e22da2b0ab7280",<br>  "06B25927C42A721631C1EFD9431E648FA62E1E39"<br>]</pre> | no |
+| <a name="input_thumbprint_list"></a> [thumbprint\_list](#input\_thumbprint\_list) | List of thumbprints for the OIDC provider. | `list(string)` | <pre>[<br/>  "9e99a48a9960b14926bb7f3b02e22da2b0ab7280",<br/>  "06B25927C42A721631C1EFD9431E648FA62E1E39"<br/>]</pre> | no |
 | <a name="input_waf_rpm_limit"></a> [waf\_rpm\_limit](#input\_waf\_rpm\_limit) | Request per minute limit for the WAF. This limit applies to our main CDN distribution and applies to all aliases on that CDN. | `number` | `400` | no |
 
 ## Outputs

--- a/environments/development/common/secrets.tf
+++ b/environments/development/common/secrets.tf
@@ -1,3 +1,511 @@
+module "admin_configuration" {
+  source                = "../../../modules/secret/"
+  name                  = "developer-hub-configuration"
+  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window       = 7
+  create_secret_version = false
+}
+
+module "commodi_tea_configuration" {
+  source                = "../../../modules/secret/"
+  name                  = "developer-hub-configuration"
+  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window       = 7
+  create_secret_version = false
+}
+
+module "developer_hub_configuration" {
+  source                = "../../../modules/secret/"
+  name                  = "developer-hub-configuration"
+  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window       = 7
+  create_secret_version = false
+}
+
+module "duty_calculator_configuration" {
+  source                = "../../../modules/secret/"
+  name                  = "duty-calculator-configuration"
+  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window       = 7
+  create_secret_version = false
+}
+
+module "frontend_configuration" {
+  source                = "../../../modules/secret/"
+  name                  = "frontend-configuration"
+  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window       = 7
+  create_secret_version = false
+}
+
+module "backend_uk_worker_configuration" {
+  source                = "../../../modules/secret/"
+  name                  = "backend-uk-worker-configuration"
+  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window       = 7
+  create_secret_version = false
+}
+
+module "backend_xi_worker_configuration" {
+  source                = "../../../modules/secret/"
+  name                  = "backend-xi-worker-configuration"
+  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window       = 7
+  create_secret_version = false
+}
+
+module "backend_uk_api_configuration" {
+  source                = "../../../modules/secret/"
+  name                  = "backend-uk-api-configuration"
+  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window       = 7
+  create_secret_version = false
+}
+
+module "backend_xi_api_configuration" {
+  source                = "../../../modules/secret/"
+  name                  = "backend-xi-api-configuration"
+  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window       = 7
+  create_secret_version = false
+}
+
+######### OLD WORLD SECRETS START HERE ##########
+
+module "frontend_secret_key_base" {
+  source          = "../../../modules/secret/"
+  name            = "frontend-secret-key-base"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.frontend_secret_key_base
+}
+
+module "frontend_sentry_dsn" {
+  source          = "../../../modules/secret/"
+  name            = "frontend-sentry-dsn"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.frontend_sentry_dsn
+}
+
+module "backend_secret_key_base" {
+  source          = "../../../modules/secret/"
+  name            = "backend-secret-key-base"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.backend_secret_key_base
+}
+
+module "slack_web_hook_url" {
+  source          = "../../../modules/secret/"
+  name            = "slack-web-hook-url"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.slack_web_hook_url
+}
+
+module "duty_calculator_secret_key_base" {
+  source          = "../../../modules/secret/"
+  name            = "duty-calculator-secret-key-base"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.duty_calculator_secret_key_base
+}
+
+module "duty_calculator_sentry_dsn" {
+  source          = "../../../modules/secret/"
+  name            = "duty-calculator-sentry-dsn"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.duty_calculator_sentry_dsn
+}
+
+module "admin_secret_key_base" {
+  source          = "../../../modules/secret/"
+  name            = "admin-secret-key-base"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.admin_secret_key_base
+}
+
+module "admin_sentry_dsn" {
+  source          = "../../../modules/secret/"
+  name            = "admin-sentry-dsn"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.admin_sentry_dsn
+}
+
+module "admin_oauth_id" {
+  source          = "../../../modules/secret/"
+  name            = "admin-oauth-id"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.admin_oauth_id
+}
+
+module "admin_oauth_secret" {
+  source          = "../../../modules/secret/"
+  name            = "admin-oauth-secret"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.admin_oauth_secret
+}
+
+module "admin_bearer_token" {
+  source          = "../../../modules/secret/"
+  name            = "admin-bearer-token"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.admin_bearer_token
+}
+
+module "backend_sentry_dsn" {
+  source          = "../../../modules/secret/"
+  name            = "backend-sentry-dsn"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.tariff_backend_sentry_dsn
+}
+
+module "backend_differences_to_emails" {
+  source          = "../../../modules/secret/"
+  name            = "backend-differences-to-emails"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.tariff_backend_differences_to_emails
+}
+
+module "backend_green_lanes_api_tokens" {
+  source          = "../../../modules/secret/"
+  name            = "backend-green-lanes-api-tokens"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.tariff_backend_green_lanes_api_tokens
+}
+
+module "backend_sync_email" {
+  source          = "../../../modules/secret/"
+  name            = "backend-sync-email"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.tariff_backend_sync_email
+}
+
+module "backend_xi_sync_host" {
+  source          = "../../../modules/secret/"
+  name            = "backend-xi-sync-host"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.tariff_backend_xi_sync_host
+}
+
+module "backend_xi_sync_password" {
+  source          = "../../../modules/secret/"
+  name            = "backend-xi-sync-password"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.tariff_backend_xi_sync_password
+}
+
+module "backend_xi_sync_username" {
+  source          = "../../../modules/secret/"
+  name            = "backend-xi-sync-username"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.tariff_backend_xi_sync_username
+}
+
+module "backend_uk_sync_host" {
+  source          = "../../../modules/secret/"
+  name            = "backend-uk-sync-host"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.tariff_backend_uk_sync_host
+}
+
+module "backend_uk_sync_password" {
+  source          = "../../../modules/secret/"
+  name            = "backend-uk-sync-password"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.tariff_backend_uk_sync_password
+}
+
+module "backend_uk_sync_username" {
+  source          = "../../../modules/secret/"
+  name            = "backend-uk-sync-username"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.tariff_backend_uk_sync_username
+}
+
+module "backend_oauth_id" {
+  source          = "../../../modules/secret/"
+  name            = "backend-oauth-id"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.tariff_backend_oauth_id
+}
+
+module "backend_oauth_secret" {
+  source          = "../../../modules/secret/"
+  name            = "backend-oauth-secret"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.tariff_backend_oauth_secret
+}
+
+module "backend_xe_api_username" {
+  source          = "../../../modules/secret/"
+  name            = "backend-xe-api-username"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.tariff_backend_xe_api_username
+}
+
+module "backend_xe_api_password" {
+  source          = "../../../modules/secret/"
+  name            = "backend-xe-api-password"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.tariff_backend_xe_api_password
+}
+
+module "signon_secret_key_base" {
+  source          = "../../../modules/secret/"
+  name            = "signon-secret-key-base"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.signon_secret_key_base
+}
+
+module "signon_devise_pepper" {
+  source          = "../../../modules/secret/"
+  name            = "signon-devise-pepper"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.signon_devise_pepper
+}
+
+module "signon_devise_secret_key" {
+  source          = "../../../modules/secret/"
+  name            = "signon-devise-secret-key"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.signon_devise_secret_key
+}
+
+module "signon_govuk_notify_api_key" {
+  source          = "../../../modules/secret/"
+  name            = "signon-govuk-notify-api-key"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.signon_govuk_notify_api_key
+}
+
+module "signon_derivation_salt" {
+  source          = "../../../modules/secret/"
+  name            = "signon-derivation-salt"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.signon_derivation_salt
+}
+
+module "signon_derivation_key" {
+  source          = "../../../modules/secret/"
+  name            = "signon-derivation-key"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.signon_derivation_key
+}
+
+module "dev_hub_backend_encryption_key" {
+  source          = "../../../modules/secret/"
+  name            = "dev-hub-backend-encryption-key"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.dev_hub_backend_encryption_key
+}
+
+module "dev_hub_backend_sentry_dsn" {
+  source          = "../../../modules/secret/"
+  name            = "dev-hub-backend-sentry-dsn"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.dev_hub_backend_sentry_dsn
+}
+
+module "dev_hub_frontend_sentry_dsn" {
+  source          = "../../../modules/secret/"
+  name            = "dev-hub-frontend-sentry-dsn"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.dev_hub_frontend_sentry_dsn
+}
+
+module "dev_hub_frontend_scp_open_id_client_id" {
+  source          = "../../../modules/secret/"
+  name            = "dev-hub-frontend-scp-open-id-client-id"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.dev_hub_frontend_scp_open_id_client_id
+}
+
+module "dev_hub_frontend_scp_open_id_client_secret" {
+  source          = "../../../modules/secret/"
+  name            = "dev-hub-frontend-scp-open-id-client-secret"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.dev_hub_frontend_scp_open_id_client_secret
+}
+
+module "dev_hub_frontend_scp_open_id_secret" {
+  source          = "../../../modules/secret/"
+  name            = "dev-hub-frontend-scp-open-id-secret"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.dev_hub_frontend_scp_open_id_secret
+}
+
+module "fpo_search_sentry_dsn" {
+  source          = "../../../modules/secret/"
+  name            = "fpo-search-sentry-dsn"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.fpo_search_sentry_dsn
+}
+
+module "fpo_search_training_pem" {
+  source          = "../../../modules/secret/"
+  name            = "fpo-search-training-pem"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.fpo_search_training_pem
+}
+
+module "slack_notify_lambda_slack_webhook_url" {
+  source          = "../../../modules/secret/"
+  name            = "slack-notify-lambda-slack-webhook-url"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.slack_notify_lambda_slack_webhook_url
+}
+
+module "dev_hub_frontend_govuk_notify_api_key" {
+  source          = "../../../modules/secret/"
+  name            = "dev-hub-frontend-govuk-notify-api-key"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.dev_hub_frontend_govuk_notify_api_key
+}
+
+module "dev_hub_frontend_application_support_email" {
+  source          = "../../../modules/secret/"
+  name            = "dev-hub-frontend-application-support-email"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.dev_hub_frontend_application_support_email
+}
+
+module "dev_hub_frontend_cookie_signing_secret" {
+  source          = "../../../modules/secret/"
+  name            = "dev-hub-frontend-cookie-signing-secret"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.dev_hub_frontend_cookie_signing_secret
+}
+
+module "dev_hub_frontend_csrf_signing_secret" {
+  source          = "../../../modules/secret/"
+  name            = "dev-hub-frontend-csrf-signing-secret"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.dev_hub_frontend_csrf_signing_secret
+}
+
+module "commodi_tea_cookie_signing_secret" {
+  source          = "../../../modules/secret/"
+  name            = "commodi-tea-cookie-signing-secret"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.commodi_tea_cookie_signing_secret
+}
+
+module "commodi_tea_fpo_search_api_key" {
+  source          = "../../../modules/secret/"
+  name            = "commodi-tea-fpo-search-api-key"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.commodi_tea_fpo_search_api_key
+}
+
+module "commodi_tea_configuration" {
+  source                = "../../../modules/secret/"
+  name                  = "developer-hub-configuration"
+  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window       = 7
+  create_secret_version = false
+}
+
+module "developer_hub_configuration" {
+  source                = "../../../modules/secret/"
+  name                  = "developer-hub-configuration"
+  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window       = 7
+  create_secret_version = false
+}
+
+module "duty_calculator_configuration" {
+  source                = "../../../modules/secret/"
+  name                  = "duty-calculator-configuration"
+  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window       = 7
+  create_secret_version = false
+}
+
+module "frontend_configuration" {
+  source                = "../../../modules/secret/"
+  name                  = "frontend-secret-key-base"
+  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window       = 7
+  create_secret_version = false
+}
+
+module "backend_uk_worker_configuration" {
+  source                = "../../../modules/secret/"
+  name                  = "frontend-secret-key-base"
+  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window       = 7
+  create_secret_version = false
+}
+
+module "backend_xi_worker_configuration" {
+  source                = "../../../modules/secret/"
+  name                  = "frontend-secret-key-base"
+  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window       = 7
+  create_secret_version = false
+}
+
+module "backend_uk_api_configuration" {
+  source          = "../../../modules/secret/"
+  name            = "frontend-secret-key-base"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.frontend_secret_key_base
+}
+
+module "backend_xi_api_configuration" {
+  source                = "../../../modules/secret/"
+  name                  = "frontend-secret-key-base"
+  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window       = 7
+  create_secret_version = false
+}
+
+######### OLD WORLD SECRETS START HERE ##########
+
 module "frontend_secret_key_base" {
   source          = "../../../modules/secret/"
   name            = "frontend-secret-key-base"

--- a/environments/production/common/README.md
+++ b/environments/production/common/README.md
@@ -26,6 +26,7 @@
 | <a name="module_acm_london"></a> [acm\_london](#module\_acm\_london) | ../../../modules/acm/ | n/a |
 | <a name="module_acm_origin"></a> [acm\_origin](#module\_acm\_origin) | ../../../modules/acm | n/a |
 | <a name="module_admin_bearer_token"></a> [admin\_bearer\_token](#module\_admin\_bearer\_token) | ../../../modules/secret/ | n/a |
+| <a name="module_admin_configuration"></a> [admin\_configuration](#module\_admin\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_admin_connection_string"></a> [admin\_connection\_string](#module\_admin\_connection\_string) | ../../../modules/secret/ | n/a |
 | <a name="module_admin_oauth_id"></a> [admin\_oauth\_id](#module\_admin\_oauth\_id) | ../../../modules/secret/ | n/a |
 | <a name="module_admin_oauth_secret"></a> [admin\_oauth\_secret](#module\_admin\_oauth\_secret) | ../../../modules/secret/ | n/a |
@@ -41,14 +42,18 @@
 | <a name="module_backend_secret_key_base"></a> [backend\_secret\_key\_base](#module\_backend\_secret\_key\_base) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_sentry_dsn"></a> [backend\_sentry\_dsn](#module\_backend\_sentry\_dsn) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_sync_email"></a> [backend\_sync\_email](#module\_backend\_sync\_email) | ../../../modules/secret/ | n/a |
+| <a name="module_backend_uk_api_configuration"></a> [backend\_uk\_api\_configuration](#module\_backend\_uk\_api\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_uk_sync_host"></a> [backend\_uk\_sync\_host](#module\_backend\_uk\_sync\_host) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_uk_sync_password"></a> [backend\_uk\_sync\_password](#module\_backend\_uk\_sync\_password) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_uk_sync_username"></a> [backend\_uk\_sync\_username](#module\_backend\_uk\_sync\_username) | ../../../modules/secret/ | n/a |
+| <a name="module_backend_uk_worker_configuration"></a> [backend\_uk\_worker\_configuration](#module\_backend\_uk\_worker\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_xe_api_password"></a> [backend\_xe\_api\_password](#module\_backend\_xe\_api\_password) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_xe_api_username"></a> [backend\_xe\_api\_username](#module\_backend\_xe\_api\_username) | ../../../modules/secret/ | n/a |
+| <a name="module_backend_xi_api_configuration"></a> [backend\_xi\_api\_configuration](#module\_backend\_xi\_api\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_xi_sync_host"></a> [backend\_xi\_sync\_host](#module\_backend\_xi\_sync\_host) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_xi_sync_password"></a> [backend\_xi\_sync\_password](#module\_backend\_xi\_sync\_password) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_xi_sync_username"></a> [backend\_xi\_sync\_username](#module\_backend\_xi\_sync\_username) | ../../../modules/secret/ | n/a |
+| <a name="module_backend_xi_worker_configuration"></a> [backend\_xi\_worker\_configuration](#module\_backend\_xi\_worker\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_backups_cdn"></a> [backups\_cdn](#module\_backups\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.4.2 |
 | <a name="module_cdn"></a> [cdn](#module\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.4.2 |
 | <a name="module_cloudwatch"></a> [cloudwatch](#module\_cloudwatch) | ../../../modules/cloudwatch/ | n/a |
@@ -56,6 +61,7 @@
 | <a name="module_cognito_client_id"></a> [cognito\_client\_id](#module\_cognito\_client\_id) | ../../../modules/secret/ | n/a |
 | <a name="module_cognito_client_secret"></a> [cognito\_client\_secret](#module\_cognito\_client\_secret) | ../../../modules/secret/ | n/a |
 | <a name="module_commodi_tea_cognito"></a> [commodi\_tea\_cognito](#module\_commodi\_tea\_cognito) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cognito | aws/cognito-v1.1.1 |
+| <a name="module_commodi_tea_configuration"></a> [commodi\_tea\_configuration](#module\_commodi\_tea\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_commodi_tea_cookie_signing_secret"></a> [commodi\_tea\_cookie\_signing\_secret](#module\_commodi\_tea\_cookie\_signing\_secret) | ../../../modules/secret/ | n/a |
 | <a name="module_commodi_tea_fpo_search_api_key"></a> [commodi\_tea\_fpo\_search\_api\_key](#module\_commodi\_tea\_fpo\_search\_api\_key) | ../../../modules/secret/ | n/a |
 | <a name="module_dev_hub_backend_encryption_key"></a> [dev\_hub\_backend\_encryption\_key](#module\_dev\_hub\_backend\_encryption\_key) | ../../../modules/secret/ | n/a |
@@ -69,11 +75,14 @@
 | <a name="module_dev_hub_frontend_scp_open_id_client_secret"></a> [dev\_hub\_frontend\_scp\_open\_id\_client\_secret](#module\_dev\_hub\_frontend\_scp\_open\_id\_client\_secret) | ../../../modules/secret/ | n/a |
 | <a name="module_dev_hub_frontend_scp_open_id_secret"></a> [dev\_hub\_frontend\_scp\_open\_id\_secret](#module\_dev\_hub\_frontend\_scp\_open\_id\_secret) | ../../../modules/secret/ | n/a |
 | <a name="module_dev_hub_frontend_sentry_dsn"></a> [dev\_hub\_frontend\_sentry\_dsn](#module\_dev\_hub\_frontend\_sentry\_dsn) | ../../../modules/secret/ | n/a |
+| <a name="module_developer_hub_configuration"></a> [developer\_hub\_configuration](#module\_developer\_hub\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_download_cds_files_to_emails_secret"></a> [download\_cds\_files\_to\_emails\_secret](#module\_download\_cds\_files\_to\_emails\_secret) | ../../../modules/secret/ | n/a |
+| <a name="module_duty_calculator_configuration"></a> [duty\_calculator\_configuration](#module\_duty\_calculator\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_duty_calculator_secret_key_base"></a> [duty\_calculator\_secret\_key\_base](#module\_duty\_calculator\_secret\_key\_base) | ../../../modules/secret/ | n/a |
 | <a name="module_duty_calculator_sentry_dsn"></a> [duty\_calculator\_sentry\_dsn](#module\_duty\_calculator\_sentry\_dsn) | ../../../modules/secret/ | n/a |
 | <a name="module_ecr"></a> [ecr](#module\_ecr) | ../../../modules/ecr/ | n/a |
 | <a name="module_fpo_search_sentry_dsn"></a> [fpo\_search\_sentry\_dsn](#module\_fpo\_search\_sentry\_dsn) | ../../../modules/secret/ | n/a |
+| <a name="module_frontend_configuration"></a> [frontend\_configuration](#module\_frontend\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_frontend_secret_key_base"></a> [frontend\_secret\_key\_base](#module\_frontend\_secret\_key\_base) | ../../../modules/secret/ | n/a |
 | <a name="module_frontend_sentry_dsn"></a> [frontend\_sentry\_dsn](#module\_frontend\_sentry\_dsn) | ../../../modules/secret/ | n/a |
 | <a name="module_logs"></a> [logs](#module\_logs) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v3.14.0 |
@@ -83,6 +92,7 @@
 | <a name="module_postgres_admin_aurora"></a> [postgres\_admin\_aurora](#module\_postgres\_admin\_aurora) | ../../../modules/rds_cluster | n/a |
 | <a name="module_postgres_aurora"></a> [postgres\_aurora](#module\_postgres\_aurora) | ../../../modules/rds_cluster | n/a |
 | <a name="module_postgres_commodi_tea"></a> [postgres\_commodi\_tea](#module\_postgres\_commodi\_tea) | ../../../modules/rds | n/a |
+| <a name="module_postgres_developer_hub"></a> [postgres\_developer\_hub](#module\_postgres\_developer\_hub) | ../../../modules/rds | n/a |
 | <a name="module_redis"></a> [redis](#module\_redis) | ../../../modules/elasticache-redis/ | n/a |
 | <a name="module_reporting_cdn"></a> [reporting\_cdn](#module\_reporting\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.4.2 |
 | <a name="module_rw_aurora_connection_string"></a> [rw\_aurora\_connection\_string](#module\_rw\_aurora\_connection\_string) | ../../../modules/secret/ | n/a |
@@ -234,7 +244,7 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_account_ids"></a> [account\_ids](#input\_account\_ids) | n/a | `map(string)` | <pre>{<br>  "development": "844815912454",<br>  "production": "382373577178",<br>  "staging": "451934005581"<br>}</pre> | no |
+| <a name="input_account_ids"></a> [account\_ids](#input\_account\_ids) | n/a | `map(string)` | <pre>{<br/>  "development": "844815912454",<br/>  "production": "382373577178",<br/>  "staging": "451934005581"<br/>}</pre> | no |
 | <a name="input_admin_bearer_token"></a> [admin\_bearer\_token](#input\_admin\_bearer\_token) | Value of BEARER\_TOKEN for the admin tool. | `string` | n/a | yes |
 | <a name="input_admin_oauth_id"></a> [admin\_oauth\_id](#input\_admin\_oauth\_id) | Value of TARIFF\_ADMIN\_OAUTH\_ID for the admin tool. | `string` | n/a | yes |
 | <a name="input_admin_oauth_secret"></a> [admin\_oauth\_secret](#input\_admin\_oauth\_secret) | Value of TARIFF\_ADMIN\_OAUTH\_SECRET for the admin tool. | `string` | n/a | yes |
@@ -279,7 +289,7 @@
 | <a name="input_tariff_backend_xi_sync_host"></a> [tariff\_backend\_xi\_sync\_host](#input\_tariff\_backend\_xi\_sync\_host) | Value of Tariff Sync host. | `string` | n/a | yes |
 | <a name="input_tariff_backend_xi_sync_password"></a> [tariff\_backend\_xi\_sync\_password](#input\_tariff\_backend\_xi\_sync\_password) | Value of Tariff Sync password. | `string` | n/a | yes |
 | <a name="input_tariff_backend_xi_sync_username"></a> [tariff\_backend\_xi\_sync\_username](#input\_tariff\_backend\_xi\_sync\_username) | Value of Tariff Sync username. | `string` | n/a | yes |
-| <a name="input_thumbprint_list"></a> [thumbprint\_list](#input\_thumbprint\_list) | List of thumbprints for the OIDC provider. | `list(string)` | <pre>[<br>  "9e99a48a9960b14926bb7f3b02e22da2b0ab7280",<br>  "06B25927C42A721631C1EFD9431E648FA62E1E39"<br>]</pre> | no |
+| <a name="input_thumbprint_list"></a> [thumbprint\_list](#input\_thumbprint\_list) | List of thumbprints for the OIDC provider. | `list(string)` | <pre>[<br/>  "9e99a48a9960b14926bb7f3b02e22da2b0ab7280",<br/>  "06B25927C42A721631C1EFD9431E648FA62E1E39"<br/>]</pre> | no |
 | <a name="input_waf_rpm_limit"></a> [waf\_rpm\_limit](#input\_waf\_rpm\_limit) | Request per minute limit for the WAF. This limit applies to our main CDN distribution and applies to all aliases on that CDN. | `number` | `500` | no |
 
 ## Outputs

--- a/environments/production/common/secrets.tf
+++ b/environments/production/common/secrets.tf
@@ -1,3 +1,77 @@
+module "admin_configuration" {
+  source                = "../../../modules/secret/"
+  name                  = "developer-hub-configuration"
+  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window       = 7
+  create_secret_version = false
+}
+
+module "commodi_tea_configuration" {
+  source                = "../../../modules/secret/"
+  name                  = "developer-hub-configuration"
+  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window       = 7
+  create_secret_version = false
+}
+
+module "developer_hub_configuration" {
+  source                = "../../../modules/secret/"
+  name                  = "developer-hub-configuration"
+  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window       = 7
+  create_secret_version = false
+}
+
+module "duty_calculator_configuration" {
+  source                = "../../../modules/secret/"
+  name                  = "duty-calculator-configuration"
+  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window       = 7
+  create_secret_version = false
+}
+
+module "frontend_configuration" {
+  source                = "../../../modules/secret/"
+  name                  = "frontend-configuration"
+  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window       = 7
+  create_secret_version = false
+}
+
+module "backend_uk_worker_configuration" {
+  source                = "../../../modules/secret/"
+  name                  = "backend-uk-worker-configuration"
+  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window       = 7
+  create_secret_version = false
+}
+
+module "backend_xi_worker_configuration" {
+  source                = "../../../modules/secret/"
+  name                  = "backend-xi-worker-configuration"
+  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window       = 7
+  create_secret_version = false
+}
+
+module "backend_uk_api_configuration" {
+  source                = "../../../modules/secret/"
+  name                  = "backend-uk-api-configuration"
+  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window       = 7
+  create_secret_version = false
+}
+
+module "backend_xi_api_configuration" {
+  source                = "../../../modules/secret/"
+  name                  = "backend-xi-api-configuration"
+  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window       = 7
+  create_secret_version = false
+}
+
+######### OLD WORLD SECRETS START HERE ##########
+
 module "frontend_secret_key_base" {
   source          = "../../../modules/secret/"
   name            = "frontend-secret-key-base"

--- a/environments/staging/common/README.md
+++ b/environments/staging/common/README.md
@@ -26,6 +26,7 @@
 | <a name="module_acm_london"></a> [acm\_london](#module\_acm\_london) | ../../../modules/acm/ | n/a |
 | <a name="module_acm_origin"></a> [acm\_origin](#module\_acm\_origin) | ../../../modules/acm | n/a |
 | <a name="module_admin_bearer_token"></a> [admin\_bearer\_token](#module\_admin\_bearer\_token) | ../../../modules/secret/ | n/a |
+| <a name="module_admin_configuration"></a> [admin\_configuration](#module\_admin\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_admin_connection_string"></a> [admin\_connection\_string](#module\_admin\_connection\_string) | ../../../modules/secret/ | n/a |
 | <a name="module_admin_oauth_id"></a> [admin\_oauth\_id](#module\_admin\_oauth\_id) | ../../../modules/secret/ | n/a |
 | <a name="module_admin_oauth_secret"></a> [admin\_oauth\_secret](#module\_admin\_oauth\_secret) | ../../../modules/secret/ | n/a |
@@ -41,14 +42,18 @@
 | <a name="module_backend_secret_key_base"></a> [backend\_secret\_key\_base](#module\_backend\_secret\_key\_base) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_sentry_dsn"></a> [backend\_sentry\_dsn](#module\_backend\_sentry\_dsn) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_sync_email"></a> [backend\_sync\_email](#module\_backend\_sync\_email) | ../../../modules/secret/ | n/a |
+| <a name="module_backend_uk_api_configuration"></a> [backend\_uk\_api\_configuration](#module\_backend\_uk\_api\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_uk_sync_host"></a> [backend\_uk\_sync\_host](#module\_backend\_uk\_sync\_host) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_uk_sync_password"></a> [backend\_uk\_sync\_password](#module\_backend\_uk\_sync\_password) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_uk_sync_username"></a> [backend\_uk\_sync\_username](#module\_backend\_uk\_sync\_username) | ../../../modules/secret/ | n/a |
+| <a name="module_backend_uk_worker_configuration"></a> [backend\_uk\_worker\_configuration](#module\_backend\_uk\_worker\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_xe_api_password"></a> [backend\_xe\_api\_password](#module\_backend\_xe\_api\_password) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_xe_api_username"></a> [backend\_xe\_api\_username](#module\_backend\_xe\_api\_username) | ../../../modules/secret/ | n/a |
+| <a name="module_backend_xi_api_configuration"></a> [backend\_xi\_api\_configuration](#module\_backend\_xi\_api\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_xi_sync_host"></a> [backend\_xi\_sync\_host](#module\_backend\_xi\_sync\_host) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_xi_sync_password"></a> [backend\_xi\_sync\_password](#module\_backend\_xi\_sync\_password) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_xi_sync_username"></a> [backend\_xi\_sync\_username](#module\_backend\_xi\_sync\_username) | ../../../modules/secret/ | n/a |
+| <a name="module_backend_xi_worker_configuration"></a> [backend\_xi\_worker\_configuration](#module\_backend\_xi\_worker\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_backups_cdn"></a> [backups\_cdn](#module\_backups\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.4.2 |
 | <a name="module_cdn"></a> [cdn](#module\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.4.2 |
 | <a name="module_cloudwatch"></a> [cloudwatch](#module\_cloudwatch) | ../../../modules/cloudwatch/ | n/a |
@@ -56,6 +61,7 @@
 | <a name="module_cognito_client_id"></a> [cognito\_client\_id](#module\_cognito\_client\_id) | ../../../modules/secret/ | n/a |
 | <a name="module_cognito_client_secret"></a> [cognito\_client\_secret](#module\_cognito\_client\_secret) | ../../../modules/secret/ | n/a |
 | <a name="module_commodi_tea_cognito"></a> [commodi\_tea\_cognito](#module\_commodi\_tea\_cognito) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cognito | aws/cognito-v1.1.1 |
+| <a name="module_commodi_tea_configuration"></a> [commodi\_tea\_configuration](#module\_commodi\_tea\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_commodi_tea_cookie_signing_secret"></a> [commodi\_tea\_cookie\_signing\_secret](#module\_commodi\_tea\_cookie\_signing\_secret) | ../../../modules/secret/ | n/a |
 | <a name="module_commodi_tea_fpo_search_api_key"></a> [commodi\_tea\_fpo\_search\_api\_key](#module\_commodi\_tea\_fpo\_search\_api\_key) | ../../../modules/secret/ | n/a |
 | <a name="module_dev_hub_backend_encryption_key"></a> [dev\_hub\_backend\_encryption\_key](#module\_dev\_hub\_backend\_encryption\_key) | ../../../modules/secret/ | n/a |
@@ -69,9 +75,12 @@
 | <a name="module_dev_hub_frontend_scp_open_id_client_secret"></a> [dev\_hub\_frontend\_scp\_open\_id\_client\_secret](#module\_dev\_hub\_frontend\_scp\_open\_id\_client\_secret) | ../../../modules/secret/ | n/a |
 | <a name="module_dev_hub_frontend_scp_open_id_secret"></a> [dev\_hub\_frontend\_scp\_open\_id\_secret](#module\_dev\_hub\_frontend\_scp\_open\_id\_secret) | ../../../modules/secret/ | n/a |
 | <a name="module_dev_hub_frontend_sentry_dsn"></a> [dev\_hub\_frontend\_sentry\_dsn](#module\_dev\_hub\_frontend\_sentry\_dsn) | ../../../modules/secret/ | n/a |
+| <a name="module_developer_hub_configuration"></a> [developer\_hub\_configuration](#module\_developer\_hub\_configuration) | ../../../modules/secret/ | n/a |
+| <a name="module_duty_calculator_configuration"></a> [duty\_calculator\_configuration](#module\_duty\_calculator\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_duty_calculator_secret_key_base"></a> [duty\_calculator\_secret\_key\_base](#module\_duty\_calculator\_secret\_key\_base) | ../../../modules/secret/ | n/a |
 | <a name="module_duty_calculator_sentry_dsn"></a> [duty\_calculator\_sentry\_dsn](#module\_duty\_calculator\_sentry\_dsn) | ../../../modules/secret/ | n/a |
 | <a name="module_fpo_search_sentry_dsn"></a> [fpo\_search\_sentry\_dsn](#module\_fpo\_search\_sentry\_dsn) | ../../../modules/secret/ | n/a |
+| <a name="module_frontend_configuration"></a> [frontend\_configuration](#module\_frontend\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_frontend_secret_key_base"></a> [frontend\_secret\_key\_base](#module\_frontend\_secret\_key\_base) | ../../../modules/secret/ | n/a |
 | <a name="module_frontend_sentry_dsn"></a> [frontend\_sentry\_dsn](#module\_frontend\_sentry\_dsn) | ../../../modules/secret/ | n/a |
 | <a name="module_logs"></a> [logs](#module\_logs) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v3.14.0 |
@@ -82,6 +91,7 @@
 | <a name="module_postgres_admin_aurora"></a> [postgres\_admin\_aurora](#module\_postgres\_admin\_aurora) | ../../../modules/rds_cluster | n/a |
 | <a name="module_postgres_aurora"></a> [postgres\_aurora](#module\_postgres\_aurora) | ../../../modules/rds_cluster | n/a |
 | <a name="module_postgres_commodi_tea"></a> [postgres\_commodi\_tea](#module\_postgres\_commodi\_tea) | ../../../modules/rds | n/a |
+| <a name="module_postgres_developer_hub"></a> [postgres\_developer\_hub](#module\_postgres\_developer\_hub) | ../../../modules/rds | n/a |
 | <a name="module_redis"></a> [redis](#module\_redis) | ../../../modules/elasticache-redis/ | n/a |
 | <a name="module_reporting_cdn"></a> [reporting\_cdn](#module\_reporting\_cdn) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/cloudfront | aws/cloudfront-v1.4.2 |
 | <a name="module_rw_aurora_connection_string"></a> [rw\_aurora\_connection\_string](#module\_rw\_aurora\_connection\_string) | ../../../modules/secret/ | n/a |
@@ -215,7 +225,7 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_account_ids"></a> [account\_ids](#input\_account\_ids) | n/a | `map(string)` | <pre>{<br>  "development": "844815912454",<br>  "production": "382373577178",<br>  "staging": "451934005581"<br>}</pre> | no |
+| <a name="input_account_ids"></a> [account\_ids](#input\_account\_ids) | n/a | `map(string)` | <pre>{<br/>  "development": "844815912454",<br/>  "production": "382373577178",<br/>  "staging": "451934005581"<br/>}</pre> | no |
 | <a name="input_admin_bearer_token"></a> [admin\_bearer\_token](#input\_admin\_bearer\_token) | Value of BEARER\_TOKEN for the admin tool. | `string` | n/a | yes |
 | <a name="input_admin_oauth_id"></a> [admin\_oauth\_id](#input\_admin\_oauth\_id) | Value of TARIFF\_ADMIN\_OAUTH\_ID for the admin tool. | `string` | n/a | yes |
 | <a name="input_admin_oauth_secret"></a> [admin\_oauth\_secret](#input\_admin\_oauth\_secret) | Value of TARIFF\_ADMIN\_OAUTH\_SECRET for the admin tool. | `string` | n/a | yes |
@@ -266,7 +276,7 @@
 | <a name="input_tariff_backend_xi_sync_host"></a> [tariff\_backend\_xi\_sync\_host](#input\_tariff\_backend\_xi\_sync\_host) | Value of Tariff Sync host. | `string` | n/a | yes |
 | <a name="input_tariff_backend_xi_sync_password"></a> [tariff\_backend\_xi\_sync\_password](#input\_tariff\_backend\_xi\_sync\_password) | Value of Tariff Sync password. | `string` | n/a | yes |
 | <a name="input_tariff_backend_xi_sync_username"></a> [tariff\_backend\_xi\_sync\_username](#input\_tariff\_backend\_xi\_sync\_username) | Value of Tariff Sync username. | `string` | n/a | yes |
-| <a name="input_thumbprint_list"></a> [thumbprint\_list](#input\_thumbprint\_list) | List of thumbprints for the OIDC provider. | `list(string)` | <pre>[<br>  "9e99a48a9960b14926bb7f3b02e22da2b0ab7280",<br>  "06B25927C42A721631C1EFD9431E648FA62E1E39"<br>]</pre> | no |
+| <a name="input_thumbprint_list"></a> [thumbprint\_list](#input\_thumbprint\_list) | List of thumbprints for the OIDC provider. | `list(string)` | <pre>[<br/>  "9e99a48a9960b14926bb7f3b02e22da2b0ab7280",<br/>  "06B25927C42A721631C1EFD9431E648FA62E1E39"<br/>]</pre> | no |
 | <a name="input_waf_rpm_limit"></a> [waf\_rpm\_limit](#input\_waf\_rpm\_limit) | Request per minute limit for the WAF. This limit applies to our main CDN distribution and applies to all aliases on that CDN. | `number` | `400` | no |
 
 ## Outputs

--- a/environments/staging/common/secrets.tf
+++ b/environments/staging/common/secrets.tf
@@ -1,3 +1,77 @@
+module "admin_configuration" {
+  source                = "../../../modules/secret/"
+  name                  = "developer-hub-configuration"
+  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window       = 7
+  create_secret_version = false
+}
+
+module "commodi_tea_configuration" {
+  source                = "../../../modules/secret/"
+  name                  = "developer-hub-configuration"
+  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window       = 7
+  create_secret_version = false
+}
+
+module "developer_hub_configuration" {
+  source                = "../../../modules/secret/"
+  name                  = "developer-hub-configuration"
+  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window       = 7
+  create_secret_version = false
+}
+
+module "duty_calculator_configuration" {
+  source                = "../../../modules/secret/"
+  name                  = "duty-calculator-configuration"
+  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window       = 7
+  create_secret_version = false
+}
+
+module "frontend_configuration" {
+  source                = "../../../modules/secret/"
+  name                  = "frontend-configuration"
+  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window       = 7
+  create_secret_version = false
+}
+
+module "backend_uk_worker_configuration" {
+  source                = "../../../modules/secret/"
+  name                  = "backend-uk-worker-configuration"
+  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window       = 7
+  create_secret_version = false
+}
+
+module "backend_xi_worker_configuration" {
+  source                = "../../../modules/secret/"
+  name                  = "backend-xi-worker-configuration"
+  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window       = 7
+  create_secret_version = false
+}
+
+module "backend_uk_api_configuration" {
+  source                = "../../../modules/secret/"
+  name                  = "backend-uk-api-configuration"
+  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window       = 7
+  create_secret_version = false
+}
+
+module "backend_xi_api_configuration" {
+  source                = "../../../modules/secret/"
+  name                  = "backend-xi-api-configuration"
+  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window       = 7
+  create_secret_version = false
+}
+
+######### OLD WORLD SECRETS START HERE ##########
+
 module "frontend_secret_key_base" {
   source          = "../../../modules/secret/"
   name            = "frontend-secret-key-base"

--- a/modules/acm/README.md
+++ b/modules/acm/README.md
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.65.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.90.1 |
 
 ## Modules
 

--- a/modules/application-load-balancer/README.md
+++ b/modules/application-load-balancer/README.md
@@ -35,7 +35,7 @@ No outputs.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.65.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.90.1 |
 
 ## Modules
 

--- a/modules/cloudwatch/README.md
+++ b/modules/cloudwatch/README.md
@@ -11,7 +11,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.65.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.3 |
 
 ## Modules
 

--- a/modules/ecr/README.md
+++ b/modules/ecr/README.md
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.65.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.90.1 |
 
 ## Modules
 

--- a/modules/elasticache-redis/README.md
+++ b/modules/elasticache-redis/README.md
@@ -13,8 +13,8 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.65.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.6.2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.90.1 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.7.1 |
 
 ## Modules
 

--- a/modules/rds/README.md
+++ b/modules/rds/README.md
@@ -15,8 +15,8 @@ Creates an AWS RDS instance.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.65.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.6.2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.90.1 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.7.1 |
 
 ## Modules
 

--- a/modules/rds_cluster/README.md
+++ b/modules/rds_cluster/README.md
@@ -13,8 +13,8 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.84.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.6.3 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.90.1 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.7.1 |
 
 ## Modules
 

--- a/modules/secret/README.md
+++ b/modules/secret/README.md
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.65.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.90.1 |
 
 ## Modules
 

--- a/modules/security-group/README.md
+++ b/modules/security-group/README.md
@@ -12,7 +12,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.65.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.90.1 |
 
 ## Modules
 

--- a/modules/ses/README.md
+++ b/modules/ses/README.md
@@ -13,7 +13,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.65.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.90.1 |
 
 ## Modules
 


### PR DESCRIPTION
# Jira link

[HMRC-814](https://transformuk.atlassian.net/browse/HMRC-814)

## What?

I have:

- Added consolidated configuration for each app in development
- Added consolidated configuration for each app in staging
- Added consolidated configuration for each app in production

## Why?

I am doing this because:

- This is needed as part of our migration from circle ci contexts to github actions
- It was realised as we were migrating the developer workflow to github actions that we have a bajillion secrets/configuration items that are hard to manage/migrate
- This approach should simplify by letting us manage a single Key/Value object inside of the AWS secrets UI
