### PR TITLE
HMRC-829: Switches dev hub on in development

### DIFF
--- a/environments/development/common/alb.tf
+++ b/environments/development/common/alb.tf
@@ -18,19 +18,19 @@ module "alb" {
       priority         = 1
     }
 
-    hub_backend = {
-      hosts            = ["hub.*"]
-      paths            = ["/api/healthcheck"]
-      healthcheck_path = "/api/healthcheckz"
-      priority         = 3
-    }
-
-    hub_frontend = {
-      hosts            = ["hub.*"]
-      paths            = ["/*"]
-      healthcheck_path = "/healthcheckz"
-      priority         = 4
-    }
+    # hub_backend = {
+    #   hosts            = ["hub.*"]
+    #   paths            = ["/api/healthcheck"]
+    #   healthcheck_path = "/api/healthcheckz"
+    #   priority         = 3
+    # }
+    #
+    # hub_frontend = {
+    #   hosts            = ["hub.*"]
+    #   paths            = ["/*"]
+    #   healthcheck_path = "/healthcheckz"
+    #   priority         = 4
+    # }
 
     tea = {
       hosts            = ["tea.*"]
@@ -57,7 +57,7 @@ module "alb" {
     }
 
     hub = {
-      hosts            = ["new-hub.*"]
+      hosts            = ["hub.*"]
       healthcheck_path = "/healthcheckz"
       priority         = 22
     }


### PR DESCRIPTION
# Jira link

[HMRC-829](https://transformuk.atlassian.net/browse/HMRC-829)

## What?

I have:

- Altered merged hub to respond to hub.\<base_domain\> in development

## Why?

I am doing this because:

- This is required as part of integrating with Government Gateway (SCP)
