### PR TITLE
HMRC-814: Removes unused policies

### DIFF
--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -177,7 +177,6 @@ No outputs.
 | [aws_iam_role.serverless_lambda_ci_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.status_checks_ci_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.tech_docs_ci_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role.terraform_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.appendix5a_ci_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.breakglass_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.ecs_deployments_ci_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
@@ -187,7 +186,6 @@ No outputs.
 | [aws_iam_role_policy_attachment.serverless_lambda_ci_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.status_checks_ci_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.tech_docs_ci_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.terraform_ci_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_user.appendix5a_ci](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_iam_user.fpo_models_ci](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_iam_user.opensearch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |

--- a/environments/development/common/iam-policies.tf
+++ b/environments/development/common/iam-policies.tf
@@ -73,6 +73,7 @@ resource "aws_iam_policy" "ci_ecs_deployment_policy" {
           "elasticloadbalancing:DescribeTargetGroups",
           "iam:AttachRolePolicy",
           "iam:CreatePolicy",
+          "iam:DeletePolicy",
           "iam:DetachRolePolicy",
           "iam:GetPolicy",
           "iam:GetPolicyVersion",

--- a/environments/development/common/iam-roles.tf
+++ b/environments/development/common/iam-roles.tf
@@ -266,54 +266,6 @@ resource "aws_iam_role_policy_attachment" "fpo_models_ci_policy_attachment" {
   policy_arn = aws_iam_policy.ci_fpo_models_secrets_policy.arn
 }
 
-# TODO: Delete this
-resource "aws_iam_role" "terraform_role" {
-  name = "CircleCi_Terraform-Role"
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Principal = {
-          Federated = aws_iam_openid_connect_provider.circleci_oidc.arn
-        }
-        Action = "sts:AssumeRoleWithWebIdentity"
-        Condition = {
-          StringEquals = {
-            "${aws_iam_openid_connect_provider.circleci_oidc.url}:aud" = var.circleci_organisation_id
-          }
-        }
-      },
-      {
-        Effect = "Allow",
-        Principal = {
-          Federated = aws_iam_openid_connect_provider.github_oidc.arn
-        },
-        Action = "sts:AssumeRoleWithWebIdentity",
-        Condition = {
-          StringEquals = {
-            "${aws_iam_openid_connect_provider.github_oidc.url}:aud" = "sts.amazonaws.com"
-          },
-          StringLike = {
-            "${aws_iam_openid_connect_provider.github_oidc.url}:sub" = [
-              "repo:trade-tariff/trade-tariff-platform-aws-terraform:*",
-              "repo:trade-tariff/trade-tariff-team:*",
-              "repo:trade-tariff/trade-tariff-platform-terraform-aws-accounts:*",
-            ]
-          }
-        }
-      }
-    ]
-  })
-}
-
-# TODO: Delete this
-resource "aws_iam_role_policy_attachment" "terraform_ci_policy_attachment" {
-  role       = aws_iam_role.terraform_role.name
-  policy_arn = aws_iam_policy.ci_terraform_policy.arn
-}
-
 resource "aws_iam_role" "ci_terraform_role" {
   name = "GithubActions-Terraform-Role"
 

--- a/environments/production/common/README.md
+++ b/environments/production/common/README.md
@@ -152,7 +152,6 @@
 | [aws_iam_role.serverless_lambda_ci_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.status_checks_ci_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.tech_docs_ci_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role.terraform_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.appendix5a_ci_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.breakglass_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.ci_downloader_file_ci_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
@@ -165,7 +164,6 @@
 | [aws_iam_role_policy_attachment.serverless_lambda_ci_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.status_checks_ci_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.tech_docs_ci_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.terraform_ci_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_user.appendix5a_ci](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_iam_user.cds_downloader_file_ci](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_iam_user.etf_ci](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |

--- a/environments/production/common/iam-policies.tf
+++ b/environments/production/common/iam-policies.tf
@@ -73,6 +73,7 @@ resource "aws_iam_policy" "ci_ecs_deployment_policy" {
           "elasticloadbalancing:DescribeTargetGroups",
           "iam:AttachRolePolicy",
           "iam:CreatePolicy",
+          "iam:DeletePolicy",
           "iam:DetachRolePolicy",
           "iam:GetPolicy",
           "iam:GetPolicyVersion",

--- a/environments/production/common/iam-roles.tf
+++ b/environments/production/common/iam-roles.tf
@@ -411,54 +411,6 @@ resource "aws_iam_role_policy_attachment" "releases_user_policy_attachment" {
   policy_arn = aws_iam_policy.release_policy.arn
 }
 
-# TODO: Delete this
-resource "aws_iam_role" "terraform_role" {
-  name = "CircleCi_Terraform-Role"
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Principal = {
-          Federated = aws_iam_openid_connect_provider.circleci_oidc.arn
-        }
-        Action = "sts:AssumeRoleWithWebIdentity"
-        Condition = {
-          StringEquals = {
-            "${aws_iam_openid_connect_provider.circleci_oidc.url}:aud" = var.circleci_organisation_id
-          }
-        }
-      },
-      {
-        Effect = "Allow",
-        Principal = {
-          Federated = aws_iam_openid_connect_provider.github_oidc.arn
-        },
-        Action = "sts:AssumeRoleWithWebIdentity",
-        Condition = {
-          StringEquals = {
-            "${aws_iam_openid_connect_provider.github_oidc.url}:aud" = "sts.amazonaws.com"
-          },
-          StringLike = {
-            "${aws_iam_openid_connect_provider.github_oidc.url}:sub" = [
-              "repo:trade-tariff/trade-tariff-platform-aws-terraform:*",
-              "repo:trade-tariff/trade-tariff-platform-terraform-aws-accounts:*",
-              "repo:trade-tariff/trade-tariff-team:*",
-            ]
-          }
-        }
-      }
-    ]
-  })
-}
-
-# TODO: Delete this
-resource "aws_iam_role_policy_attachment" "terraform_ci_policy_attachment" {
-  role       = aws_iam_role.terraform_role.name
-  policy_arn = aws_iam_policy.ci_terraform_policy.arn
-}
-
 resource "aws_iam_role" "ci_terraform_role" {
   name = "GithubActions-Terraform-Role"
 

--- a/environments/staging/common/README.md
+++ b/environments/staging/common/README.md
@@ -150,7 +150,6 @@
 | [aws_iam_role.serverless_lambda_ci_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.status_checks_ci_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.tech_docs_ci_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role.terraform_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.appendix5a_ci_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.breakglass_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.ecs_deployments_ci_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
@@ -160,7 +159,6 @@
 | [aws_iam_role_policy_attachment.serverless_lambda_ci_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.status_checks_ci_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.tech_docs_ci_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.terraform_ci_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_user.appendix5a_ci](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_iam_user.fpo_models_ci](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_iam_user.opensearch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |

--- a/environments/staging/common/iam-policies.tf
+++ b/environments/staging/common/iam-policies.tf
@@ -74,6 +74,7 @@ resource "aws_iam_policy" "ci_ecs_deployment_policy" {
           "elasticloadbalancing:DescribeTargetGroups",
           "iam:AttachRolePolicy",
           "iam:CreatePolicy",
+          "iam:DeletePolicy",
           "iam:DetachRolePolicy",
           "iam:GetPolicy",
           "iam:GetPolicyVersion",

--- a/environments/staging/common/iam-roles.tf
+++ b/environments/staging/common/iam-roles.tf
@@ -266,54 +266,6 @@ resource "aws_iam_role_policy_attachment" "fpo_models_ci_policy_attachment" {
   policy_arn = aws_iam_policy.ci_fpo_models_policy.arn
 }
 
-# TODO: Delete this
-resource "aws_iam_role" "terraform_role" {
-  name = "CircleCi_Terraform-Role"
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Principal = {
-          Federated = aws_iam_openid_connect_provider.circleci_oidc.arn
-        }
-        Action = "sts:AssumeRoleWithWebIdentity"
-        Condition = {
-          StringEquals = {
-            "${aws_iam_openid_connect_provider.circleci_oidc.url}:aud" = var.circleci_organisation_id
-          }
-        }
-      },
-      {
-        Effect = "Allow",
-        Principal = {
-          Federated = aws_iam_openid_connect_provider.github_oidc.arn
-        },
-        Action = "sts:AssumeRoleWithWebIdentity",
-        Condition = {
-          StringEquals = {
-            "${aws_iam_openid_connect_provider.github_oidc.url}:aud" = "sts.amazonaws.com"
-          },
-          StringLike = {
-            "${aws_iam_openid_connect_provider.github_oidc.url}:sub" = [
-              "repo:trade-tariff/trade-tariff-platform-aws-terraform:*",
-              "repo:trade-tariff/trade-tariff-platform-terraform-aws-accounts:*",
-              "repo:trade-tariff/trade-tariff-team:*",
-            ]
-          }
-        }
-      }
-    ]
-  })
-}
-
-# TODO: Delete this
-resource "aws_iam_role_policy_attachment" "terraform_ci_policy_attachment" {
-  role       = aws_iam_role.terraform_role.name
-  policy_arn = aws_iam_policy.ci_terraform_policy.arn
-}
-
 resource "aws_iam_role" "ci_terraform_role" {
   name = "GithubActions-Terraform-Role"
 


### PR DESCRIPTION
# Jira link

[HMRC-814](https://transformuk.atlassian.net/browse/HMRC-814)

## What?

I have:

- Removed unused policy
- Altered existing ECS deployment policy to include ability to delete renamed policies

## Why?

I am doing this because:

- We don't want lingering policies left over
- This is required to fix deployments of the DC
