### PR TITLE
HMRC-973: Updates distribution policies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 ---
 repos:
   - repo: https://github.com/gruntwork-io/pre-commit
-    rev: v0.1.26
+    rev: v0.1.28
     hooks:
       - id: terragrunt-hclfmt
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.97.4
+    rev: v1.98.1
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -26,6 +26,6 @@ repos:
       - id: check-merge-conflict
 
   - repo: https://github.com/trufflesecurity/trufflehog
-    rev: v3.88.17
+    rev: v3.88.23
     hooks:
       - id: trufflehog

--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -142,8 +142,8 @@ No outputs.
 | [aws_cloudfront_cache_policy.very_very_long_cache](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_cache_policy) | resource |
 | [aws_cloudfront_function.basic_auth](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_function) | resource |
 | [aws_cloudfront_origin_access_control.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_access_control) | resource |
+| [aws_cloudfront_origin_request_policy.forward_all_qsa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_request_policy) | resource |
 | [aws_cloudfront_origin_request_policy.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_request_policy) | resource |
-| [aws_cloudfront_origin_request_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_request_policy) | resource |
 | [aws_cloudfront_response_headers_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_response_headers_policy) | resource |
 | [aws_cloudwatch_log_group.redis_engine_lg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.redis_slow_lg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |

--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -117,7 +117,6 @@ No outputs.
 | <a name="module_postgres_aurora"></a> [postgres\_aurora](#module\_postgres\_aurora) | ../../../modules/rds_cluster | n/a |
 | <a name="module_postgres_commodi_tea"></a> [postgres\_commodi\_tea](#module\_postgres\_commodi\_tea) | ../../../modules/rds | n/a |
 | <a name="module_postgres_developer_hub"></a> [postgres\_developer\_hub](#module\_postgres\_developer\_hub) | ../../../modules/rds | n/a |
-| <a name="module_preview_cdn"></a> [preview\_cdn](#module\_preview\_cdn) | ../../../modules/cloudfront | n/a |
 | <a name="module_redis"></a> [redis](#module\_redis) | ../../../modules/elasticache-redis/ | n/a |
 | <a name="module_reporting_cdn"></a> [reporting\_cdn](#module\_reporting\_cdn) | ../../../modules/cloudfront | n/a |
 | <a name="module_rw_aurora_connection_string"></a> [rw\_aurora\_connection\_string](#module\_rw\_aurora\_connection\_string) | ../../../modules/secret/ | n/a |
@@ -136,12 +135,15 @@ No outputs.
 
 | Name | Type |
 |------|------|
-| [aws_cloudfront_cache_policy.cache_api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_cache_policy) | resource |
+| [aws_cloudfront_cache_policy.long_cache](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_cache_policy) | resource |
+| [aws_cloudfront_cache_policy.medium_cache](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_cache_policy) | resource |
 | [aws_cloudfront_cache_policy.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_cache_policy) | resource |
+| [aws_cloudfront_cache_policy.short_cache](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_cache_policy) | resource |
+| [aws_cloudfront_cache_policy.very_very_long_cache](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_cache_policy) | resource |
 | [aws_cloudfront_function.basic_auth](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_function) | resource |
 | [aws_cloudfront_origin_access_control.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_access_control) | resource |
-| [aws_cloudfront_origin_request_policy.forward_all_qsa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_request_policy) | resource |
 | [aws_cloudfront_origin_request_policy.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_request_policy) | resource |
+| [aws_cloudfront_origin_request_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_request_policy) | resource |
 | [aws_cloudfront_response_headers_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_response_headers_policy) | resource |
 | [aws_cloudwatch_log_group.redis_engine_lg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.redis_slow_lg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |

--- a/environments/development/common/cloudfront-policy.tf
+++ b/environments/development/common/cloudfront-policy.tf
@@ -8,28 +8,59 @@ resource "random_password" "origin_header" {
   special = false
 }
 
-resource "aws_cloudfront_cache_policy" "cache_api" {
-  name        = "cache-apiv2"
-  default_ttl = 1800
-  max_ttl     = 1800
+resource "aws_cloudfront_cache_policy" "very_very_long_cache" {
+  name        = "very-very-long-cache"
+  default_ttl = 31536000 # 1 year
+  max_ttl     = 31536000 # 1 year
   min_ttl     = 1
 
   parameters_in_cache_key_and_forwarded_to_origin {
-    cookies_config {
-      cookie_behavior = "none"
-    }
-
-    headers_config {
-      header_behavior = "none"
-    }
-
-    query_strings_config {
-      query_string_behavior = "all"
-    }
+    cookies_config { cookie_behavior = "none" }
+    headers_config { header_behavior = "none" }
+    query_strings_config { query_string_behavior = "all" }
   }
 }
 
-resource "aws_cloudfront_origin_request_policy" "forward_all_qsa" {
+resource "aws_cloudfront_cache_policy" "long_cache" {
+  name        = "long-cache"
+  default_ttl = 86400 # 1 day
+  max_ttl     = 86400 # 1 day
+  min_ttl     = 1
+
+  parameters_in_cache_key_and_forwarded_to_origin {
+    cookies_config { cookie_behavior = "none" }
+    headers_config { header_behavior = "none" }
+    query_strings_config { query_string_behavior = "all" }
+  }
+}
+
+resource "aws_cloudfront_cache_policy" "medium_cache" {
+  name        = "medium-cache"
+  default_ttl = 7200 # 2 hours
+  max_ttl     = 7200 # 2 hours
+  min_ttl     = 1
+
+  parameters_in_cache_key_and_forwarded_to_origin {
+    cookies_config { cookie_behavior = "none" }
+    headers_config { header_behavior = "none" }
+    query_strings_config { query_string_behavior = "all" }
+  }
+}
+
+resource "aws_cloudfront_cache_policy" "short_cache" {
+  name        = "short-cache"
+  default_ttl = 1800 # 30 minutes
+  max_ttl     = 1800 # 30 minutes
+  min_ttl     = 1
+
+  parameters_in_cache_key_and_forwarded_to_origin {
+    cookies_config { cookie_behavior = "none" }
+    headers_config { header_behavior = "none" }
+    query_strings_config { query_string_behavior = "all" }
+  }
+}
+
+resource "aws_cloudfront_origin_request_policy" "this" {
   name    = "Forward-All-QSA-${var.environment}"
   comment = "Forward all QSA (managed by Terraform)"
   cookies_config {

--- a/environments/development/common/cloudfront-policy.tf
+++ b/environments/development/common/cloudfront-policy.tf
@@ -60,7 +60,7 @@ resource "aws_cloudfront_cache_policy" "short_cache" {
   }
 }
 
-resource "aws_cloudfront_origin_request_policy" "this" {
+resource "aws_cloudfront_origin_request_policy" "forward_all_qsa" {
   name    = "Forward-All-QSA-${var.environment}"
   comment = "Forward all QSA (managed by Terraform)"
   cookies_config {

--- a/environments/development/common/cloudfront.tf
+++ b/environments/development/common/cloudfront.tf
@@ -73,28 +73,28 @@ module "cdn" {
     }
 
     # Green lanes/SPIMM endpoints
-    xi_api_exchange_rates = {
+    xi_api_spimm = {
       target_origin_id           = "alb"
       path_pattern               = "/xi/api/v2/green_lanes/*"
       viewer_protocol_policy     = "redirect-to-https"
       cache_policy_id            = aws_cloudfront_cache_policy.short_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
-    uk_api_exchange_rates = {
+    uk_api_spimm = {
       target_origin_id           = "alb"
       path_pattern               = "/uk/api/v2/green_lanes/*"
       viewer_protocol_policy     = "redirect-to-https"
       cache_policy_id            = aws_cloudfront_cache_policy.short_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
-    default_api_exchange_rates = {
+    default_api_spimm = {
       target_origin_id           = "alb"
       path_pattern               = "/api/v2/green_lanes/*"
       viewer_protocol_policy     = "redirect-to-https"
       cache_policy_id            = aws_cloudfront_cache_policy.short_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
 
@@ -104,7 +104,7 @@ module "cdn" {
       path_pattern               = "/xi/api/v2/exchange_rates/*"
       viewer_protocol_policy     = "redirect-to-https"
       cache_policy_id            = aws_cloudfront_cache_policy.medium_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
     uk_api_exchange_rates = {
@@ -112,7 +112,7 @@ module "cdn" {
       path_pattern               = "/uk/api/v2/exchange_rates/*"
       viewer_protocol_policy     = "redirect-to-https"
       cache_policy_id            = aws_cloudfront_cache_policy.medium_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
     default_api_exchange_rates = {
@@ -120,7 +120,7 @@ module "cdn" {
       path_pattern               = "/api/v2/exchange_rates/*"
       viewer_protocol_policy     = "redirect-to-https"
       cache_policy_id            = aws_cloudfront_cache_policy.medium_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
 
@@ -129,24 +129,24 @@ module "cdn" {
       target_origin_id           = "alb"
       path_pattern               = "/xi/api/v2/search_references"
       viewer_protocol_policy     = "redirect-to-https"
-      cache_policy_id            = aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
     uk_api_search_references = {
       target_origin_id           = "alb"
       path_pattern               = "/uk/api/v2/search_references"
       viewer_protocol_policy     = "redirect-to-https"
-      cache_policy_id            = aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
     default_api_search_references = {
       target_origin_id           = "alb"
       path_pattern               = "/api/v2/search_references"
       viewer_protocol_policy     = "redirect-to-https"
-      cache_policy_id            = aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
 
@@ -155,24 +155,24 @@ module "cdn" {
       target_origin_id           = "alb"
       path_pattern               = "/xi/api/v2/news*"
       viewer_protocol_policy     = "redirect-to-https"
-      cache_policy_id            = aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
     uk_api_news = {
       target_origin_id           = "alb"
       path_pattern               = "/uk/api/v2/news*"
       viewer_protocol_policy     = "redirect-to-https"
-      cache_policy_id            = aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
     default_api_news = {
       target_origin_id           = "alb"
       path_pattern               = "/api/v2/news*"
       viewer_protocol_policy     = "redirect-to-https"
-      cache_policy_id            = aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
 
@@ -182,7 +182,7 @@ module "cdn" {
       path_pattern               = "/xi/api/v2/*"
       viewer_protocol_policy     = "redirect-to-https"
       cache_policy_id            = aws_cloudfront_cache_policy.long_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
     uk_api = {
@@ -190,7 +190,7 @@ module "cdn" {
       path_pattern               = "/uk/api/v2/*"
       viewer_protocol_policy     = "redirect-to-https"
       cache_policy_id            = aws_cloudfront_cache_policy.long_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
     default_api = {
@@ -198,7 +198,7 @@ module "cdn" {
       path_pattern               = "/api/v2/*"
       viewer_protocol_policy     = "redirect-to-https"
       cache_policy_id            = aws_cloudfront_cache_policy.long_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
 
@@ -208,7 +208,7 @@ module "cdn" {
       path_pattern               = "/xi/api/v1/*"
       viewer_protocol_policy     = "redirect-to-https"
       cache_policy_id            = aws_cloudfront_cache_policy.long_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
     uk_v1_api = {
@@ -216,7 +216,7 @@ module "cdn" {
       path_pattern               = "/uk/api/v1/*"
       viewer_protocol_policy     = "redirect-to-https"
       cache_policy_id            = aws_cloudfront_cache_policy.long_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
     default_v1_api = {
@@ -224,7 +224,7 @@ module "cdn" {
       path_pattern               = "/api/v1/*"
       viewer_protocol_policy     = "redirect-to-https"
       cache_policy_id            = aws_cloudfront_cache_policy.long_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
 
@@ -233,7 +233,7 @@ module "cdn" {
       target_origin_id           = "alb"
       viewer_protocol_policy     = "redirect-to-https"
       cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
   }

--- a/environments/development/common/cloudfront.tf
+++ b/environments/development/common/cloudfront.tf
@@ -41,67 +41,200 @@ module "cdn" {
     }
   }
 
+  # NOTE: More specific paths should be listed first, as they are evaluated in order
+  #       where the first matching path is used and the policy is applied.
   cache_behavior = {
-    default = {
-      target_origin_id       = "alb"
-      viewer_protocol_policy = "redirect-to-https"
-
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+    # Static assets are fingerprinted and cached for a long time
+    assets = {
+      target_origin_id           = "alb"
+      viewer_protocol_policy     = "redirect-to-https"
+      path_pattern               = "/assets/*"
+      cache_policy_id            = aws_cloudfront_cache_policy.very_very_long_cache.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-
-      min_ttl     = 0
-      default_ttl = 0
-      max_ttl     = 0
-
-      compress = true
-
-      allowed_methods = [
-        "GET",
-        "HEAD",
-        "OPTIONS",
-        "PUT",
-        "POST",
-        "PATCH",
-        "DELETE"
-      ]
-
-      cached_methods = [
-        "GET",
-        "HEAD"
-      ]
     }
 
-    api = {
-      target_origin_id       = "alb"
-      viewer_protocol_policy = "redirect-to-https"
-
-      path_pattern = "/api/v2/*"
-
-      cache_policy_id            = aws_cloudfront_cache_policy.cache_api.id
+    packs = {
+      target_origin_id           = "alb"
+      viewer_protocol_policy     = "redirect-to-https"
+      path_pattern               = "/packs/*"
+      cache_policy_id            = aws_cloudfront_cache_policy.very_very_long_cache.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
 
-      min_ttl     = 1
-      default_ttl = 1800
-      max_ttl     = 1800
+    images = {
+      target_origin_id           = "alb"
+      viewer_protocol_policy     = "redirect-to-https"
+      path_pattern               = "/images/*"
+      cache_policy_id            = aws_cloudfront_cache_policy.long_cache.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
 
-      compress = true
+    # Green lanes/SPIMM endpoints
+    xi_api_exchange_rates = {
+      target_origin_id           = "alb"
+      path_pattern               = "/xi/api/v2/green_lanes/*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.short_cache.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+    uk_api_exchange_rates = {
+      target_origin_id           = "alb"
+      path_pattern               = "/uk/api/v2/green_lanes/*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.short_cache.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+    default_api_exchange_rates = {
+      target_origin_id           = "alb"
+      path_pattern               = "/api/v2/green_lanes/*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.short_cache.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
 
-      allowed_methods = [
-        "GET",
-        "HEAD",
-        "OPTIONS",
-        "PUT",
-        "POST",
-        "PATCH",
-        "DELETE"
-      ]
+    # Exchange rate endpoints
+    xi_api_exchange_rates = {
+      target_origin_id           = "alb"
+      path_pattern               = "/xi/api/v2/exchange_rates/*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.medium_cache.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+    uk_api_exchange_rates = {
+      target_origin_id           = "alb"
+      path_pattern               = "/uk/api/v2/exchange_rates/*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.medium_cache.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+    default_api_exchange_rates = {
+      target_origin_id           = "alb"
+      path_pattern               = "/api/v2/exchange_rates/*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.medium_cache.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
 
-      cached_methods = [
-        "GET",
-        "HEAD"
-      ]
+    # Search reference endpoints
+    xi_api_search_references = {
+      target_origin_id           = "alb"
+      path_pattern               = "/xi/api/v2/search_references"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+    uk_api_search_references = {
+      target_origin_id           = "alb"
+      path_pattern               = "/uk/api/v2/search_references"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+    default_api_search_references = {
+      target_origin_id           = "alb"
+      path_pattern               = "/api/v2/search_references"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+
+    # News endpoints
+    xi_api_news = {
+      target_origin_id           = "alb"
+      path_pattern               = "/xi/api/v2/news*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+    uk_api_news = {
+      target_origin_id           = "alb"
+      path_pattern               = "/uk/api/v2/news*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+    default_api_news = {
+      target_origin_id           = "alb"
+      path_pattern               = "/api/v2/news*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+
+    # API v2 endpoints
+    xi_api = {
+      target_origin_id           = "alb"
+      path_pattern               = "/xi/api/v2/*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.long_cache.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+    uk_api = {
+      target_origin_id           = "alb"
+      path_pattern               = "/uk/api/v2/*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.long_cache.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+    default_api = {
+      target_origin_id           = "alb"
+      path_pattern               = "/api/v2/*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.long_cache.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+
+    # API v1 endpoints TODO: this can be removed once we've migrated users to v2
+    xi_v1_api = {
+      target_origin_id           = "alb"
+      path_pattern               = "/xi/api/v1/*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.long_cache.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+    uk_v1_api = {
+      target_origin_id           = "alb"
+      path_pattern               = "/uk/api/v1/*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.long_cache.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+    default_v1_api = {
+      target_origin_id           = "alb"
+      path_pattern               = "/api/v1/*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.long_cache.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+
+    # Fallback for all other endpoints
+    default = {
+      target_origin_id           = "alb"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
   }
 
@@ -154,8 +287,6 @@ module "api_cdn" {
       min_ttl     = 0
       default_ttl = 0
       max_ttl     = 0
-
-      compress = true
     },
   }
 
@@ -206,8 +337,6 @@ module "reporting_cdn" {
       min_ttl     = 0
       default_ttl = 0
       max_ttl     = 0
-
-      compress = true
     },
   }
 
@@ -258,8 +387,6 @@ module "backups_cdn" {
       min_ttl     = 0
       default_ttl = 0
       max_ttl     = 0
-
-      compress = true
 
       function_association = {
         "viewer-request" = {
@@ -322,15 +449,6 @@ module "tech_docs_cdn" {
       min_ttl     = 0
       default_ttl = 0
       max_ttl     = 0
-
-      compress = true
-
-      # TODO: When we're ready to enable basic auth for tech docs, uncomment this block
-      # function_association = {
-      #   "viewer-request" = {
-      #     function_arn = aws_cloudfront_function.basic_auth.arn
-      #   }
-      # }
     },
   }
 
@@ -382,8 +500,6 @@ module "status_checks_cdn" {
       min_ttl     = 0
       default_ttl = 0
       max_ttl     = 0
-
-      compress = true
     },
   }
 
@@ -392,121 +508,6 @@ module "status_checks_cdn" {
     acm_certificate_arn = module.acm.validated_certificate_arn
     depends_on = [
       module.acm.validated_certificate_arn
-    ]
-  }
-}
-
-module "preview_cdn" {
-  source = "../../../modules/cloudfront"
-
-  aliases = [
-    "preview.${var.domain_name}",
-    "admin.preview.${var.domain_name}",
-    "hub.preview.${var.domain_name}",
-    "tea.preview.${var.domain_name}",
-  ]
-
-  create_alias    = true
-  route53_zone_id = data.aws_route53_zone.this.id
-  comment         = "Preview CDN ${title(var.environment)}"
-
-  enabled         = true
-  is_ipv6_enabled = true
-  price_class     = "PriceClass_100"
-
-  web_acl_id = module.waf.web_acl_id
-
-  logging_config = {
-    bucket = module.logs.s3_bucket_bucket_domain_name
-    prefix = "cloudfront/${var.environment}"
-  }
-
-  origin = {
-    frontend = {
-      domain_name = local.origin_domain_name
-      custom_origin_config = {
-        http_port              = 80
-        https_port             = 443
-        origin_protocol_policy = "https-only"
-        origin_ssl_protocols   = ["TLSv1.2"]
-      }
-
-      custom_header = [{
-        name  = random_password.origin_header[0].result
-        value = random_password.origin_header[1].result
-      }]
-    }
-  }
-
-  cache_behavior = {
-    default = {
-      target_origin_id       = "frontend"
-      viewer_protocol_policy = "redirect-to-https"
-
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-
-      min_ttl     = 0
-      default_ttl = 0
-      max_ttl     = 0
-
-      compress = true
-
-      allowed_methods = [
-        "GET",
-        "HEAD",
-        "OPTIONS",
-        "PUT",
-        "POST",
-        "PATCH",
-        "DELETE"
-      ]
-
-      cached_methods = [
-        "GET",
-        "HEAD"
-      ]
-    }
-
-    api = {
-      target_origin_id       = "frontend"
-      viewer_protocol_policy = "redirect-to-https"
-
-      path_pattern = "/api/v2/*"
-
-      cache_policy_id            = aws_cloudfront_cache_policy.cache_api.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-
-      min_ttl     = 1
-      default_ttl = 1800
-      max_ttl     = 1800
-
-      compress = true
-
-      allowed_methods = [
-        "GET",
-        "HEAD",
-        "OPTIONS",
-        "PUT",
-        "POST",
-        "PATCH",
-        "DELETE"
-      ]
-
-      cached_methods = [
-        "GET",
-        "HEAD"
-      ]
-    }
-  }
-
-  viewer_certificate = {
-    ssl_support_method  = "sni-only"
-    acm_certificate_arn = module.acm_preview.validated_certificate_arn
-    depends_on = [
-      module.acm_preview.validated_certificate_arn
     ]
   }
 }

--- a/environments/development/common/cloudfront.tf
+++ b/environments/development/common/cloudfront.tf
@@ -4,7 +4,6 @@ module "cdn" {
   aliases = [
     var.domain_name,
     "admin.${var.domain_name}",
-    "beta.${var.domain_name}",
     "hub.${var.domain_name}",
     "new-hub.${var.domain_name}",
     "tea.${var.domain_name}",
@@ -26,7 +25,7 @@ module "cdn" {
   }
 
   origin = {
-    frontend = {
+    alb = {
       domain_name = local.origin_domain_name
       custom_origin_config = {
         http_port              = 80
@@ -44,7 +43,7 @@ module "cdn" {
 
   cache_behavior = {
     default = {
-      target_origin_id       = "frontend"
+      target_origin_id       = "alb"
       viewer_protocol_policy = "redirect-to-https"
 
       cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
@@ -74,7 +73,7 @@ module "cdn" {
     }
 
     api = {
-      target_origin_id       = "frontend"
+      target_origin_id       = "alb"
       viewer_protocol_policy = "redirect-to-https"
 
       path_pattern = "/api/v2/*"

--- a/environments/production/common/README.md
+++ b/environments/production/common/README.md
@@ -113,12 +113,15 @@
 
 | Name | Type |
 |------|------|
-| [aws_cloudfront_cache_policy.cache_api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_cache_policy) | resource |
+| [aws_cloudfront_cache_policy.long_cache](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_cache_policy) | resource |
+| [aws_cloudfront_cache_policy.medium_cache](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_cache_policy) | resource |
 | [aws_cloudfront_cache_policy.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_cache_policy) | resource |
+| [aws_cloudfront_cache_policy.short_cache](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_cache_policy) | resource |
+| [aws_cloudfront_cache_policy.very_very_long_cache](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_cache_policy) | resource |
 | [aws_cloudfront_function.basic_auth](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_function) | resource |
 | [aws_cloudfront_origin_access_control.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_access_control) | resource |
-| [aws_cloudfront_origin_request_policy.forward_all_qsa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_request_policy) | resource |
 | [aws_cloudfront_origin_request_policy.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_request_policy) | resource |
+| [aws_cloudfront_origin_request_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_request_policy) | resource |
 | [aws_cloudfront_response_headers_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_response_headers_policy) | resource |
 | [aws_cloudwatch_log_group.redis_engine_lg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.redis_slow_lg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |

--- a/environments/production/common/README.md
+++ b/environments/production/common/README.md
@@ -120,8 +120,8 @@
 | [aws_cloudfront_cache_policy.very_very_long_cache](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_cache_policy) | resource |
 | [aws_cloudfront_function.basic_auth](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_function) | resource |
 | [aws_cloudfront_origin_access_control.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_access_control) | resource |
+| [aws_cloudfront_origin_request_policy.forward_all_qsa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_request_policy) | resource |
 | [aws_cloudfront_origin_request_policy.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_request_policy) | resource |
-| [aws_cloudfront_origin_request_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_request_policy) | resource |
 | [aws_cloudfront_response_headers_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_response_headers_policy) | resource |
 | [aws_cloudwatch_log_group.redis_engine_lg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.redis_slow_lg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |

--- a/environments/production/common/cloudfront-policy.tf
+++ b/environments/production/common/cloudfront-policy.tf
@@ -8,28 +8,59 @@ resource "random_password" "origin_header" {
   special = false
 }
 
-resource "aws_cloudfront_cache_policy" "cache_api" {
-  name        = "cache-apiv2"
-  default_ttl = 86400
-  max_ttl     = 86400
+resource "aws_cloudfront_cache_policy" "very_very_long_cache" {
+  name        = "very-very-long-cache"
+  default_ttl = 31536000 # 1 year
+  max_ttl     = 31536000 # 1 year
   min_ttl     = 1
 
   parameters_in_cache_key_and_forwarded_to_origin {
-    cookies_config {
-      cookie_behavior = "none"
-    }
-
-    headers_config {
-      header_behavior = "none"
-    }
-
-    query_strings_config {
-      query_string_behavior = "all"
-    }
+    cookies_config { cookie_behavior = "none" }
+    headers_config { header_behavior = "none" }
+    query_strings_config { query_string_behavior = "all" }
   }
 }
 
-resource "aws_cloudfront_origin_request_policy" "forward_all_qsa" {
+resource "aws_cloudfront_cache_policy" "long_cache" {
+  name        = "long-cache"
+  default_ttl = 86400 # 1 day
+  max_ttl     = 86400 # 1 day
+  min_ttl     = 1
+
+  parameters_in_cache_key_and_forwarded_to_origin {
+    cookies_config { cookie_behavior = "none" }
+    headers_config { header_behavior = "none" }
+    query_strings_config { query_string_behavior = "all" }
+  }
+}
+
+resource "aws_cloudfront_cache_policy" "medium_cache" {
+  name        = "medium-cache"
+  default_ttl = 7200 # 2 hours
+  max_ttl     = 7200 # 2 hours
+  min_ttl     = 1
+
+  parameters_in_cache_key_and_forwarded_to_origin {
+    cookies_config { cookie_behavior = "none" }
+    headers_config { header_behavior = "none" }
+    query_strings_config { query_string_behavior = "all" }
+  }
+}
+
+resource "aws_cloudfront_cache_policy" "short_cache" {
+  name        = "short-cache"
+  default_ttl = 1800 # 30 minutes
+  max_ttl     = 1800 # 30 minutes
+  min_ttl     = 1
+
+  parameters_in_cache_key_and_forwarded_to_origin {
+    cookies_config { cookie_behavior = "none" }
+    headers_config { header_behavior = "none" }
+    query_strings_config { query_string_behavior = "all" }
+  }
+}
+
+resource "aws_cloudfront_origin_request_policy" "this" {
   name    = "Forward-All-QSA-${var.environment}"
   comment = "Forward all QSA (managed by Terraform)"
   cookies_config {
@@ -74,10 +105,10 @@ resource "aws_cloudfront_response_headers_policy" "this" {
     access_control_max_age_sec = 7200
 
     access_control_allow_headers {
-      items = ["*"]
+      items = ["Authorization"]
     }
 
-    access_control_allow_credentials = false
+    access_control_allow_credentials = true
 
     origin_override = false
   }

--- a/environments/production/common/cloudfront-policy.tf
+++ b/environments/production/common/cloudfront-policy.tf
@@ -60,7 +60,7 @@ resource "aws_cloudfront_cache_policy" "short_cache" {
   }
 }
 
-resource "aws_cloudfront_origin_request_policy" "this" {
+resource "aws_cloudfront_origin_request_policy" "forward_all_qsa" {
   name    = "Forward-All-QSA-${var.environment}"
   comment = "Forward all QSA (managed by Terraform)"
   cookies_config {
@@ -105,10 +105,10 @@ resource "aws_cloudfront_response_headers_policy" "this" {
     access_control_max_age_sec = 7200
 
     access_control_allow_headers {
-      items = ["Authorization"]
+      items = ["*"]
     }
 
-    access_control_allow_credentials = true
+    access_control_allow_credentials = false
 
     origin_override = false
   }

--- a/environments/production/common/cloudfront.tf
+++ b/environments/production/common/cloudfront.tf
@@ -4,7 +4,6 @@ module "cdn" {
   aliases = [
     var.domain_name,
     "admin.${var.domain_name}",
-    "beta.${var.domain_name}",
     "hub.${var.domain_name}",
     "new-hub.${var.domain_name}",
     "tea.${var.domain_name}",

--- a/environments/production/common/cloudfront.tf
+++ b/environments/production/common/cloudfront.tf
@@ -74,28 +74,28 @@ module "cdn" {
     }
 
     # Green lanes/SPIMM endpoints
-    xi_api_exchange_rates = {
+    xi_api_spimm = {
       target_origin_id           = "alb"
       path_pattern               = "/xi/api/v2/green_lanes/*"
       viewer_protocol_policy     = "redirect-to-https"
       cache_policy_id            = aws_cloudfront_cache_policy.short_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
-    uk_api_exchange_rates = {
+    uk_api_spimm = {
       target_origin_id           = "alb"
       path_pattern               = "/uk/api/v2/green_lanes/*"
       viewer_protocol_policy     = "redirect-to-https"
       cache_policy_id            = aws_cloudfront_cache_policy.short_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
-    default_api_exchange_rates = {
+    default_api_spimm = {
       target_origin_id           = "alb"
       path_pattern               = "/api/v2/green_lanes/*"
       viewer_protocol_policy     = "redirect-to-https"
       cache_policy_id            = aws_cloudfront_cache_policy.short_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
 
@@ -105,7 +105,7 @@ module "cdn" {
       path_pattern               = "/xi/api/v2/exchange_rates/*"
       viewer_protocol_policy     = "redirect-to-https"
       cache_policy_id            = aws_cloudfront_cache_policy.medium_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
     uk_api_exchange_rates = {
@@ -113,7 +113,7 @@ module "cdn" {
       path_pattern               = "/uk/api/v2/exchange_rates/*"
       viewer_protocol_policy     = "redirect-to-https"
       cache_policy_id            = aws_cloudfront_cache_policy.medium_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
     default_api_exchange_rates = {
@@ -121,7 +121,7 @@ module "cdn" {
       path_pattern               = "/api/v2/exchange_rates/*"
       viewer_protocol_policy     = "redirect-to-https"
       cache_policy_id            = aws_cloudfront_cache_policy.medium_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
 
@@ -130,24 +130,24 @@ module "cdn" {
       target_origin_id           = "alb"
       path_pattern               = "/xi/api/v2/search_references"
       viewer_protocol_policy     = "redirect-to-https"
-      cache_policy_id            = aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
     uk_api_search_references = {
       target_origin_id           = "alb"
       path_pattern               = "/uk/api/v2/search_references"
       viewer_protocol_policy     = "redirect-to-https"
-      cache_policy_id            = aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
     default_api_search_references = {
       target_origin_id           = "alb"
       path_pattern               = "/api/v2/search_references"
       viewer_protocol_policy     = "redirect-to-https"
-      cache_policy_id            = aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
 
@@ -156,24 +156,24 @@ module "cdn" {
       target_origin_id           = "alb"
       path_pattern               = "/xi/api/v2/news*"
       viewer_protocol_policy     = "redirect-to-https"
-      cache_policy_id            = aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
     uk_api_news = {
       target_origin_id           = "alb"
       path_pattern               = "/uk/api/v2/news*"
       viewer_protocol_policy     = "redirect-to-https"
-      cache_policy_id            = aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
     default_api_news = {
       target_origin_id           = "alb"
       path_pattern               = "/api/v2/news*"
       viewer_protocol_policy     = "redirect-to-https"
-      cache_policy_id            = aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
 
@@ -183,7 +183,7 @@ module "cdn" {
       path_pattern               = "/xi/api/v2/*"
       viewer_protocol_policy     = "redirect-to-https"
       cache_policy_id            = aws_cloudfront_cache_policy.long_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
     uk_api = {
@@ -191,7 +191,7 @@ module "cdn" {
       path_pattern               = "/uk/api/v2/*"
       viewer_protocol_policy     = "redirect-to-https"
       cache_policy_id            = aws_cloudfront_cache_policy.long_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
     default_api = {
@@ -199,7 +199,7 @@ module "cdn" {
       path_pattern               = "/api/v2/*"
       viewer_protocol_policy     = "redirect-to-https"
       cache_policy_id            = aws_cloudfront_cache_policy.long_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
 
@@ -209,7 +209,7 @@ module "cdn" {
       path_pattern               = "/xi/api/v1/*"
       viewer_protocol_policy     = "redirect-to-https"
       cache_policy_id            = aws_cloudfront_cache_policy.long_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
     uk_v1_api = {
@@ -217,7 +217,7 @@ module "cdn" {
       path_pattern               = "/uk/api/v1/*"
       viewer_protocol_policy     = "redirect-to-https"
       cache_policy_id            = aws_cloudfront_cache_policy.long_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
     default_v1_api = {
@@ -225,7 +225,7 @@ module "cdn" {
       path_pattern               = "/api/v1/*"
       viewer_protocol_policy     = "redirect-to-https"
       cache_policy_id            = aws_cloudfront_cache_policy.long_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
 
@@ -234,7 +234,7 @@ module "cdn" {
       target_origin_id           = "alb"
       viewer_protocol_policy     = "redirect-to-https"
       cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
   }

--- a/environments/production/common/cloudfront.tf
+++ b/environments/production/common/cloudfront.tf
@@ -26,7 +26,7 @@ module "cdn" {
   }
 
   origin = {
-    frontend = {
+    alb = {
       domain_name = local.origin_domain_name
       custom_origin_config = {
         http_port              = 80
@@ -42,215 +42,200 @@ module "cdn" {
     }
   }
 
+  # NOTE: More specific paths should be listed first, as they are evaluated in order
+  #       where the first matching path is used and the policy is applied.
   cache_behavior = {
-    default = {
-      target_origin_id       = "frontend"
-      viewer_protocol_policy = "redirect-to-https"
-
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-
-      min_ttl     = 0
-      default_ttl = 0
-      max_ttl     = 0
-
-      compress = true
-
-      allowed_methods = [
-        "GET",
-        "HEAD",
-        "OPTIONS",
-        "PUT",
-        "POST",
-        "PATCH",
-        "DELETE"
-      ]
-
-      cached_methods = [
-        "GET",
-        "HEAD"
-      ]
-    }
-
-    api = {
-      target_origin_id       = "frontend"
-      viewer_protocol_policy = "redirect-to-https"
-
-      path_pattern = "/api/v2/*"
-
-      cache_policy_id            = aws_cloudfront_cache_policy.cache_api.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-
-      min_ttl     = 1
-      default_ttl = 1800
-      max_ttl     = 1800
-
-      compress = true
-
-      allowed_methods = [
-        "GET",
-        "HEAD",
-        "OPTIONS",
-        "PUT",
-        "POST",
-        "PATCH",
-        "DELETE"
-      ]
-
-      cached_methods = [
-        "GET",
-        "HEAD"
-      ]
-    }
-
-    xi_api = {
-      target_origin_id       = "frontend"
-      viewer_protocol_policy = "redirect-to-https"
-
-      path_pattern = "/xi/api/*"
-
-      cache_policy_id            = aws_cloudfront_cache_policy.cache_api.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-
-      min_ttl     = 1
-      default_ttl = 1800
-      max_ttl     = 1800
-
-      compress = true
-
-      allowed_methods = [
-        "GET",
-        "HEAD",
-        "OPTIONS",
-        "PUT",
-        "POST",
-        "PATCH",
-        "DELETE"
-      ]
-
-      cached_methods = [
-        "GET",
-        "HEAD"
-      ]
-    }
-
-    uk_api = {
-      target_origin_id       = "frontend"
-      viewer_protocol_policy = "redirect-to-https"
-
-      path_pattern = "/uk/api/*"
-
-      cache_policy_id            = aws_cloudfront_cache_policy.cache_api.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-
-      min_ttl     = 1
-      default_ttl = 1800
-      max_ttl     = 1800
-
-      compress = true
-
-      allowed_methods = [
-        "GET",
-        "HEAD",
-        "OPTIONS",
-        "PUT",
-        "POST",
-        "PATCH",
-        "DELETE"
-      ]
-
-      cached_methods = [
-        "GET",
-        "HEAD"
-      ]
-    }
-
+    # Static assets are fingerprinted and cached for a long time
     assets = {
-      target_origin_id       = "frontend"
-      viewer_protocol_policy = "redirect-to-https"
-
-      path_pattern = "/assets/*"
-
-      cache_policy_id            = aws_cloudfront_cache_policy.cache_api.id
+      target_origin_id           = "alb"
+      viewer_protocol_policy     = "redirect-to-https"
+      path_pattern               = "/assets/*"
+      cache_policy_id            = aws_cloudfront_cache_policy.very_very_long_cache.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-
-      min_ttl     = 1
-      default_ttl = 86400
-      max_ttl     = 86400
-
-      compress = true
-
-      allowed_methods = [
-        "GET",
-        "HEAD",
-        "OPTIONS"
-      ]
-
-      cached_methods = [
-        "GET",
-        "HEAD"
-      ]
     }
 
     packs = {
-      target_origin_id       = "frontend"
-      viewer_protocol_policy = "redirect-to-https"
-
-      path_pattern = "/packs/*"
-
-      cache_policy_id            = aws_cloudfront_cache_policy.cache_api.id
+      target_origin_id           = "alb"
+      viewer_protocol_policy     = "redirect-to-https"
+      path_pattern               = "/packs/*"
+      cache_policy_id            = aws_cloudfront_cache_policy.very_very_long_cache.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-
-      min_ttl     = 1
-      default_ttl = 86400
-      max_ttl     = 86400
-
-      compress = true
-
-      allowed_methods = [
-        "GET",
-        "HEAD",
-        "OPTIONS"
-      ]
-
-      cached_methods = [
-        "GET",
-        "HEAD"
-      ]
     }
 
     images = {
-      target_origin_id       = "frontend"
-      viewer_protocol_policy = "redirect-to-https"
-
-      path_pattern = "/images/*"
-
-      cache_policy_id            = aws_cloudfront_cache_policy.cache_api.id
+      target_origin_id           = "alb"
+      viewer_protocol_policy     = "redirect-to-https"
+      path_pattern               = "/images/*"
+      cache_policy_id            = aws_cloudfront_cache_policy.long_cache.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
 
-      min_ttl     = 1
-      default_ttl = 86400
-      max_ttl     = 86400
+    # Green lanes/SPIMM endpoints
+    xi_api_exchange_rates = {
+      target_origin_id           = "alb"
+      path_pattern               = "/xi/api/v2/green_lanes/*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.short_cache.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+    uk_api_exchange_rates = {
+      target_origin_id           = "alb"
+      path_pattern               = "/uk/api/v2/green_lanes/*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.short_cache.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+    default_api_exchange_rates = {
+      target_origin_id           = "alb"
+      path_pattern               = "/api/v2/green_lanes/*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.short_cache.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
 
-      compress = true
+    # Exchange rate endpoints
+    xi_api_exchange_rates = {
+      target_origin_id           = "alb"
+      path_pattern               = "/xi/api/v2/exchange_rates/*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.medium_cache.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+    uk_api_exchange_rates = {
+      target_origin_id           = "alb"
+      path_pattern               = "/uk/api/v2/exchange_rates/*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.medium_cache.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+    default_api_exchange_rates = {
+      target_origin_id           = "alb"
+      path_pattern               = "/api/v2/exchange_rates/*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.medium_cache.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
 
-      allowed_methods = [
-        "GET",
-        "HEAD",
-        "OPTIONS"
-      ]
+    # Search reference endpoints
+    xi_api_search_references = {
+      target_origin_id           = "alb"
+      path_pattern               = "/xi/api/v2/search_references"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+    uk_api_search_references = {
+      target_origin_id           = "alb"
+      path_pattern               = "/uk/api/v2/search_references"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+    default_api_search_references = {
+      target_origin_id           = "alb"
+      path_pattern               = "/api/v2/search_references"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
 
-      cached_methods = [
-        "GET",
-        "HEAD"
-      ]
+    # News endpoints
+    xi_api_news = {
+      target_origin_id           = "alb"
+      path_pattern               = "/xi/api/v2/news*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+    uk_api_news = {
+      target_origin_id           = "alb"
+      path_pattern               = "/uk/api/v2/news*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+    default_api_news = {
+      target_origin_id           = "alb"
+      path_pattern               = "/api/v2/news*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+
+    # API v2 endpoints
+    xi_api = {
+      target_origin_id           = "alb"
+      path_pattern               = "/xi/api/v2/*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.long_cache.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+    uk_api = {
+      target_origin_id           = "alb"
+      path_pattern               = "/uk/api/v2/*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.long_cache.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+    default_api = {
+      target_origin_id           = "alb"
+      path_pattern               = "/api/v2/*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.long_cache.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+
+    # API v1 endpoints TODO: this can be removed once we've migrated users to v2
+    xi_v1_api = {
+      target_origin_id           = "alb"
+      path_pattern               = "/xi/api/v1/*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.long_cache.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+    uk_v1_api = {
+      target_origin_id           = "alb"
+      path_pattern               = "/uk/api/v1/*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.long_cache.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+    default_v1_api = {
+      target_origin_id           = "alb"
+      path_pattern               = "/api/v1/*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.long_cache.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+
+    # Fallback for all other endpoints
+    default = {
+      target_origin_id           = "alb"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
   }
 
@@ -299,12 +284,6 @@ module "api_cdn" {
       cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.s3.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-
-      min_ttl     = 0
-      default_ttl = 0
-      max_ttl     = 0
-
-      compress = true
     },
   }
 
@@ -351,12 +330,6 @@ module "reporting_cdn" {
       cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.s3.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-
-      min_ttl     = 0
-      default_ttl = 0
-      max_ttl     = 0
-
-      compress = true
     },
   }
 
@@ -403,12 +376,6 @@ module "backups_cdn" {
       cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.s3.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-
-      min_ttl     = 0
-      default_ttl = 0
-      max_ttl     = 0
-
-      compress = true
 
       function_association = {
         "viewer-request" = {
@@ -469,19 +436,6 @@ module "tech_docs_cdn" {
       cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.s3.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-
-      min_ttl     = 0
-      default_ttl = 0
-      max_ttl     = 0
-
-      compress = true
-
-      # TODO: When we're ready to enable basic auth for tech docs, uncomment this block
-      # function_association = {
-      #   "viewer-request" = {
-      #     function_arn = aws_cloudfront_function.basic_auth.arn
-      #   }
-      # }
     },
   }
 
@@ -529,12 +483,6 @@ module "status_checks_cdn" {
       cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.s3.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-
-      min_ttl     = 0
-      default_ttl = 0
-      max_ttl     = 0
-
-      compress = true
     },
   }
 

--- a/environments/staging/common/README.md
+++ b/environments/staging/common/README.md
@@ -109,12 +109,15 @@
 
 | Name | Type |
 |------|------|
-| [aws_cloudfront_cache_policy.cache_api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_cache_policy) | resource |
+| [aws_cloudfront_cache_policy.long_cache](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_cache_policy) | resource |
+| [aws_cloudfront_cache_policy.medium_cache](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_cache_policy) | resource |
 | [aws_cloudfront_cache_policy.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_cache_policy) | resource |
+| [aws_cloudfront_cache_policy.short_cache](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_cache_policy) | resource |
+| [aws_cloudfront_cache_policy.very_very_long_cache](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_cache_policy) | resource |
 | [aws_cloudfront_function.basic_auth](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_function) | resource |
 | [aws_cloudfront_origin_access_control.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_access_control) | resource |
-| [aws_cloudfront_origin_request_policy.forward_all_qsa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_request_policy) | resource |
 | [aws_cloudfront_origin_request_policy.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_request_policy) | resource |
+| [aws_cloudfront_origin_request_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_request_policy) | resource |
 | [aws_cloudfront_response_headers_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_response_headers_policy) | resource |
 | [aws_cloudwatch_log_group.redis_engine_lg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.redis_slow_lg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |

--- a/environments/staging/common/README.md
+++ b/environments/staging/common/README.md
@@ -116,8 +116,8 @@
 | [aws_cloudfront_cache_policy.very_very_long_cache](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_cache_policy) | resource |
 | [aws_cloudfront_function.basic_auth](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_function) | resource |
 | [aws_cloudfront_origin_access_control.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_access_control) | resource |
+| [aws_cloudfront_origin_request_policy.forward_all_qsa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_request_policy) | resource |
 | [aws_cloudfront_origin_request_policy.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_request_policy) | resource |
-| [aws_cloudfront_origin_request_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_request_policy) | resource |
 | [aws_cloudfront_response_headers_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_response_headers_policy) | resource |
 | [aws_cloudwatch_log_group.redis_engine_lg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_cloudwatch_log_group.redis_slow_lg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |

--- a/environments/staging/common/cloudfront-policy.tf
+++ b/environments/staging/common/cloudfront-policy.tf
@@ -8,28 +8,59 @@ resource "random_password" "origin_header" {
   special = false
 }
 
-resource "aws_cloudfront_cache_policy" "cache_api" {
-  name        = "cache-apiv2"
-  default_ttl = 1800
-  max_ttl     = 1800
+resource "aws_cloudfront_cache_policy" "very_very_long_cache" {
+  name        = "very-very-long-cache"
+  default_ttl = 31536000 # 1 year
+  max_ttl     = 31536000 # 1 year
   min_ttl     = 1
 
   parameters_in_cache_key_and_forwarded_to_origin {
-    cookies_config {
-      cookie_behavior = "none"
-    }
-
-    headers_config {
-      header_behavior = "none"
-    }
-
-    query_strings_config {
-      query_string_behavior = "all"
-    }
+    cookies_config { cookie_behavior = "none" }
+    headers_config { header_behavior = "none" }
+    query_strings_config { query_string_behavior = "all" }
   }
 }
 
-resource "aws_cloudfront_origin_request_policy" "forward_all_qsa" {
+resource "aws_cloudfront_cache_policy" "long_cache" {
+  name        = "long-cache"
+  default_ttl = 86400 # 1 day
+  max_ttl     = 86400 # 1 day
+  min_ttl     = 1
+
+  parameters_in_cache_key_and_forwarded_to_origin {
+    cookies_config { cookie_behavior = "none" }
+    headers_config { header_behavior = "none" }
+    query_strings_config { query_string_behavior = "all" }
+  }
+}
+
+resource "aws_cloudfront_cache_policy" "medium_cache" {
+  name        = "medium-cache"
+  default_ttl = 7200 # 2 hours
+  max_ttl     = 7200 # 2 hours
+  min_ttl     = 1
+
+  parameters_in_cache_key_and_forwarded_to_origin {
+    cookies_config { cookie_behavior = "none" }
+    headers_config { header_behavior = "none" }
+    query_strings_config { query_string_behavior = "all" }
+  }
+}
+
+resource "aws_cloudfront_cache_policy" "short_cache" {
+  name        = "short-cache"
+  default_ttl = 1800 # 30 minutes
+  max_ttl     = 1800 # 30 minutes
+  min_ttl     = 1
+
+  parameters_in_cache_key_and_forwarded_to_origin {
+    cookies_config { cookie_behavior = "none" }
+    headers_config { header_behavior = "none" }
+    query_strings_config { query_string_behavior = "all" }
+  }
+}
+
+resource "aws_cloudfront_origin_request_policy" "this" {
   name    = "Forward-All-QSA-${var.environment}"
   comment = "Forward all QSA (managed by Terraform)"
   cookies_config {

--- a/environments/staging/common/cloudfront-policy.tf
+++ b/environments/staging/common/cloudfront-policy.tf
@@ -60,7 +60,7 @@ resource "aws_cloudfront_cache_policy" "short_cache" {
   }
 }
 
-resource "aws_cloudfront_origin_request_policy" "this" {
+resource "aws_cloudfront_origin_request_policy" "forward_all_qsa" {
   name    = "Forward-All-QSA-${var.environment}"
   comment = "Forward all QSA (managed by Terraform)"
   cookies_config {

--- a/environments/staging/common/cloudfront.tf
+++ b/environments/staging/common/cloudfront.tf
@@ -4,7 +4,6 @@ module "cdn" {
   aliases = [
     var.domain_name,
     "admin.${var.domain_name}",
-    "beta.${var.domain_name}",
     "hub.${var.domain_name}",
     "new-hub.${var.domain_name}",
     "tea.${var.domain_name}",

--- a/environments/staging/common/cloudfront.tf
+++ b/environments/staging/common/cloudfront.tf
@@ -73,28 +73,28 @@ module "cdn" {
     }
 
     # Green lanes/SPIMM endpoints
-    xi_api_exchange_rates = {
+    xi_api_spimm = {
       target_origin_id           = "alb"
       path_pattern               = "/xi/api/v2/green_lanes/*"
       viewer_protocol_policy     = "redirect-to-https"
       cache_policy_id            = aws_cloudfront_cache_policy.short_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
-    uk_api_exchange_rates = {
+    uk_api_spimm = {
       target_origin_id           = "alb"
       path_pattern               = "/uk/api/v2/green_lanes/*"
       viewer_protocol_policy     = "redirect-to-https"
       cache_policy_id            = aws_cloudfront_cache_policy.short_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
-    default_api_exchange_rates = {
+    default_api_spimm = {
       target_origin_id           = "alb"
       path_pattern               = "/api/v2/green_lanes/*"
       viewer_protocol_policy     = "redirect-to-https"
       cache_policy_id            = aws_cloudfront_cache_policy.short_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
 
@@ -104,7 +104,7 @@ module "cdn" {
       path_pattern               = "/xi/api/v2/exchange_rates/*"
       viewer_protocol_policy     = "redirect-to-https"
       cache_policy_id            = aws_cloudfront_cache_policy.medium_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
     uk_api_exchange_rates = {
@@ -112,7 +112,7 @@ module "cdn" {
       path_pattern               = "/uk/api/v2/exchange_rates/*"
       viewer_protocol_policy     = "redirect-to-https"
       cache_policy_id            = aws_cloudfront_cache_policy.medium_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
     default_api_exchange_rates = {
@@ -120,7 +120,7 @@ module "cdn" {
       path_pattern               = "/api/v2/exchange_rates/*"
       viewer_protocol_policy     = "redirect-to-https"
       cache_policy_id            = aws_cloudfront_cache_policy.medium_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
 
@@ -129,24 +129,24 @@ module "cdn" {
       target_origin_id           = "alb"
       path_pattern               = "/xi/api/v2/search_references"
       viewer_protocol_policy     = "redirect-to-https"
-      cache_policy_id            = aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
     uk_api_search_references = {
       target_origin_id           = "alb"
       path_pattern               = "/uk/api/v2/search_references"
       viewer_protocol_policy     = "redirect-to-https"
-      cache_policy_id            = aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
     default_api_search_references = {
       target_origin_id           = "alb"
       path_pattern               = "/api/v2/search_references"
       viewer_protocol_policy     = "redirect-to-https"
-      cache_policy_id            = aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
 
@@ -155,24 +155,24 @@ module "cdn" {
       target_origin_id           = "alb"
       path_pattern               = "/xi/api/v2/news*"
       viewer_protocol_policy     = "redirect-to-https"
-      cache_policy_id            = aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
     uk_api_news = {
       target_origin_id           = "alb"
       path_pattern               = "/uk/api/v2/news*"
       viewer_protocol_policy     = "redirect-to-https"
-      cache_policy_id            = aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
     default_api_news = {
       target_origin_id           = "alb"
       path_pattern               = "/api/v2/news*"
       viewer_protocol_policy     = "redirect-to-https"
-      cache_policy_id            = aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
 
@@ -182,7 +182,7 @@ module "cdn" {
       path_pattern               = "/xi/api/v2/*"
       viewer_protocol_policy     = "redirect-to-https"
       cache_policy_id            = aws_cloudfront_cache_policy.long_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
     uk_api = {
@@ -190,7 +190,7 @@ module "cdn" {
       path_pattern               = "/uk/api/v2/*"
       viewer_protocol_policy     = "redirect-to-https"
       cache_policy_id            = aws_cloudfront_cache_policy.long_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
     default_api = {
@@ -198,7 +198,7 @@ module "cdn" {
       path_pattern               = "/api/v2/*"
       viewer_protocol_policy     = "redirect-to-https"
       cache_policy_id            = aws_cloudfront_cache_policy.long_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
 
@@ -208,7 +208,7 @@ module "cdn" {
       path_pattern               = "/xi/api/v1/*"
       viewer_protocol_policy     = "redirect-to-https"
       cache_policy_id            = aws_cloudfront_cache_policy.long_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
     uk_v1_api = {
@@ -216,7 +216,7 @@ module "cdn" {
       path_pattern               = "/uk/api/v1/*"
       viewer_protocol_policy     = "redirect-to-https"
       cache_policy_id            = aws_cloudfront_cache_policy.long_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
     default_v1_api = {
@@ -224,7 +224,7 @@ module "cdn" {
       path_pattern               = "/api/v1/*"
       viewer_protocol_policy     = "redirect-to-https"
       cache_policy_id            = aws_cloudfront_cache_policy.long_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
 
@@ -233,7 +233,7 @@ module "cdn" {
       target_origin_id           = "alb"
       viewer_protocol_policy     = "redirect-to-https"
       cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
   }

--- a/environments/staging/common/cloudfront.tf
+++ b/environments/staging/common/cloudfront.tf
@@ -25,7 +25,7 @@ module "cdn" {
   }
 
   origin = {
-    frontend = {
+    alb = {
       domain_name = local.origin_domain_name
       custom_origin_config = {
         http_port              = 80
@@ -41,67 +41,200 @@ module "cdn" {
     }
   }
 
+  # NOTE: More specific paths should be listed first, as they are evaluated in order
+  #       where the first matching path is used and the policy is applied.
   cache_behavior = {
-    default = {
-      target_origin_id       = "frontend"
-      viewer_protocol_policy = "redirect-to-https"
-
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+    # Static assets are fingerprinted and cached for a long time
+    assets = {
+      target_origin_id           = "alb"
+      viewer_protocol_policy     = "redirect-to-https"
+      path_pattern               = "/assets/*"
+      cache_policy_id            = aws_cloudfront_cache_policy.very_very_long_cache.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-
-      min_ttl     = 0
-      default_ttl = 0
-      max_ttl     = 0
-
-      compress = true
-
-      allowed_methods = [
-        "GET",
-        "HEAD",
-        "OPTIONS",
-        "PUT",
-        "POST",
-        "PATCH",
-        "DELETE"
-      ]
-
-      cached_methods = [
-        "GET",
-        "HEAD"
-      ]
     }
 
-    api = {
-      target_origin_id       = "frontend"
-      viewer_protocol_policy = "redirect-to-https"
-
-      path_pattern = "/api/v2/*"
-
-      cache_policy_id            = aws_cloudfront_cache_policy.cache_api.id
+    packs = {
+      target_origin_id           = "alb"
+      viewer_protocol_policy     = "redirect-to-https"
+      path_pattern               = "/packs/*"
+      cache_policy_id            = aws_cloudfront_cache_policy.very_very_long_cache.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
 
-      min_ttl     = 1
-      default_ttl = 1800
-      max_ttl     = 1800
+    images = {
+      target_origin_id           = "alb"
+      viewer_protocol_policy     = "redirect-to-https"
+      path_pattern               = "/images/*"
+      cache_policy_id            = aws_cloudfront_cache_policy.long_cache.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
 
-      compress = true
+    # Green lanes/SPIMM endpoints
+    xi_api_exchange_rates = {
+      target_origin_id           = "alb"
+      path_pattern               = "/xi/api/v2/green_lanes/*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.short_cache.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+    uk_api_exchange_rates = {
+      target_origin_id           = "alb"
+      path_pattern               = "/uk/api/v2/green_lanes/*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.short_cache.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+    default_api_exchange_rates = {
+      target_origin_id           = "alb"
+      path_pattern               = "/api/v2/green_lanes/*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.short_cache.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
 
-      allowed_methods = [
-        "GET",
-        "HEAD",
-        "OPTIONS",
-        "PUT",
-        "POST",
-        "PATCH",
-        "DELETE"
-      ]
+    # Exchange rate endpoints
+    xi_api_exchange_rates = {
+      target_origin_id           = "alb"
+      path_pattern               = "/xi/api/v2/exchange_rates/*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.medium_cache.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+    uk_api_exchange_rates = {
+      target_origin_id           = "alb"
+      path_pattern               = "/uk/api/v2/exchange_rates/*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.medium_cache.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+    default_api_exchange_rates = {
+      target_origin_id           = "alb"
+      path_pattern               = "/api/v2/exchange_rates/*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.medium_cache.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
 
-      cached_methods = [
-        "GET",
-        "HEAD"
-      ]
+    # Search reference endpoints
+    xi_api_search_references = {
+      target_origin_id           = "alb"
+      path_pattern               = "/xi/api/v2/search_references"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+    uk_api_search_references = {
+      target_origin_id           = "alb"
+      path_pattern               = "/uk/api/v2/search_references"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+    default_api_search_references = {
+      target_origin_id           = "alb"
+      path_pattern               = "/api/v2/search_references"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+
+    # News endpoints
+    xi_api_news = {
+      target_origin_id           = "alb"
+      path_pattern               = "/xi/api/v2/news*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+    uk_api_news = {
+      target_origin_id           = "alb"
+      path_pattern               = "/uk/api/v2/news*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+    default_api_news = {
+      target_origin_id           = "alb"
+      path_pattern               = "/api/v2/news*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+
+    # API v2 endpoints
+    xi_api = {
+      target_origin_id           = "alb"
+      path_pattern               = "/xi/api/v2/*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.long_cache.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+    uk_api = {
+      target_origin_id           = "alb"
+      path_pattern               = "/uk/api/v2/*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.long_cache.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+    default_api = {
+      target_origin_id           = "alb"
+      path_pattern               = "/api/v2/*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.long_cache.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+
+    # API v1 endpoints TODO: this can be removed once we've migrated users to v2
+    xi_v1_api = {
+      target_origin_id           = "alb"
+      path_pattern               = "/xi/api/v1/*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.long_cache.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+    uk_v1_api = {
+      target_origin_id           = "alb"
+      path_pattern               = "/uk/api/v1/*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.long_cache.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+    default_v1_api = {
+      target_origin_id           = "alb"
+      path_pattern               = "/api/v1/*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = aws_cloudfront_cache_policy.long_cache.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+
+    # Fallback for all other endpoints
+    default = {
+      target_origin_id           = "alb"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.this.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
   }
 
@@ -150,12 +283,6 @@ module "api_cdn" {
       cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.s3.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-
-      min_ttl     = 0
-      default_ttl = 0
-      max_ttl     = 0
-
-      compress = true
     },
   }
 
@@ -202,12 +329,6 @@ module "reporting_cdn" {
       cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.s3.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-
-      min_ttl     = 0
-      default_ttl = 0
-      max_ttl     = 0
-
-      compress = true
     },
   }
 
@@ -254,12 +375,6 @@ module "backups_cdn" {
       cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.s3.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-
-      min_ttl     = 0
-      default_ttl = 0
-      max_ttl     = 0
-
-      compress = true
 
       function_association = {
         "viewer-request" = {
@@ -320,19 +435,6 @@ module "tech_docs_cdn" {
       cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.s3.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-
-      min_ttl     = 0
-      default_ttl = 0
-      max_ttl     = 0
-
-      compress = true
-
-      # TODO: When we're ready to enable basic auth for tech docs, uncomment this block
-      # function_association = {
-      #   "viewer-request" = {
-      #     function_arn = aws_cloudfront_function.basic_auth.arn
-      #   }
-      # }
     },
   }
 
@@ -380,12 +482,6 @@ module "status_checks_cdn" {
       cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.s3.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-
-      min_ttl     = 0
-      default_ttl = 0
-      max_ttl     = 0
-
-      compress = true
     },
   }
 

--- a/modules/cloudfront/main.tf
+++ b/modules/cloudfront/main.tf
@@ -129,17 +129,19 @@ resource "aws_cloudfront_distribution" "this" {
       target_origin_id       = i.value["target_origin_id"]
       viewer_protocol_policy = i.value["viewer_protocol_policy"]
 
-      allowed_methods = lookup(i.value, "allowed_methods", ["GET", "HEAD", "OPTIONS"])
+      allowed_methods = lookup(i.value, "allowed_methods", ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"])
       cached_methods  = lookup(i.value, "cached_methods", ["GET", "HEAD"])
-      compress        = lookup(i.value, "compress", null)
+      compress        = lookup(i.value, "compress", true)
 
       field_level_encryption_id = lookup(i.value, "field_level_encryption_id", null)
       smooth_streaming          = lookup(i.value, "smooth_streaming", null)
       trusted_signers           = lookup(i.value, "trusted_signers", null)
 
-      min_ttl     = lookup(i.value, "min_ttl", null)
-      default_ttl = lookup(i.value, "default_ttl", null)
-      max_ttl     = lookup(i.value, "max_ttl", null)
+      # Thes are for legacy cache policies (where the policy is missing).
+      # TTLs are actually set in the cache policy.
+      min_ttl     = lookup(i.value, "min_ttl", 1)
+      default_ttl = lookup(i.value, "default_ttl", 1800)
+      max_ttl     = lookup(i.value, "max_ttl", 1800)
 
       cache_policy_id            = i.value["cache_policy_id"]
       origin_request_policy_id   = i.value["origin_request_policy_id"]

--- a/modules/cloudfront/main.tf
+++ b/modules/cloudfront/main.tf
@@ -82,13 +82,14 @@ resource "aws_cloudfront_distribution" "this" {
       target_origin_id       = i.value["target_origin_id"]
       viewer_protocol_policy = i.value["viewer_protocol_policy"]
 
-      allowed_methods           = lookup(i.value, "allowed_methods", ["GET", "HEAD", "OPTIONS"])
+      allowed_methods           = lookup(i.value, "allowed_methods", ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"])
       cached_methods            = lookup(i.value, "cached_methods", ["GET", "HEAD"])
-      compress                  = lookup(i.value, "compress", null)
+      compress                  = lookup(i.value, "compress", true)
       field_level_encryption_id = lookup(i.value, "field_level_encryption_id", null)
       smooth_streaming          = lookup(i.value, "smooth_streaming", null)
       trusted_signers           = lookup(i.value, "trusted_signers", null)
 
+      # NOTE:These are for legacy cache policies (where the cache policy is present this is vestigial).
       min_ttl     = lookup(i.value, "min_ttl", null)
       default_ttl = lookup(i.value, "default_ttl", null)
       max_ttl     = lookup(i.value, "max_ttl", null)
@@ -137,8 +138,7 @@ resource "aws_cloudfront_distribution" "this" {
       smooth_streaming          = lookup(i.value, "smooth_streaming", null)
       trusted_signers           = lookup(i.value, "trusted_signers", null)
 
-      # Thes are for legacy cache policies (where the policy is missing).
-      # TTLs are actually set in the cache policy.
+      # NOTE:These are for legacy cache policies (where the cache policy is present this is vestigial).
       min_ttl     = lookup(i.value, "min_ttl", 1)
       default_ttl = lookup(i.value, "default_ttl", 1800)
       max_ttl     = lookup(i.value, "max_ttl", 1800)


### PR DESCRIPTION
# Jira link

[HMRC-973](https://transformuk.atlassian.net/browse/HMRC-973)

## What?

I have:

- [x] Removed all references to beta
- [x] Rename `frontend` origin to `alb`
- [x] Adding policies for each of the development environment to allow specific caching policies
- [x] Adding policies for each of the staging environment to allow specific caching policies
- [x] Adding policies for each of the production environment to allow specific caching policies

## Why?

I am doing this because:

- This is needed because we're migrating away from having the caching configuration specified at the application level and clumsily applied with etags
