### PR TITLE
HMRC-948 Increase CloudFront TTL

### DIFF
--- a/environments/production/common/cloudfront-policy.tf
+++ b/environments/production/common/cloudfront-policy.tf
@@ -10,8 +10,8 @@ resource "random_password" "origin_header" {
 
 resource "aws_cloudfront_cache_policy" "cache_api" {
   name        = "cache-apiv2"
-  default_ttl = 1800
-  max_ttl     = 1800
+  default_ttl = 86400
+  max_ttl     = 86400
   min_ttl     = 1
 
   parameters_in_cache_key_and_forwarded_to_origin {


### PR DESCRIPTION
# Jira link

HMRC-948

## What?

Increases the TTL on our CF policy to cache for a day.  This will increase our cache hit ratios, decreasing traffic on the servers, but does depend on https://github.com/trade-tariff/trade-tariff-backend/pull/2127 being live and working