### PR TITLE
HMRC-896: Adds cross-account permissions for the FPO Model Role

### DIFF
--- a/environments/production/common/iam.tf
+++ b/environments/production/common/iam.tf
@@ -623,7 +623,10 @@ data "aws_iam_policy_document" "fpo_model_access" {
         "arn:aws:iam::451934005581:role/fpo-model-garbage-collection-staging-eu-west-2-lambdaRole",
         "arn:aws:iam::451934005581:user/fpo-models-ci",
         "arn:aws:iam::382373577178:role/fpo-model-garbage-collection-production-eu-west-2-lambdaRole",
-        "arn:aws:iam::382373577178:user/fpo-models-ci"
+        "arn:aws:iam::382373577178:user/fpo-models-ci",
+        "arn:aws:iam::844815912454:role/GithubActions-FPO-Models-Role",
+        "arn:aws:iam::451934005581:role/GithubActions-FPO-Models-Role",
+        "arn:aws:iam::382373577178:role/GithubActions-FPO-Models-Role"
       ]
     }
   }

--- a/environments/production/common/s3.tf
+++ b/environments/production/common/s3.tf
@@ -42,9 +42,14 @@ data "aws_iam_policy_document" "s3_kms_key_policy" {
 
     principals {
       type = "AWS"
-      identifiers = [
-        for account_id in values(var.account_ids) : "arn:aws:iam::${account_id}:user/fpo-models-ci"
-      ]
+      identifiers = concat(
+        [
+          for account_id in values(var.account_ids) : "arn:aws:iam::${account_id}:user/fpo-models-ci"
+        ],
+        [
+          for account_id in values(var.account_ids) : "arn:aws:iam::${account_id}:role/GithubActions-FPO-Models-Role"
+        ]
+      )
     }
   }
 


### PR DESCRIPTION
# Jira link

[HMRC-896](https://transformuk.atlassian.net/browse/HMRC-896)

## What?

I have:

- Added cross account permissions to the dev/staging/production roles to access the model

## Why?

I am doing this because:

- This is required to unblock a role based migration to GithubActions
