### PR TITLE
HMRC-814: Updates permissions for ECS deployer role

### DIFF
--- a/environments/development/common/iam-policies.tf
+++ b/environments/development/common/iam-policies.tf
@@ -107,8 +107,8 @@ resource "aws_iam_policy" "ci_ecs_deployment_policy" {
           "s3:ListBucket"
         ],
         Resource = [
-          "arn:aws:s3:::terraform-state-development-844815912454",
-          "arn:aws:s3:::terraform-state-development-844815912454/*"
+          "arn:aws:s3:::terraform-state-${var.environment}-${local.account_id}",
+          "arn:aws:s3:::terraform-state-${var.environment}-${local.account_id}/*"
         ]
       },
       {

--- a/environments/production/common/iam-policies.tf
+++ b/environments/production/common/iam-policies.tf
@@ -107,8 +107,8 @@ resource "aws_iam_policy" "ci_ecs_deployment_policy" {
           "s3:ListBucket"
         ],
         Resource = [
-          "arn:aws:s3:::terraform-state-development-844815912454",
-          "arn:aws:s3:::terraform-state-development-844815912454/*"
+          "arn:aws:s3:::terraform-state-${var.environment}-${local.account_id}",
+          "arn:aws:s3:::terraform-state-${var.environment}-${local.account_id}/*"
         ]
       },
       {

--- a/environments/staging/common/iam-policies.tf
+++ b/environments/staging/common/iam-policies.tf
@@ -108,8 +108,8 @@ resource "aws_iam_policy" "ci_ecs_deployment_policy" {
           "s3:ListBucket"
         ],
         Resource = [
-          "arn:aws:s3:::terraform-state-development-844815912454",
-          "arn:aws:s3:::terraform-state-development-844815912454/*"
+          "arn:aws:s3:::terraform-state-${var.environment}-${local.account_id}",
+          "arn:aws:s3:::terraform-state-${var.environment}-${local.account_id}/*"
         ]
       },
       {


### PR DESCRIPTION
# Jira link

[HMRC-814](https://transformuk.atlassian.net/browse/HMRC-814)

## What?

I have:

- Altered permissions to reflect environment/account for the deployer role

## Why?

I am doing this because:

- This is required to manage the application state file in the environment
