### PR TITLE
HMRC-1099: Adds missing iam-role-attachment for tech docs in development

### DIFF
--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -149,6 +149,7 @@ No outputs.
 | [aws_iam_role_policy_attachment.github_terraform_ci_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.reporting_ci_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.serverless_lambda_ci_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.tech_docs_ci_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_kms_alias.logs_bucket_kms_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_alias.opensearch_kms_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_alias.s3_kms_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |

--- a/environments/development/common/iam-roles.tf
+++ b/environments/development/common/iam-roles.tf
@@ -125,6 +125,11 @@ resource "aws_iam_role" "tech_docs_ci_role" {
   })
 }
 
+resource "aws_iam_role_policy_attachment" "tech_docs_ci_policy_attachment" {
+  role       = aws_iam_role.tech_docs_ci_role.name
+  policy_arn = aws_iam_policy.ci_tech_docs_persistence_readwrite_policy.arn
+}
+
 resource "aws_iam_role" "fpo_models_ci_role" {
   name = "GithubActions-FPO-Models-Role"
 


### PR DESCRIPTION
# Jira link

[HMRC-1099](https://transformuk.atlassian.net/browse/HMRC-1099)

## What?

I have:

- Added missing attachment for tech-docs role in development

## Why?

I am doing this because:

- This is required to unblock tech-docs deployments
