### PR TITLE
Add etf_configuration secret & update ci_etf_policy accordingly

### DIFF
--- a/environments/production/common/README.md
+++ b/environments/production/common/README.md
@@ -82,6 +82,7 @@
 | <a name="module_duty_calculator_secret_key_base"></a> [duty\_calculator\_secret\_key\_base](#module\_duty\_calculator\_secret\_key\_base) | ../../../modules/secret/ | n/a |
 | <a name="module_duty_calculator_sentry_dsn"></a> [duty\_calculator\_sentry\_dsn](#module\_duty\_calculator\_sentry\_dsn) | ../../../modules/secret/ | n/a |
 | <a name="module_ecr"></a> [ecr](#module\_ecr) | ../../../modules/ecr/ | n/a |
+| <a name="module_etf_configuration"></a> [etf\_configuration](#module\_etf\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_fpo_search_sentry_dsn"></a> [fpo\_search\_sentry\_dsn](#module\_fpo\_search\_sentry\_dsn) | ../../../modules/secret/ | n/a |
 | <a name="module_frontend_configuration"></a> [frontend\_configuration](#module\_frontend\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_frontend_secret_key_base"></a> [frontend\_secret\_key\_base](#module\_frontend\_secret\_key\_base) | ../../../modules/secret/ | n/a |

--- a/environments/production/common/iam.tf
+++ b/environments/production/common/iam.tf
@@ -331,7 +331,8 @@ resource "aws_iam_policy" "ci_etf_policy" {
           "kms:Decrypt"
         ],
         Resource = [
-          aws_kms_alias.s3_kms_alias.target_key_arn
+          aws_kms_alias.s3_kms_alias.target_key_arn,
+          aws_kms_key.secretsmanager_kms_key.arn
         ]
       },
       {
@@ -341,6 +342,16 @@ resource "aws_iam_policy" "ci_etf_policy" {
           "ses:SendRawEmail"
         ],
         Resource = ["*"]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:GetResourcePolicy",
+          "secretsmanager:GetSecretValue",
+          "secretsmanager:DescribeSecret",
+          "secretsmanager:ListSecretVersionIds"
+        ],
+        Resource = [module.etf_configuration.secret_arn]
       }
     ]
   })

--- a/environments/production/common/secrets.tf
+++ b/environments/production/common/secrets.tf
@@ -78,6 +78,14 @@ module "download_cds_files_configuration" {
   create_secret_version = false
 }
 
+module "etf_configuration" {
+  source                = "../../../modules/secret/"
+  name                  = "electronic-tariff-file-configuration"
+  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window       = 7
+  create_secret_version = false
+}
+
 ######### OLD WORLD SECRETS START HERE ##########
 
 module "frontend_secret_key_base" {


### PR DESCRIPTION
# Jira link
[HMRC-888](https://transformuk.atlassian.net/browse/HMRC-888)
## What?

I have:

- Added etf_configuration secret
- Updated ci_etf_policy to allow secret manager actions

## Why?

I am doing this because:

- We need to migrate secrets from CircleCi to AWS Secret Manager as part of the migration to GitHub Actions

