### PR TITLE
HMRC-814: Adds "iam:DeletePolicyVersion" to deployment role

### DIFF
--- a/environments/development/common/iam-policies.tf
+++ b/environments/development/common/iam-policies.tf
@@ -74,6 +74,7 @@ resource "aws_iam_policy" "ci_ecs_deployment_policy" {
           "iam:AttachRolePolicy",
           "iam:CreatePolicy",
           "iam:DeletePolicy",
+          "iam:DeletePolicyVersion",
           "iam:DetachRolePolicy",
           "iam:GetPolicy",
           "iam:GetPolicyVersion",

--- a/environments/production/common/iam-policies.tf
+++ b/environments/production/common/iam-policies.tf
@@ -74,6 +74,7 @@ resource "aws_iam_policy" "ci_ecs_deployment_policy" {
           "iam:AttachRolePolicy",
           "iam:CreatePolicy",
           "iam:DeletePolicy",
+          "iam:DeletePolicyVersion",
           "iam:DetachRolePolicy",
           "iam:GetPolicy",
           "iam:GetPolicyVersion",

--- a/environments/staging/common/iam-policies.tf
+++ b/environments/staging/common/iam-policies.tf
@@ -75,6 +75,7 @@ resource "aws_iam_policy" "ci_ecs_deployment_policy" {
           "iam:AttachRolePolicy",
           "iam:CreatePolicy",
           "iam:DeletePolicy",
+          "iam:DeletePolicyVersion",
           "iam:DetachRolePolicy",
           "iam:GetPolicy",
           "iam:GetPolicyVersion",


### PR DESCRIPTION
# Jira link

[HMRC-814](https://transformuk.atlassian.net/browse/HMRC-814)

## What?

I have:

- Added extra permission to deployment user

## Why?

I am doing this because:

- This is required to enable deployments to change their execution/task policy names when I noticed these were poorly named
- I didn't see this before because I changed the name under the super admin role we've been using globally
