### PR TITLE
BAU_: Create place holder for db-replicate-configuration to fix deployment

### DIFF
--- a/environments/production/common/secrets.tf
+++ b/environments/production/common/secrets.tf
@@ -86,6 +86,14 @@ module "etf_configuration" {
   create_secret_version = false
 }
 
+module "db_replicate_configuration" {
+  source                = "../../../modules/secret/"
+  name                  = "db-replicate-configuration"
+  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window       = 7
+  create_secret_version = false
+}
+
 ######### OLD WORLD SECRETS START HERE ##########
 
 module "fpo_search_sentry_dsn" {


### PR DESCRIPTION
# Jira link 
BAU_

## What?

I have:

- Added secret to prod env

## Why?

I am doing this because:

- db-replicate-configuration secret is only needed in dev and staging. But without this in prod env, deployment failed as terrafomr looking for the resource.
-
-
