### PR TITLE
HMRC-874: Keep S3 archived logs for 3 years in deep archive

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,7 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
+      - id: check-merge-conflict
 
   - repo: https://github.com/trufflesecurity/trufflehog
     rev: v3.88.17

--- a/environments/production/common/cloudwatch.tf
+++ b/environments/production/common/cloudwatch.tf
@@ -114,16 +114,18 @@ module "logs" {
   attach_policy = true
   policy        = data.aws_iam_policy_document.logs_bucket_policy.json
 
-  lifecycle_rule = [
-    {
-      id      = "log"
-      enabled = true
+  lifecycle_rule = [{
+    id      = "log"
+    enabled = true
 
-      expiration = {
-        days = 30
-      }
+    transition = [{
+      storage_class = "DEEP_ARCHIVE"
+    }]
+
+    expiration = {
+      days = 1096
     }
-  ]
+  }]
 }
 
 module "cloudwatch-logs-exporter" {


### PR DESCRIPTION
# Jira link

[HMRC-874](https://transformuk.atlassian.net/browse/HMRC-874)

## What?

I have:

- Updated the logging bucket's lifecycle policy to transition objects to S3 Deep Archive, and retain them for 3 years.
