### PR TITLE
HMRC-827: Adds dev-hub to allowed webidentity repos

### DIFF
--- a/environments/development/common/iam-roles.tf
+++ b/environments/development/common/iam-roles.tf
@@ -330,16 +330,17 @@ resource "aws_iam_role" "ci_ecs_deployments_role" {
           },
           StringLike = {
             "${aws_iam_openid_connect_provider.github_oidc.url}:sub" = [
-              "repo:trade-tariff/trade-tariff-duty-calculator:*",
               "repo:trade-tariff/trade-tariff-admin:*",
-              "repo:trade-tariff/trade-tariff-frontend:*",
-              "repo:trade-tariff/trade-tariff-backend:*",
-              "repo:trade-tariff/trade-tariff-lambdas-fpo-search:*",
               "repo:trade-tariff/trade-tariff-api-docs:*",
+              "repo:trade-tariff/trade-tariff-backend:*",
               "repo:trade-tariff/trade-tariff-commodi-tea:*",
-              "repo:trade-tariff/trade-tariff-lambdas-database-backups:*",
-              "repo:trade-tariff/trade-tariff-dev-hub-frontend:*",
               "repo:trade-tariff/trade-tariff-dev-hub-backend:*",
+              "repo:trade-tariff/trade-tariff-dev-hub-frontend:*",
+              "repo:trade-tariff/trade-tariff-dev-hub:*",
+              "repo:trade-tariff/trade-tariff-duty-calculator:*",
+              "repo:trade-tariff/trade-tariff-frontend:*",
+              "repo:trade-tariff/trade-tariff-lambdas-database-backups:*",
+              "repo:trade-tariff/trade-tariff-lambdas-fpo-search:*",
               "repo:trade-tariff/trade-tariff-signon-builder:*",
             ]
           }

--- a/environments/production/common/iam-roles.tf
+++ b/environments/production/common/iam-roles.tf
@@ -475,16 +475,17 @@ resource "aws_iam_role" "ci_ecs_deployments_role" {
           },
           StringLike = {
             "${aws_iam_openid_connect_provider.github_oidc.url}:sub" = [
-              "repo:trade-tariff/trade-tariff-duty-calculator:*",
               "repo:trade-tariff/trade-tariff-admin:*",
-              "repo:trade-tariff/trade-tariff-frontend:*",
-              "repo:trade-tariff/trade-tariff-backend:*",
-              "repo:trade-tariff/trade-tariff-lambdas-fpo-search:*",
               "repo:trade-tariff/trade-tariff-api-docs:*",
+              "repo:trade-tariff/trade-tariff-backend:*",
               "repo:trade-tariff/trade-tariff-commodi-tea:*",
-              "repo:trade-tariff/trade-tariff-lambdas-database-backups:*",
-              "repo:trade-tariff/trade-tariff-dev-hub-frontend:*",
               "repo:trade-tariff/trade-tariff-dev-hub-backend:*",
+              "repo:trade-tariff/trade-tariff-dev-hub-frontend:*",
+              "repo:trade-tariff/trade-tariff-dev-hub:*",
+              "repo:trade-tariff/trade-tariff-duty-calculator:*",
+              "repo:trade-tariff/trade-tariff-frontend:*",
+              "repo:trade-tariff/trade-tariff-lambdas-database-backups:*",
+              "repo:trade-tariff/trade-tariff-lambdas-fpo-search:*",
               "repo:trade-tariff/trade-tariff-signon-builder:*",
             ]
           }

--- a/environments/staging/common/iam-roles.tf
+++ b/environments/staging/common/iam-roles.tf
@@ -330,16 +330,17 @@ resource "aws_iam_role" "ci_ecs_deployments_role" {
           },
           StringLike = {
             "${aws_iam_openid_connect_provider.github_oidc.url}:sub" = [
-              "repo:trade-tariff/trade-tariff-duty-calculator:*",
               "repo:trade-tariff/trade-tariff-admin:*",
-              "repo:trade-tariff/trade-tariff-frontend:*",
-              "repo:trade-tariff/trade-tariff-backend:*",
-              "repo:trade-tariff/trade-tariff-lambdas-fpo-search:*",
               "repo:trade-tariff/trade-tariff-api-docs:*",
+              "repo:trade-tariff/trade-tariff-backend:*",
               "repo:trade-tariff/trade-tariff-commodi-tea:*",
-              "repo:trade-tariff/trade-tariff-lambdas-database-backups:*",
-              "repo:trade-tariff/trade-tariff-dev-hub-frontend:*",
               "repo:trade-tariff/trade-tariff-dev-hub-backend:*",
+              "repo:trade-tariff/trade-tariff-dev-hub-frontend:*",
+              "repo:trade-tariff/trade-tariff-dev-hub:*",
+              "repo:trade-tariff/trade-tariff-duty-calculator:*",
+              "repo:trade-tariff/trade-tariff-frontend:*",
+              "repo:trade-tariff/trade-tariff-lambdas-database-backups:*",
+              "repo:trade-tariff/trade-tariff-lambdas-fpo-search:*",
               "repo:trade-tariff/trade-tariff-signon-builder:*",
             ]
           }


### PR DESCRIPTION
# Jira link

[HMRC-827](https://transformuk.atlassian.net/browse/HMRC-827)

## What?

I have:

- Added permission to assume the deployment role in GHA for the dev-hub in development
- Added permission to assume the deployment role in GHA for the dev-hub in staging
- Added permission to assume the deployment role in GHA for the dev-hub in production

## Why?

I am doing this because:

- This is needed to unblock deployments in this repo
