### PR TITLE
HMRC-938: Create a receiving email address that dumps to S3

### DIFF
--- a/environments/development/common/ses.tf
+++ b/environments/development/common/ses.tf
@@ -1,5 +1,11 @@
 module "ses" {
-  source          = "../../../modules/ses"
-  domain_name     = var.domain_name
-  route53_zone_id = data.aws_route53_zone.this.zone_id
+  source             = "../../../modules/ses"
+  domain_name        = var.domain_name
+  route53_zone_id    = data.aws_route53_zone.this.zone_id
+
+  email_receiver        = true
+  receiving_endpoint    = "inbound-smtp.${var.region}.amazonaws.com"
+  ses_inbound_bucket    = aws_s3_bucket.this["ses-inbound"].bucket
+  s3_kms_key            = aws_kms_key.s3.arn
+  ses_iam_role          = aws_iam_role.ses_s3.arn
 }

--- a/environments/production/common/ses.tf
+++ b/environments/production/common/ses.tf
@@ -2,4 +2,5 @@ module "ses" {
   source          = "../../../modules/ses"
   domain_name     = var.domain_name
   route53_zone_id = data.aws_route53_zone.this.zone_id
+  email_receiver  = false
 }

--- a/environments/staging/common/ses.tf
+++ b/environments/staging/common/ses.tf
@@ -2,4 +2,5 @@ module "ses" {
   source          = "../../../modules/ses"
   domain_name     = var.domain_name
   route53_zone_id = data.aws_route53_zone.this.zone_id
+  email_receiver  = false
 }

--- a/environments/staging/common/ses.tf
+++ b/environments/staging/common/ses.tf
@@ -2,5 +2,10 @@ module "ses" {
   source          = "../../../modules/ses"
   domain_name     = var.domain_name
   route53_zone_id = data.aws_route53_zone.this.zone_id
-  email_receiver  = false
+
+  email_receiver        = true
+  receiving_endpoint    = "inbound-smtp.${var.region}.amazonaws.com"
+  ses_inbound_bucket    = aws_s3_bucket.this["ses-inbound"].bucket
+  s3_kms_key            = aws_kms_key.s3.arn
+  ses_iam_role          = aws_iam_role.ses_s3.arn
 }

--- a/modules/ses/main.tf
+++ b/modules/ses/main.tf
@@ -60,7 +60,6 @@ resource "aws_ses_receipt_rule" "receive_all" {
     position          = 1
     bucket_name       = var.ses_inbound_bucket
     object_key_prefix = "inbound/"
-    kms_key_arn       = var.s3_kms_key
     iam_role_arn      = var.ses_iam_role
   }
 }

--- a/modules/ses/variables.tf
+++ b/modules/ses/variables.tf
@@ -7,3 +7,32 @@ variable "route53_zone_id" {
   description = "Route 53 hosted zone ID."
   type        = string
 }
+
+variable "email_receiver" {
+  description = "Activate email receiver"
+  type        = bool
+}
+
+variable "receiving_endpoint" {
+  description = "Email Receiving endpoints"
+  type        = string
+  default     = "placeholder"
+}
+
+variable "ses_inbound_bucket" {
+  description = "S3 bucket for email inbox"
+  type        = string
+  default     = "placeholder"
+}
+
+variable "s3_kms_key" {
+  description = "S3 kms key for SES inbox"
+  type        = string
+  default     = "placeholder"
+}
+
+variable "ses_iam_role" {
+  description = "SES iam role to access s3"
+  type        = string
+  default     = "placeholder"
+}


### PR DESCRIPTION
# Jira link
https://transformuk.atlassian.net/browse/HMRC-938

## What?

I have:

- Added inbound emain configuration for ses service


## Why?

I am doing this because:

- We have a need for an email address which we can send to for testing purposes. SES has an email receiving feature which can dump the email to an S3 bucket.
-
-
