### PR TITLE
HMRC-1139: Scale down development opensearch cluster

### DIFF
--- a/environments/development/common/opensearch.tf
+++ b/environments/development/common/opensearch.tf
@@ -67,9 +67,10 @@ module "opensearch" {
 
   master_instance_enabled = false
   warm_instance_enabled   = false
-  instance_count          = 3
-  instance_type           = "m5.xlarge.search"
+  instance_count          = 1
+  instance_type           = "t3.small.search"
   ebs_volume_size         = 80
+  availability_zones      = 1
 
   create_master_user = true
   encrypt_kms_key_id = aws_kms_key.opensearch_kms_key.key_id


### PR DESCRIPTION
# Jira link

[HMRC-1139](https://transformuk.atlassian.net/browse/HMRC-1139)

## What?

I have:

- Scaled down the opensearch cluster in development

## Why?

I am doing this because:

- In development this brings our costs from $0.327 x 3 ($23 dollars a day) to $0.038 x 1 per hour ($0.9 a day)
