### PR TITLE
HMRC-896: Permissions adjustments for FPO search

### DIFF
--- a/environments/development/common/iam-policies.tf
+++ b/environments/development/common/iam-policies.tf
@@ -212,6 +212,29 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
         ]
       },
       {
+        Effect = "Allow",
+        Action = [
+          "s3:GetBucketLocation",
+          "s3:GetObject",
+          "s3:ListBucket",
+        ],
+        Resource = [
+          "arn:aws:s3:::trade-tariff-models-382373577178",
+          "arn:aws:s3:::trade-tariff-models-382373577178/*"
+        ]
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "kms:GenerateDataKey",
+          "kms:Decrypt"
+        ],
+        Resource = [
+          # Production S3 KMS key
+          "arn:aws:kms:eu-west-2:382373577178:key/7fc9fd19-e970-4877-9b56-3869a02c7b85"
+        ]
+      },
+      {
         Effect   = "Allow",
         Action   = ["cloudformation:*"],
         Resource = "*"

--- a/environments/development/common/iam-policies.tf
+++ b/environments/development/common/iam-policies.tf
@@ -209,18 +209,7 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
         Resource = [
           "arn:aws:s3:::${aws_s3_bucket.this["lambda-deployment"].id}",
           "arn:aws:s3:::${aws_s3_bucket.this["lambda-deployment"].id}/*",
-          "arn:aws:s3:::${aws_s3_bucket.this["database-backups"].id}"
-        ]
-      },
-      {
-        Effect = "Allow",
-        Action = [
-          "s3:GetBucketLocation",
-          "s3:GetObject",
-          "s3:ListBucket",
-          "s3:ListObjectsV2",
-        ],
-        Resource = [
+          "arn:aws:s3:::${aws_s3_bucket.this["database-backups"].id}",
           "arn:aws:s3:::trade-tariff-models-382373577178",
           "arn:aws:s3:::trade-tariff-models-382373577178/*"
         ]

--- a/environments/development/common/iam-policies.tf
+++ b/environments/development/common/iam-policies.tf
@@ -218,6 +218,7 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
           "s3:GetBucketLocation",
           "s3:GetObject",
           "s3:ListBucket",
+          "s3:ListObjectsV2",
         ],
         Resource = [
           "arn:aws:s3:::trade-tariff-models-382373577178",

--- a/environments/development/common/iam-policies.tf
+++ b/environments/development/common/iam-policies.tf
@@ -384,8 +384,44 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
 
 data "aws_iam_policy_document" "ci_build_ami_policy" {
   statement {
-    actions   = ["ec2:*"]
+    actions = [
+      "ec2:AttachVolume",
+      "ec2:AuthorizeSecurityGroupIngress",
+      "ec2:CopyImage",
+      "ec2:CreateImage",
+      "ec2:CreateKeyPair",
+      "ec2:CreateSecurityGroup",
+      "ec2:CreateSnapshot",
+      "ec2:CreateTags",
+      "ec2:CreateVolume",
+      "ec2:DeleteKeyPair",
+      "ec2:DeleteSecurityGroup",
+      "ec2:DeleteSnapshot",
+      "ec2:DeleteVolume",
+      "ec2:DeregisterImage",
+      "ec2:DescribeImageAttribute",
+      "ec2:DescribeImages",
+      "ec2:DescribeInstances",
+      "ec2:DescribeInstanceStatus",
+      "ec2:DescribeRegions",
+      "ec2:DescribeSecurityGroups",
+      "ec2:DescribeSnapshots",
+      "ec2:DescribeSubnets",
+      "ec2:DescribeTags",
+      "ec2:DescribeVolumes",
+      "ec2:DetachVolume",
+      "ec2:GetPasswordData",
+      "ec2:ModifyImageAttribute",
+      "ec2:ModifyInstanceAttribute",
+      "ec2:ModifySnapshotAttribute",
+      "ec2:RegisterImage",
+      "ec2:RunInstances",
+      "ec2:StopInstances",
+      "ec2:TerminateInstances"
+    ]
+
     resources = ["*"]
+
     condition {
       test     = "StringEquals"
       variable = "aws:RequestedRegion"

--- a/environments/development/common/iam-policies.tf
+++ b/environments/development/common/iam-policies.tf
@@ -77,6 +77,7 @@ resource "aws_iam_policy" "ci_ecs_deployment_policy" {
           "iam:CreateRole",
           "iam:DeletePolicy",
           "iam:DeletePolicyVersion",
+          "iam:DeleteRole",
           "iam:DetachRolePolicy",
           "iam:GetPolicy",
           "iam:GetPolicyVersion",

--- a/environments/development/common/iam-roles.tf
+++ b/environments/development/common/iam-roles.tf
@@ -214,6 +214,9 @@ resource "aws_iam_role_policy_attachment" "status_checks_ci_policy_attachment" {
 resource "aws_iam_role" "fpo_models_ci_role" {
   name = "GithubActions-FPO-Models-Role"
 
+  # NOTE: Models take a while to train so require a longer session duration
+  max_session_duration = 10800 # 3 hours
+
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [

--- a/environments/development/common/iam.tf
+++ b/environments/development/common/iam.tf
@@ -260,6 +260,7 @@ resource "aws_iam_policy" "ci_fpo_models_secrets_policy" {
           "s3:GetBucketLocation",
           "s3:GetObject",
           "s3:ListBucket",
+          "s3:ListObjectsV2",
           "s3:PutObject",
         ],
         Resource = [

--- a/environments/production/common/iam-policies.tf
+++ b/environments/production/common/iam-policies.tf
@@ -248,6 +248,23 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
         ]
       },
       {
+        Effect = "Allow",
+        Action = [
+          "s3:GetBucketLocation",
+          "s3:GetObject",
+          "s3:ListBucket",
+        ],
+        Resource = [
+          "arn:aws:s3:::${aws_s3_bucket.this["models"].id}",
+          "arn:aws:s3:::${aws_s3_bucket.this["models"].id}/*"
+        ]
+      },
+      {
+        Effect   = "Allow",
+        Action   = ["kms:GenerateDataKey", "kms:Decrypt"],
+        Resource = [aws_kms_key.s3.arn]
+      },
+      {
         Effect   = "Allow",
         Action   = ["cloudformation:*"],
         Resource = "*"
@@ -413,11 +430,6 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
           "ecr:*",
         ],
         Resource = ["*"]
-        Condition = {
-          "StringEquals" : {
-            "aws:RequestedRegion" : ["eu-west-2", "us-east-1"]
-          }
-        }
       },
     ]
   })

--- a/environments/production/common/iam-policies.tf
+++ b/environments/production/common/iam-policies.tf
@@ -244,25 +244,21 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
         Resource = [
           "arn:aws:s3:::${aws_s3_bucket.this["lambda-deployment"].id}",
           "arn:aws:s3:::${aws_s3_bucket.this["lambda-deployment"].id}/*",
-          "arn:aws:s3:::${aws_s3_bucket.this["database-backups"].id}"
+          "arn:aws:s3:::${aws_s3_bucket.this["database-backups"].id}",
+          "arn:aws:s3:::trade-tariff-models-382373577178",
+          "arn:aws:s3:::trade-tariff-models-382373577178/*"
         ]
       },
       {
         Effect = "Allow",
         Action = [
-          "s3:GetBucketLocation",
-          "s3:GetObject",
-          "s3:ListBucket",
+          "kms:GenerateDataKey",
+          "kms:Decrypt"
         ],
         Resource = [
-          "arn:aws:s3:::${aws_s3_bucket.this["models"].id}",
-          "arn:aws:s3:::${aws_s3_bucket.this["models"].id}/*"
+          # Production S3 KMS key
+          "arn:aws:kms:eu-west-2:382373577178:key/7fc9fd19-e970-4877-9b56-3869a02c7b85"
         ]
-      },
-      {
-        Effect   = "Allow",
-        Action   = ["kms:GenerateDataKey", "kms:Decrypt"],
-        Resource = [aws_kms_key.s3.arn]
       },
       {
         Effect   = "Allow",

--- a/environments/production/common/iam.tf
+++ b/environments/production/common/iam.tf
@@ -461,7 +461,11 @@ data "aws_iam_policy_document" "fpo_model_access" {
         "arn:aws:iam::382373577178:user/fpo-models-ci",
         "arn:aws:iam::844815912454:role/GithubActions-FPO-Models-Role",
         "arn:aws:iam::451934005581:role/GithubActions-FPO-Models-Role",
-        "arn:aws:iam::382373577178:role/GithubActions-FPO-Models-Role"
+        "arn:aws:iam::382373577178:role/GithubActions-FPO-Models-Role",
+        "arn:aws:iam::844815912454:role/GithubActions-Serverless-Lambda-Role",
+        "arn:aws:iam::451934005581:role/GithubActions-Serverless-Lambda-Role",
+        "arn:aws:iam::382373577178:role/GithubActions-Serverless-Lambda-Role"
+
       ]
     }
   }

--- a/environments/production/common/s3.tf
+++ b/environments/production/common/s3.tf
@@ -48,6 +48,9 @@ data "aws_iam_policy_document" "s3_kms_key_policy" {
         ],
         [
           for account_id in values(var.account_ids) : "arn:aws:iam::${account_id}:role/GithubActions-FPO-Models-Role"
+        ],
+        [
+          for account_id in values(var.account_ids) : "arn:aws:iam::${account_id}:role/GithubActions-Serverless-Lambda-Role"
         ]
       )
     }

--- a/environments/staging/common/iam-policies.tf
+++ b/environments/staging/common/iam-policies.tf
@@ -212,6 +212,26 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
         ]
       },
       {
+        Effect = "Allow",
+        Action = [
+          "s3:GetBucketLocation",
+          "s3:GetObject",
+          "s3:ListBucket",
+        ],
+        Resource = [
+          "arn:aws:s3:::trade-tariff-models-382373577178",
+          "arn:aws:s3:::trade-tariff-models-382373577178/*"
+        ]
+      },
+      {
+        Effect = "Allow",
+        Action = ["kms:GenerateDataKey", "kms:Decrypt"],
+        Resource = [
+          # Production S3 KMS key
+          "arn:aws:kms:eu-west-2:382373577178:key/7fc9fd19-e970-4877-9b56-3869a02c7b85"
+        ]
+      },
+      {
         Effect   = "Allow",
         Action   = ["cloudformation:*"],
         Resource = "*"
@@ -377,11 +397,6 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
           "ecr:*",
         ],
         Resource = ["*"]
-        Condition = {
-          "StringEquals" : {
-            "aws:RequestedRegion" : ["eu-west-2", "us-east-1"]
-          }
-        }
       },
     ]
   })

--- a/environments/staging/common/iam-policies.tf
+++ b/environments/staging/common/iam-policies.tf
@@ -209,23 +209,16 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
           "arn:aws:s3:::${aws_s3_bucket.this["lambda-deployment"].id}",
           "arn:aws:s3:::${aws_s3_bucket.this["lambda-deployment"].id}/*",
           "arn:aws:s3:::${aws_s3_bucket.this["database-backups"].id}",
-        ]
-      },
-      {
-        Effect = "Allow",
-        Action = [
-          "s3:GetBucketLocation",
-          "s3:GetObject",
-          "s3:ListBucket",
-        ],
-        Resource = [
           "arn:aws:s3:::trade-tariff-models-382373577178",
           "arn:aws:s3:::trade-tariff-models-382373577178/*"
         ]
       },
       {
         Effect = "Allow",
-        Action = ["kms:GenerateDataKey", "kms:Decrypt"],
+        Action = [
+          "kms:GenerateDataKey",
+          "kms:Decrypt"
+        ],
         Resource = [
           # Production S3 KMS key
           "arn:aws:kms:eu-west-2:382373577178:key/7fc9fd19-e970-4877-9b56-3869a02c7b85"


### PR DESCRIPTION
# Jira link

[HMRC-896](https://transformuk.atlassian.net/browse/HMRC-896)

## What?

I have:

- Reinstated ami perms
- Added cross account read-only access to the models bucket to the serverless role
- Added an extended session duration for the FPO models role
- Removed some extra restrictive conditions

## Why?

I am doing this because:

- I've reinstated the ami role permissions as this was adjusted to debug permissions by being permissive and not a long term solution

