### PR TITLE
HMRC-1135: Adds a scope down which excludes assets

### DIFF
--- a/modules/waf/README.md
+++ b/modules/waf/README.md
@@ -22,6 +22,7 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_wafv2_regex_pattern_set.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_regex_pattern_set) | resource |
 | [aws_wafv2_web_acl.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl) | resource |
 | [aws_wafv2_web_acl_association.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_association) | resource |
 


### PR DESCRIPTION
# Jira link

[HMRC-1135](https://transformuk.atlassian.net/browse/HMRC-1135)

## What?

I have:

- Added a scope down statement when ip based rate limiting is in place which excludes assets from adding to the rate limit

## Why?

I am doing this because:

- This is required since importmaps triggers many more assets to be fetched compared to one big uglified js/css file
