### PR TITLE
HMRC-899: Adds role for the teams repo

### DIFF
--- a/environments/development/common/iam-roles.tf
+++ b/environments/development/common/iam-roles.tf
@@ -298,7 +298,6 @@ resource "aws_iam_role" "ci_terraform_role" {
             "${aws_iam_openid_connect_provider.github_oidc.url}:sub" = [
               "repo:trade-tariff/trade-tariff-platform-aws-terraform:*",
               "repo:trade-tariff/trade-tariff-platform-terraform-aws-accounts:*",
-              "repo:trade-tariff/trade-tariff-team:*",
             ]
           }
         }

--- a/environments/production/common/README.md
+++ b/environments/production/common/README.md
@@ -140,6 +140,7 @@
 | [aws_iam_policy.ci_status_checks_persistence_readwrite_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.ci_tech_docs_persistence_readwrite_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.ci_terraform_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.ci_terraform_teams_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.opensearch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.release_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.appendix5a_ci_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
@@ -147,6 +148,7 @@
 | [aws_iam_role.ci_downloader_file_ci_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.ci_ecs_deployments_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.ci_terraform_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.ci_terraform_teams_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.etf_ci_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.fpo_models_ci_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.releases_user_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
@@ -161,6 +163,7 @@
 | [aws_iam_role_policy_attachment.etf_ci_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.fpo_models_ci_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.github_terraform_ci_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.github_terraform_teams_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.releases_user_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.reporting_ci_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.serverless_lambda_ci_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
@@ -249,7 +252,7 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_account_ids"></a> [account\_ids](#input\_account\_ids) | n/a | `map(string)` | <pre>{<br>  "development": "844815912454",<br>  "production": "382373577178",<br>  "staging": "451934005581"<br>}</pre> | no |
+| <a name="input_account_ids"></a> [account\_ids](#input\_account\_ids) | n/a | `map(string)` | <pre>{<br/>  "development": "844815912454",<br/>  "production": "382373577178",<br/>  "staging": "451934005581"<br/>}</pre> | no |
 | <a name="input_admin_bearer_token"></a> [admin\_bearer\_token](#input\_admin\_bearer\_token) | Value of BEARER\_TOKEN for the admin tool. | `string` | n/a | yes |
 | <a name="input_admin_oauth_id"></a> [admin\_oauth\_id](#input\_admin\_oauth\_id) | Value of TARIFF\_ADMIN\_OAUTH\_ID for the admin tool. | `string` | n/a | yes |
 | <a name="input_admin_oauth_secret"></a> [admin\_oauth\_secret](#input\_admin\_oauth\_secret) | Value of TARIFF\_ADMIN\_OAUTH\_SECRET for the admin tool. | `string` | n/a | yes |
@@ -294,7 +297,7 @@
 | <a name="input_tariff_backend_xi_sync_host"></a> [tariff\_backend\_xi\_sync\_host](#input\_tariff\_backend\_xi\_sync\_host) | Value of Tariff Sync host. | `string` | n/a | yes |
 | <a name="input_tariff_backend_xi_sync_password"></a> [tariff\_backend\_xi\_sync\_password](#input\_tariff\_backend\_xi\_sync\_password) | Value of Tariff Sync password. | `string` | n/a | yes |
 | <a name="input_tariff_backend_xi_sync_username"></a> [tariff\_backend\_xi\_sync\_username](#input\_tariff\_backend\_xi\_sync\_username) | Value of Tariff Sync username. | `string` | n/a | yes |
-| <a name="input_thumbprint_list"></a> [thumbprint\_list](#input\_thumbprint\_list) | List of thumbprints for the OIDC provider. | `list(string)` | <pre>[<br>  "9e99a48a9960b14926bb7f3b02e22da2b0ab7280",<br>  "06B25927C42A721631C1EFD9431E648FA62E1E39"<br>]</pre> | no |
+| <a name="input_thumbprint_list"></a> [thumbprint\_list](#input\_thumbprint\_list) | List of thumbprints for the OIDC provider. | `list(string)` | <pre>[<br/>  "9e99a48a9960b14926bb7f3b02e22da2b0ab7280",<br/>  "06B25927C42A721631C1EFD9431E648FA62E1E39"<br/>]</pre> | no |
 | <a name="input_waf_rpm_limit"></a> [waf\_rpm\_limit](#input\_waf\_rpm\_limit) | Request per minute limit for the WAF. This limit applies to our main CDN distribution and applies to all aliases on that CDN. | `number` | `500` | no |
 
 ## Outputs

--- a/environments/production/common/iam-policies.tf
+++ b/environments/production/common/iam-policies.tf
@@ -140,3 +140,39 @@ resource "aws_iam_policy" "ci_ecs_deployment_policy" {
     ]
   })
 }
+
+resource "aws_iam_policy" "ci_terraform_teams_policy" {
+  name        = "ci-terraform-teams-policy"
+  description = "Policy for Terraform to store state as part of the teams repo run"
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "kms:*",
+          "sts:AssumeRoleWithWebIdentity",
+        ],
+        Resource = "*",
+        Condition = {
+          "StringEquals" : {
+            "aws:RequestedRegion" : ["eu-west-2"]
+          }
+        }
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:ListBucket"
+        ],
+        Resource = [
+          "arn:aws:s3:::terraform-state-${var.environment}-${local.account_id}",
+          "arn:aws:s3:::terraform-state-${var.environment}-${local.account_id}/*"
+        ]
+      },
+    ]
+  })
+}

--- a/environments/production/common/iam-roles.tf
+++ b/environments/production/common/iam-roles.tf
@@ -443,7 +443,6 @@ resource "aws_iam_role" "ci_terraform_role" {
             "${aws_iam_openid_connect_provider.github_oidc.url}:sub" = [
               "repo:trade-tariff/trade-tariff-platform-aws-terraform:*",
               "repo:trade-tariff/trade-tariff-platform-terraform-aws-accounts:*",
-              "repo:trade-tariff/trade-tariff-team:*",
             ]
           }
         }
@@ -498,4 +497,36 @@ resource "aws_iam_role" "ci_ecs_deployments_role" {
 resource "aws_iam_role_policy_attachment" "ecs_deployments_ci_policy_attachment" {
   role       = aws_iam_role.ci_ecs_deployments_role.name
   policy_arn = aws_iam_policy.ci_ecs_deployment_policy.arn
+}
+
+resource "aws_iam_role" "ci_terraform_teams_role" {
+  name = "GithubActions-Terraform-Teams-Role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.github_oidc.arn
+        },
+        Action = "sts:AssumeRoleWithWebIdentity",
+        Condition = {
+          StringEquals = {
+            "${aws_iam_openid_connect_provider.github_oidc.url}:aud" = "sts.amazonaws.com"
+          },
+          StringLike = {
+            "${aws_iam_openid_connect_provider.github_oidc.url}:sub" = [
+              "repo:trade-tariff/trade-tariff-team:*",
+            ]
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "github_terraform_teams_policy_attachment" {
+  role       = aws_iam_role.ci_terraform_teams_role.name
+  policy_arn = aws_iam_policy.ci_terraform_teams_policy.arn
 }

--- a/environments/staging/common/iam-roles.tf
+++ b/environments/staging/common/iam-roles.tf
@@ -298,7 +298,6 @@ resource "aws_iam_role" "ci_terraform_role" {
             "${aws_iam_openid_connect_provider.github_oidc.url}:sub" = [
               "repo:trade-tariff/trade-tariff-platform-aws-terraform:*",
               "repo:trade-tariff/trade-tariff-platform-terraform-aws-accounts:*",
-              "repo:trade-tariff/trade-tariff-team:*",
             ]
           }
         }


### PR DESCRIPTION
# Jira link

[HMRC-899](https://transformuk.atlassian.net/browse/HMRC-899)

## What?

I have:

- Added role for the teams repo
- Added restricted policy to constrain the new role to just the things it needs to do
- Removed teams as a repo in the permissive terraform superadmin role

## Why?

I am doing this because:

- This is part of making sure our access is strictly controlled to what is necessary
