### PR TITLE
HMRC-1039: Migrate production dev hub to merged dev-hub

### DIFF
--- a/environments/production/common/alb.tf
+++ b/environments/production/common/alb.tf
@@ -18,20 +18,6 @@ module "alb" {
       priority         = 1
     }
 
-    hub_backend = {
-      hosts            = ["hub.*"]
-      paths            = ["/api/healthcheck"]
-      healthcheck_path = "/api/healthcheckz"
-      priority         = 3
-    }
-
-    hub_frontend = {
-      hosts            = ["hub.*"]
-      paths            = ["/*"]
-      healthcheck_path = "/healthcheckz"
-      priority         = 4
-    }
-
     tea = {
       hosts            = ["tea.*"]
       healthcheck_path = "/healthcheckz"
@@ -57,7 +43,7 @@ module "alb" {
     }
 
     hub = {
-      hosts            = ["new-hub.*"]
+      hosts            = ["hub.*"]
       healthcheck_path = "/healthcheckz"
       priority         = 22
     }


### PR DESCRIPTION
# Jira link

[HMRC-1039](https://transformuk.atlassian.net/browse/HMRC-1039)

## What?

I have:

- Altered the merged dev hub target group to listen on the hub.* domain
- Removed old dev hub target groups/listener rules

## Why?

I am doing this because:

- This is needed for users to get migrated to the new dev hub
