### PR TITLE
HMRC-977-Config for GovUK Notify

### DIFF
--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -61,9 +61,11 @@ No outputs.
 | <a name="module_alb_preview"></a> [alb\_preview](#module\_alb\_preview) | ../../../modules/application-load-balancer/ | n/a |
 | <a name="module_api_cdn"></a> [api\_cdn](#module\_api\_cdn) | ../../../modules/cloudfront | n/a |
 | <a name="module_backend_differences_to_emails"></a> [backend\_differences\_to\_emails](#module\_backend\_differences\_to\_emails) | ../../../modules/secret/ | n/a |
+| <a name="module_backend_govuk_notify_api_key"></a> [backend\_govuk\_notify\_api\_key](#module\_backend\_govuk\_notify\_api\_key) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_green_lanes_api_tokens"></a> [backend\_green\_lanes\_api\_tokens](#module\_backend\_green\_lanes\_api\_tokens) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_oauth_id"></a> [backend\_oauth\_id](#module\_backend\_oauth\_id) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_oauth_secret"></a> [backend\_oauth\_secret](#module\_backend\_oauth\_secret) | ../../../modules/secret/ | n/a |
+| <a name="module_backend_override_notify_email"></a> [backend\_override\_notify\_email](#module\_backend\_override\_notify\_email) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_secret_key_base"></a> [backend\_secret\_key\_base](#module\_backend\_secret\_key\_base) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_sentry_dsn"></a> [backend\_sentry\_dsn](#module\_backend\_sentry\_dsn) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_sync_email"></a> [backend\_sync\_email](#module\_backend\_sync\_email) | ../../../modules/secret/ | n/a |
@@ -286,9 +288,11 @@ No outputs.
 | <a name="input_slack_notify_lambda_slack_webhook_url"></a> [slack\_notify\_lambda\_slack\_webhook\_url](#input\_slack\_notify\_lambda\_slack\_webhook\_url) | Value of SLACK\_WEB\_HOOK\_URL for the slack notify lambda. | `string` | n/a | yes |
 | <a name="input_slack_web_hook_url"></a> [slack\_web\_hook\_url](#input\_slack\_web\_hook\_url) | Value of SLACK\_WEB\_HOOK\_URL for the backend. | `string` | n/a | yes |
 | <a name="input_tariff_backend_differences_to_emails"></a> [tariff\_backend\_differences\_to\_emails](#input\_tariff\_backend\_differences\_to\_emails) | Differences report TO email addresses. | `string` | n/a | yes |
+| <a name="input_tariff_backend_govuk_notify_api_key"></a> [tariff\_backend\_govuk\_notify\_api\_key](#input\_tariff\_backend\_govuk\_notify\_api\_key) | Value of GOVUK\_NOTIFY\_API\_KEY for the tariff backend. | `string` | n/a | yes |
 | <a name="input_tariff_backend_green_lanes_api_tokens"></a> [tariff\_backend\_green\_lanes\_api\_tokens](#input\_tariff\_backend\_green\_lanes\_api\_tokens) | Value of GREEN\_LANES\_API\_TOKENS for the tariff backend. | `string` | n/a | yes |
 | <a name="input_tariff_backend_oauth_id"></a> [tariff\_backend\_oauth\_id](#input\_tariff\_backend\_oauth\_id) | Value of Tariff Backend OAuth ID. | `string` | n/a | yes |
 | <a name="input_tariff_backend_oauth_secret"></a> [tariff\_backend\_oauth\_secret](#input\_tariff\_backend\_oauth\_secret) | Value of Tariff Backend OAuth secret. | `string` | n/a | yes |
+| <a name="input_tariff_backend_override_notify_email"></a> [tariff\_backend\_override\_notify\_email](#input\_tariff\_backend\_override\_notify\_email) | Value of OVERRIDE\_NOTIFY\_EMAIL for the tariff backend. | `string` | n/a | yes |
 | <a name="input_tariff_backend_sentry_dsn"></a> [tariff\_backend\_sentry\_dsn](#input\_tariff\_backend\_sentry\_dsn) | Value of Backend Sentry DSN. | `string` | n/a | yes |
 | <a name="input_tariff_backend_sync_email"></a> [tariff\_backend\_sync\_email](#input\_tariff\_backend\_sync\_email) | Value of Tariff Sync email. | `string` | n/a | yes |
 | <a name="input_tariff_backend_uk_sync_host"></a> [tariff\_backend\_uk\_sync\_host](#input\_tariff\_backend\_uk\_sync\_host) | Value of Tariff Sync host. | `string` | n/a | yes |

--- a/environments/development/common/secrets.tf
+++ b/environments/development/common/secrets.tf
@@ -176,12 +176,28 @@ module "backend_differences_to_emails" {
   secret_string   = var.tariff_backend_differences_to_emails
 }
 
+module "backend_govuk_notify_api_key" {
+  source          = "../../../modules/secret/"
+  name            = "backend-govuk-notify-api-key"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.tariff_backend_govuk_notify_api_key
+}
+
 module "backend_green_lanes_api_tokens" {
   source          = "../../../modules/secret/"
   name            = "backend-green-lanes-api-tokens"
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
   recovery_window = 7
   secret_string   = var.tariff_backend_green_lanes_api_tokens
+}
+
+module "backend_override_notify_email" {
+  source          = "../../../modules/secret/"
+  name            = "backend-govuk-notify-api-key"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.tariff_backend_override_notify_email
 }
 
 module "backend_sync_email" {

--- a/environments/development/common/secrets.tf
+++ b/environments/development/common/secrets.tf
@@ -194,7 +194,7 @@ module "backend_green_lanes_api_tokens" {
 
 module "backend_override_notify_email" {
   source          = "../../../modules/secret/"
-  name            = "backend-govuk-notify-api-key"
+  name            = "backend-override-notify-email"
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
   recovery_window = 7
   secret_string   = var.tariff_backend_override_notify_email

--- a/environments/development/common/variables.tf
+++ b/environments/development/common/variables.tf
@@ -113,8 +113,20 @@ variable "tariff_backend_differences_to_emails" {
   sensitive   = true
 }
 
+variable "tariff_backend_govuk_notify_api_key" {
+  description = "Value of GOVUK_NOTIFY_API_KEY for the tariff backend."
+  type        = string
+  sensitive   = true
+}
+
 variable "tariff_backend_green_lanes_api_tokens" {
   description = "Value of GREEN_LANES_API_TOKENS for the tariff backend."
+  type        = string
+  sensitive   = true
+}
+
+variable "tariff_backend_override_notify_email" {
+  description = "Value of OVERRIDE_NOTIFY_EMAIL for the tariff backend."
   type        = string
   sensitive   = true
 }

--- a/environments/production/common/README.md
+++ b/environments/production/common/README.md
@@ -36,6 +36,7 @@
 | <a name="module_alb-security-group"></a> [alb-security-group](#module\_alb-security-group) | ../../../modules/security-group/ | n/a |
 | <a name="module_api_cdn"></a> [api\_cdn](#module\_api\_cdn) | ../../../modules/cloudfront | n/a |
 | <a name="module_backend_differences_to_emails"></a> [backend\_differences\_to\_emails](#module\_backend\_differences\_to\_emails) | ../../../modules/secret/ | n/a |
+| <a name="module_backend_govuk_notify_api_key"></a> [backend\_govuk\_notify\_api\_key](#module\_backend\_govuk\_notify\_api\_key) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_green_lanes_api_tokens"></a> [backend\_green\_lanes\_api\_tokens](#module\_backend\_green\_lanes\_api\_tokens) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_oauth_id"></a> [backend\_oauth\_id](#module\_backend\_oauth\_id) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_oauth_secret"></a> [backend\_oauth\_secret](#module\_backend\_oauth\_secret) | ../../../modules/secret/ | n/a |
@@ -290,6 +291,7 @@
 | <a name="input_slack_notify_lambda_slack_webhook_url"></a> [slack\_notify\_lambda\_slack\_webhook\_url](#input\_slack\_notify\_lambda\_slack\_webhook\_url) | Value of SLACK\_WEB\_HOOK\_URL for the slack notify lambda. | `string` | n/a | yes |
 | <a name="input_slack_web_hook_url"></a> [slack\_web\_hook\_url](#input\_slack\_web\_hook\_url) | Value of SLACK\_WEB\_HOOK\_URL for the backend. | `string` | n/a | yes |
 | <a name="input_tariff_backend_differences_to_emails"></a> [tariff\_backend\_differences\_to\_emails](#input\_tariff\_backend\_differences\_to\_emails) | Differences report TO email addresses. | `string` | n/a | yes |
+| <a name="input_tariff_backend_govuk_notify_api_key"></a> [tariff\_backend\_govuk\_notify\_api\_key](#input\_tariff\_backend\_govuk\_notify\_api\_key) | Value of GOVUK\_NOTIFY\_API\_KEY for the tariff backend. | `string` | n/a | yes |
 | <a name="input_tariff_backend_green_lanes_api_tokens"></a> [tariff\_backend\_green\_lanes\_api\_tokens](#input\_tariff\_backend\_green\_lanes\_api\_tokens) | Value of GREEN\_LANES\_API\_TOKENS for the tariff backend. | `string` | n/a | yes |
 | <a name="input_tariff_backend_oauth_id"></a> [tariff\_backend\_oauth\_id](#input\_tariff\_backend\_oauth\_id) | Value of Tariff Backend OAuth ID. | `string` | n/a | yes |
 | <a name="input_tariff_backend_oauth_secret"></a> [tariff\_backend\_oauth\_secret](#input\_tariff\_backend\_oauth\_secret) | Value of Tariff Backend OAuth secret. | `string` | n/a | yes |

--- a/environments/production/common/secrets.tf
+++ b/environments/production/common/secrets.tf
@@ -192,6 +192,14 @@ module "backend_differences_to_emails" {
   secret_string   = var.tariff_backend_differences_to_emails
 }
 
+module "backend_govuk_notify_api_key" {
+  source          = "../../../modules/secret/"
+  name            = "backend-govuk-notify-api-key"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.tariff_backend_govuk_notify_api_key
+}
+
 module "backend_green_lanes_api_tokens" {
   source          = "../../../modules/secret/"
   name            = "backend-green-lanes-api-tokens"

--- a/environments/production/common/variables.tf
+++ b/environments/production/common/variables.tf
@@ -113,6 +113,13 @@ variable "tariff_backend_differences_to_emails" {
   sensitive   = true
 }
 
+variable "tariff_backend_govuk_notify_api_key" {
+  description = "Value of GOVUK_NOTIFY_API_KEY for the tariff backend."
+  type        = string
+  sensitive   = true
+}
+
+
 variable "tariff_backend_green_lanes_api_tokens" {
   description = "Value of GREEN_LANES_API_TOKENS for the tariff backend."
   type        = string

--- a/environments/staging/common/README.md
+++ b/environments/staging/common/README.md
@@ -36,9 +36,11 @@
 | <a name="module_alb-security-group"></a> [alb-security-group](#module\_alb-security-group) | ../../../modules/security-group/ | n/a |
 | <a name="module_api_cdn"></a> [api\_cdn](#module\_api\_cdn) | ../../../modules/cloudfront | n/a |
 | <a name="module_backend_differences_to_emails"></a> [backend\_differences\_to\_emails](#module\_backend\_differences\_to\_emails) | ../../../modules/secret/ | n/a |
+| <a name="module_backend_govuk_notify_api_key"></a> [backend\_govuk\_notify\_api\_key](#module\_backend\_govuk\_notify\_api\_key) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_green_lanes_api_tokens"></a> [backend\_green\_lanes\_api\_tokens](#module\_backend\_green\_lanes\_api\_tokens) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_oauth_id"></a> [backend\_oauth\_id](#module\_backend\_oauth\_id) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_oauth_secret"></a> [backend\_oauth\_secret](#module\_backend\_oauth\_secret) | ../../../modules/secret/ | n/a |
+| <a name="module_backend_override_notify_email"></a> [backend\_override\_notify\_email](#module\_backend\_override\_notify\_email) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_secret_key_base"></a> [backend\_secret\_key\_base](#module\_backend\_secret\_key\_base) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_sentry_dsn"></a> [backend\_sentry\_dsn](#module\_backend\_sentry\_dsn) | ../../../modules/secret/ | n/a |
 | <a name="module_backend_sync_email"></a> [backend\_sync\_email](#module\_backend\_sync\_email) | ../../../modules/secret/ | n/a |
@@ -259,9 +261,11 @@
 | <a name="input_slack_notify_lambda_slack_webhook_url"></a> [slack\_notify\_lambda\_slack\_webhook\_url](#input\_slack\_notify\_lambda\_slack\_webhook\_url) | Value of SLACK\_WEB\_HOOK\_URL for the slack notify lambda. | `string` | n/a | yes |
 | <a name="input_slack_web_hook_url"></a> [slack\_web\_hook\_url](#input\_slack\_web\_hook\_url) | Value of SLACK\_WEB\_HOOK\_URL for the backend. | `string` | n/a | yes |
 | <a name="input_tariff_backend_differences_to_emails"></a> [tariff\_backend\_differences\_to\_emails](#input\_tariff\_backend\_differences\_to\_emails) | Differences report TO email addresses. | `string` | n/a | yes |
+| <a name="input_tariff_backend_govuk_notify_api_key"></a> [tariff\_backend\_govuk\_notify\_api\_key](#input\_tariff\_backend\_govuk\_notify\_api\_key) | Govuk Notify API key for the tariff backend. | `string` | n/a | yes |
 | <a name="input_tariff_backend_green_lanes_api_tokens"></a> [tariff\_backend\_green\_lanes\_api\_tokens](#input\_tariff\_backend\_green\_lanes\_api\_tokens) | Value of GREEN\_LANES\_API\_TOKENS for the tariff backend. | `string` | n/a | yes |
 | <a name="input_tariff_backend_oauth_id"></a> [tariff\_backend\_oauth\_id](#input\_tariff\_backend\_oauth\_id) | Value of Tariff Backend OAuth ID. | `string` | n/a | yes |
 | <a name="input_tariff_backend_oauth_secret"></a> [tariff\_backend\_oauth\_secret](#input\_tariff\_backend\_oauth\_secret) | Value of Tariff Backend OAuth secret. | `string` | n/a | yes |
+| <a name="input_tariff_backend_override_notify_email"></a> [tariff\_backend\_override\_notify\_email](#input\_tariff\_backend\_override\_notify\_email) | Value of OVERRIDE\_NOTIFY\_EMAIL for the tariff backend. | `string` | n/a | yes |
 | <a name="input_tariff_backend_sentry_dsn"></a> [tariff\_backend\_sentry\_dsn](#input\_tariff\_backend\_sentry\_dsn) | Value of Backend Sentry DSN. | `string` | n/a | yes |
 | <a name="input_tariff_backend_sync_email"></a> [tariff\_backend\_sync\_email](#input\_tariff\_backend\_sync\_email) | Value of Tariff Sync email. | `string` | n/a | yes |
 | <a name="input_tariff_backend_uk_sync_host"></a> [tariff\_backend\_uk\_sync\_host](#input\_tariff\_backend\_uk\_sync\_host) | Value of Tariff Sync host. | `string` | n/a | yes |

--- a/environments/staging/common/secrets.tf
+++ b/environments/staging/common/secrets.tf
@@ -176,12 +176,28 @@ module "backend_differences_to_emails" {
   secret_string   = var.tariff_backend_differences_to_emails
 }
 
+module "backend_govuk_notify_api_key" {
+  source          = "../../../modules/secret/"
+  name            = "backend-govuk-notify-api-key"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.tariff_backend_govuk_notify_api_key
+}
+
 module "backend_green_lanes_api_tokens" {
   source          = "../../../modules/secret/"
   name            = "backend-green-lanes-api-tokens"
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
   recovery_window = 7
   secret_string   = var.tariff_backend_green_lanes_api_tokens
+}
+
+module "backend_override_notify_email" {
+  source          = "../../../modules/secret/"
+  name            = "backend-govuk-notify-api-key"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = var.tariff_backend_override_notify_email
 }
 
 module "backend_sync_email" {

--- a/environments/staging/common/secrets.tf
+++ b/environments/staging/common/secrets.tf
@@ -194,7 +194,7 @@ module "backend_green_lanes_api_tokens" {
 
 module "backend_override_notify_email" {
   source          = "../../../modules/secret/"
-  name            = "backend-govuk-notify-api-key"
+  name            = "backend-override-notify-email"
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
   recovery_window = 7
   secret_string   = var.tariff_backend_override_notify_email

--- a/environments/staging/common/variables.tf
+++ b/environments/staging/common/variables.tf
@@ -113,8 +113,20 @@ variable "tariff_backend_differences_to_emails" {
   sensitive   = true
 }
 
+variable "tariff_backend_govuk_notify_api_key" {
+  description = "Govuk Notify API key for the tariff backend."
+  type        = string
+  sensitive   = true
+}
+
 variable "tariff_backend_green_lanes_api_tokens" {
   description = "Value of GREEN_LANES_API_TOKENS for the tariff backend."
+  type        = string
+  sensitive   = true
+}
+
+variable "tariff_backend_override_notify_email" {
+  description = "Value of OVERRIDE_NOTIFY_EMAIL for the tariff backend."
   type        = string
   sensitive   = true
 }


### PR DESCRIPTION
# Jira link

HMRC-977

## What?

Adds configuration required for GovUK Notify

Related to https://github.com/trade-tariff/trade-tariff-backend/pull/2216