### PR TITLE
HMRC-983: Make CloudFront module more robust

### DIFF
--- a/environments/production/common/cloudfront-moved.tf
+++ b/environments/production/common/cloudfront-moved.tf
@@ -1,0 +1,54 @@
+moved {
+  from = module.cdn.aws_route53_record.alias_record[0]
+  to   = module.cdn.aws_route53_record.alias_record["trade-tariff.service.gov.uk"]
+}
+
+moved {
+  from = module.cdn.aws_route53_record.alias_record[1]
+  to   = module.cdn.aws_route53_record.alias_record["admin.trade-tariff.service.gov.uk"]
+}
+
+moved {
+  from = module.cdn.aws_route53_record.alias_record[2]
+  to   = module.cdn.aws_route53_record.alias_record["hub.trade-tariff.service.gov.uk"]
+}
+
+moved {
+  from = module.cdn.aws_route53_record.alias_record[3]
+  to   = module.cdn.aws_route53_record.alias_record["new-hub.trade-tariff.service.gov.uk"]
+}
+
+moved {
+  from = module.cdn.aws_route53_record.alias_record[4]
+  to   = module.cdn.aws_route53_record.alias_record["tea.trade-tariff.service.gov.uk"]
+}
+
+moved {
+  from = module.cdn.aws_route53_record.alias_record[5]
+  to   = module.cdn.aws_route53_record.alias_record["www.trade-tariff.service.gov.uk"]
+}
+
+moved {
+  from = module.api_cdn.aws_route53_record.alias_record[0]
+  to   = module.api_cdn.aws_route53_record.alias_record["api.trade-tariff.service.gov.uk"]
+}
+
+moved {
+  from = module.backups_cdn.aws_route53_record.alias_record[0]
+  to   = module.backups_cdn.aws_route53_record.alias_record["dumps.trade-tariff.service.gov.uk"]
+}
+
+moved {
+  from = module.reporting_cdn.aws_route53_record.alias_record[0]
+  to   = module.reporting_cdn.aws_route53_record.alias_record["reporting.trade-tariff.service.gov.uk"]
+}
+
+moved {
+  from = module.status_checks_cdn.aws_route53_record.alias_record[0]
+  to   = module.status_checks_cdn.aws_route53_record.alias_record["status.trade-tariff.service.gov.uk"]
+}
+
+moved {
+  from = module.tech_docs_cdn.aws_route53_record.alias_record[0]
+  to   = module.tech_docs_cdn.aws_route53_record.alias_record["docs.trade-tariff.service.gov.uk"]
+}

--- a/environments/staging/common/cloudfront-moved.tf
+++ b/environments/staging/common/cloudfront-moved.tf
@@ -1,0 +1,49 @@
+moved {
+  from = module.cdn.aws_route53_record.alias_record[0]
+  to   = module.cdn.aws_route53_record.alias_record["staging.trade-tariff.service.gov.uk"]
+}
+
+moved {
+  from = module.cdn.aws_route53_record.alias_record[1]
+  to   = module.cdn.aws_route53_record.alias_record["admin.staging.trade-tariff.service.gov.uk"]
+}
+
+moved {
+  from = module.cdn.aws_route53_record.alias_record[2]
+  to   = module.cdn.aws_route53_record.alias_record["hub.staging.trade-tariff.service.gov.uk"]
+}
+
+moved {
+  from = module.cdn.aws_route53_record.alias_record[3]
+  to   = module.cdn.aws_route53_record.alias_record["new-hub.staging.trade-tariff.service.gov.uk"]
+}
+
+moved {
+  from = module.cdn.aws_route53_record.alias_record[4]
+  to   = module.cdn.aws_route53_record.alias_record["tea.staging.trade-tariff.service.gov.uk"]
+}
+
+moved {
+  from = module.api_cdn.aws_route53_record.alias_record[0]
+  to   = module.api_cdn.aws_route53_record.alias_record["api.staging.trade-tariff.service.gov.uk"]
+}
+
+moved {
+  from = module.backups_cdn.aws_route53_record.alias_record[0]
+  to   = module.backups_cdn.aws_route53_record.alias_record["dumps.staging.trade-tariff.service.gov.uk"]
+}
+
+moved {
+  from = module.reporting_cdn.aws_route53_record.alias_record[0]
+  to   = module.reporting_cdn.aws_route53_record.alias_record["reporting.staging.trade-tariff.service.gov.uk"]
+}
+
+moved {
+  from = module.status_checks_cdn.aws_route53_record.alias_record[0]
+  to   = module.status_checks_cdn.aws_route53_record.alias_record["status.staging.trade-tariff.service.gov.uk"]
+}
+
+moved {
+  from = module.tech_docs_cdn.aws_route53_record.alias_record[0]
+  to   = module.tech_docs_cdn.aws_route53_record.alias_record["docs.staging.trade-tariff.service.gov.uk"]
+}

--- a/modules/cloudfront/README.md
+++ b/modules/cloudfront/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.94.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.91.0 |
 
 ## Modules
 

--- a/modules/cloudfront/main.tf
+++ b/modules/cloudfront/main.tf
@@ -204,8 +204,11 @@ resource "aws_cloudfront_distribution" "this" {
 }
 
 resource "aws_route53_record" "alias_record" {
-  count   = var.aliases != null && var.create_alias ? length(var.aliases) : 0
-  name    = element(var.aliases, count.index)
+  for_each = {
+    for alias in var.aliases : alias => alias
+    if var.create_alias
+  }
+  name    = each.key
   type    = "A"
   zone_id = var.route53_zone_id
 
@@ -217,8 +220,11 @@ resource "aws_route53_record" "alias_record" {
 }
 
 resource "aws_route53_record" "cname_record" {
-  count           = var.aliases != null && var.create_cname ? length(var.aliases) : 0
-  name            = element(var.aliases, count.index)
+  for_each = {
+    for alias in var.aliases : alias => alias
+    if var.create_cname
+  }
+  name            = each.key
   type            = "CNAME"
   ttl             = 60
   records         = [aws_cloudfront_distribution.this[0].domain_name]


### PR DESCRIPTION
# Jira link

[HMRC-983](https://transformuk.atlassian.net/browse/HMRC-983)

## What?

I have:

- Changed the `count` arguments for Route53 resources to `for_each`.
- Added `moved` blocks to prevent the destruction/recreation of these records (these can be removed after this PR is merged and applied).

## Why?

I am doing this because:

- After a change to the CDN aliases in #351, applying the production Terraform led to a failed deployment, in which it had already deleted the Route53 A records for the production CDN before stopping and exiting. This happened because `count` was used for these resources, and when their insertion order in the list changed (due to the removal of `beta.`), they all were due for deletion and recreation.
- This PR will prevent this from happening again, as `for_each` preserves insertion order and does not have to delete and recreate all records if part of the input data changes.