### PR TITLE
HMRC-896: Adjusts permissions of ami builder role

### DIFF
--- a/environments/development/common/iam-policies.tf
+++ b/environments/development/common/iam-policies.tf
@@ -383,44 +383,8 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
 
 data "aws_iam_policy_document" "ci_build_ami_policy" {
   statement {
-    actions = [
-      "ec2:AttachVolume",
-      "ec2:AuthorizeSecurityGroupIngress",
-      "ec2:CopyImage",
-      "ec2:CreateImage",
-      "ec2:CreateKeyPair",
-      "ec2:CreateSecurityGroup",
-      "ec2:CreateSnapshot",
-      "ec2:CreateTags",
-      "ec2:CreateVolume",
-      "ec2:DeleteKeyPair",
-      "ec2:DeleteSecurityGroup",
-      "ec2:DeleteSnapshot",
-      "ec2:DeleteVolume",
-      "ec2:DeregisterImage",
-      "ec2:DescribeImageAttribute",
-      "ec2:DescribeImages",
-      "ec2:DescribeInstances",
-      "ec2:DescribeInstanceStatus",
-      "ec2:DescribeRegions",
-      "ec2:DescribeSecurityGroups",
-      "ec2:DescribeSnapshots",
-      "ec2:DescribeSubnets",
-      "ec2:DescribeTags",
-      "ec2:DescribeVolumes",
-      "ec2:DetachVolume",
-      "ec2:GetPasswordData",
-      "ec2:ModifyImageAttribute",
-      "ec2:ModifyInstanceAttribute",
-      "ec2:ModifySnapshotAttribute",
-      "ec2:RegisterImage",
-      "ec2:RunInstances",
-      "ec2:StopInstances",
-      "ec2:TerminateInstances"
-    ]
-
+    actions   = ["ec2:*"]
     resources = ["*"]
-
     condition {
       test     = "StringEquals"
       variable = "aws:RequestedRegion"

--- a/environments/development/common/iam-policies.tf
+++ b/environments/development/common/iam-policies.tf
@@ -83,6 +83,7 @@ resource "aws_iam_policy" "ci_ecs_deployment_policy" {
           "iam:GetRole",
           "iam:ListAttachedRolePolicies",
           "iam:ListGroups",
+          "iam:ListInstanceProfilesForRole",
           "iam:ListPolicyVersions",
           "iam:ListRolePolicies",
           "iam:ListRoles",

--- a/environments/production/common/iam-policies.tf
+++ b/environments/production/common/iam-policies.tf
@@ -83,6 +83,7 @@ resource "aws_iam_policy" "ci_ecs_deployment_policy" {
           "iam:GetRole",
           "iam:ListAttachedRolePolicies",
           "iam:ListGroups",
+          "iam:ListInstanceProfilesForRole",
           "iam:ListPolicyVersions",
           "iam:ListRolePolicies",
           "iam:ListRoles",

--- a/environments/staging/common/iam-policies.tf
+++ b/environments/staging/common/iam-policies.tf
@@ -83,6 +83,7 @@ resource "aws_iam_policy" "ci_ecs_deployment_policy" {
           "iam:GetRole",
           "iam:ListAttachedRolePolicies",
           "iam:ListGroups",
+          "iam:ListInstanceProfilesForRole",
           "iam:ListPolicyVersions",
           "iam:ListRolePolicies",
           "iam:ListRoles",


### PR DESCRIPTION
# Jira link

[HMRC-896](https://transformuk.atlassian.net/browse/HMRC-896)

## What?

I have:

- Added more permissive EC2 permissions

## Why?

I am doing this because:

- This is not quite right and given we're restricting it to EC2 in an generally unused region this should be fine
