### PR TITLE
HMRC-879: Extends permissions for the ECS deployment role

### DIFF
--- a/environments/development/common/iam-policies.tf
+++ b/environments/development/common/iam-policies.tf
@@ -73,6 +73,7 @@ resource "aws_iam_policy" "ci_ecs_deployment_policy" {
           "elasticloadbalancing:DescribeTargetGroups",
           "iam:AttachRolePolicy",
           "iam:CreatePolicy",
+          "iam:CreatePolicyVersion",
           "iam:CreateRole",
           "iam:DeletePolicy",
           "iam:DeletePolicyVersion",

--- a/environments/production/common/iam-policies.tf
+++ b/environments/production/common/iam-policies.tf
@@ -73,6 +73,7 @@ resource "aws_iam_policy" "ci_ecs_deployment_policy" {
           "elasticloadbalancing:DescribeTargetGroups",
           "iam:AttachRolePolicy",
           "iam:CreatePolicy",
+          "iam:CreatePolicyVersion",
           "iam:CreateRole",
           "iam:DeletePolicy",
           "iam:DeletePolicyVersion",

--- a/environments/staging/common/iam-policies.tf
+++ b/environments/staging/common/iam-policies.tf
@@ -43,7 +43,6 @@ resource "aws_iam_policy" "ci_terraform_policy" {
         Condition = {
           "StringEquals" : {
             "aws:RequestedRegion" : ["eu-west-2", "us-east-1"]
-
           }
         }
       }
@@ -74,6 +73,7 @@ resource "aws_iam_policy" "ci_ecs_deployment_policy" {
           "elasticloadbalancing:DescribeTargetGroups",
           "iam:AttachRolePolicy",
           "iam:CreatePolicy",
+          "iam:CreatePolicyVersion",
           "iam:CreateRole",
           "iam:DeletePolicy",
           "iam:DeletePolicyVersion",


### PR DESCRIPTION
# Jira link

[HMRC-879](https://transformuk.atlassian.net/browse/HMRC-879)

## What?

I have:

- Added iam:CreatePolicyVersion permission to the ECS role in development
- Added iam:CreatePolicyVersion permission to the ECS role in staging
- Added iam:CreatePolicyVersion permission to the ECS role in production

## Why?

I am doing this because:

- This unblocks the deployments of new policy versions for the new dev-hub
