### PR TITLE
HMRC-1153: Removes unused secrets

### DIFF
--- a/.github/workflows/deploy-to-development.yml
+++ b/.github/workflows/deploy-to-development.yml
@@ -61,8 +61,6 @@ jobs:
     environment: development
     env:
       TF_VAR_backups_basic_auth: ${{ secrets.BACKUPS_BASIC_AUTH }}
-      TF_VAR_fpo_search_sentry_dsn: ${{ secrets.FPO_SEARCH_SENTRY_DSN }}
-      TF_VAR_fpo_search_training_pem: ${{ secrets.FPO_SEARCH_TRAINING_PEM }}
       TF_VAR_slack_notify_lambda_slack_webhook_url: ${{ secrets.SLACK_NOTIFY_LAMBDA_SLACK_WEBHOOK_URL }}
 
     runs-on: ubuntu-latest
@@ -97,8 +95,6 @@ jobs:
     environment: development
     env:
       TF_VAR_backups_basic_auth: ${{ secrets.BACKUPS_BASIC_AUTH }}
-      TF_VAR_fpo_search_sentry_dsn: ${{ secrets.FPO_SEARCH_SENTRY_DSN }}
-      TF_VAR_fpo_search_training_pem: ${{ secrets.FPO_SEARCH_TRAINING_PEM }}
       TF_VAR_slack_notify_lambda_slack_webhook_url: ${{ secrets.SLACK_NOTIFY_LAMBDA_SLACK_WEBHOOK_URL }}
       TERRAGRUNT_NON_INTERACTIVE: true
       TF_INPUT: false
@@ -165,9 +161,6 @@ jobs:
     environment: staging
     env:
       TF_VAR_backups_basic_auth: ${{ secrets.BACKUPS_BASIC_AUTH }}
-      TF_VAR_commodi_tea_cookie_signing_secret: ${{ secrets.COMMODI_TEA_COOKIE_SIGNING_SECRET }}
-      TF_VAR_commodi_tea_fpo_search_api_key: ${{ secrets.COMMODI_TEA_FPO_SEARCH_API_KEY }}
-      TF_VAR_fpo_search_sentry_dsn: ${{ secrets.FPO_SEARCH_SENTRY_DSN }}
       TF_VAR_slack_notify_lambda_slack_webhook_url: ${{ secrets.SLACK_NOTIFY_LAMBDA_SLACK_WEBHOOK_URL }}
     runs-on: ubuntu-latest
     steps:
@@ -200,9 +193,6 @@ jobs:
     environment: production
     env:
       TF_VAR_backups_basic_auth: ${{ secrets.BACKUPS_BASIC_AUTH }}
-      TF_VAR_commodi_tea_cookie_signing_secret: ${{ secrets.COMMODI_TEA_COOKIE_SIGNING_SECRET }}
-      TF_VAR_commodi_tea_fpo_search_api_key: ${{ secrets.COMMODI_TEA_FPO_SEARCH_API_KEY }}
-      TF_VAR_fpo_search_sentry_dsn: ${{ secrets.FPO_SEARCH_SENTRY_DSN }}
       TF_VAR_slack_notify_lambda_slack_webhook_url: ${{ secrets.SLACK_NOTIFY_LAMBDA_SLACK_WEBHOOK_URL }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -24,7 +24,6 @@ jobs:
     environment: production
     env:
       TF_VAR_backups_basic_auth: ${{ secrets.BACKUPS_BASIC_AUTH }}
-      TF_VAR_fpo_search_sentry_dsn: ${{ secrets.FPO_SEARCH_SENTRY_DSN }}
       TF_VAR_slack_notify_lambda_slack_webhook_url: ${{ secrets.SLACK_NOTIFY_LAMBDA_SLACK_WEBHOOK_URL }}
       TERRAGRUNT_NON_INTERACTIVE: true
       TF_INPUT: false

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -21,7 +21,6 @@ jobs:
     environment: staging
     env:
       TF_VAR_backups_basic_auth: ${{ secrets.BACKUPS_BASIC_AUTH }}
-      TF_VAR_fpo_search_sentry_dsn: ${{ secrets.FPO_SEARCH_SENTRY_DSN }}
       TF_VAR_slack_notify_lambda_slack_webhook_url: ${{ secrets.SLACK_NOTIFY_LAMBDA_SLACK_WEBHOOK_URL }}
       TERRAGRUNT_NON_INTERACTIVE: true
       TF_INPUT: false

--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -71,7 +71,7 @@ No outputs.
 | <a name="module_dev_hub_cognito"></a> [dev\_hub\_cognito](#module\_dev\_hub\_cognito) | ../../../modules/cognito | n/a |
 | <a name="module_dev_hub_configuration"></a> [dev\_hub\_configuration](#module\_dev\_hub\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_duty_calculator_configuration"></a> [duty\_calculator\_configuration](#module\_duty\_calculator\_configuration) | ../../../modules/secret/ | n/a |
-| <a name="module_fpo_search_sentry_dsn"></a> [fpo\_search\_sentry\_dsn](#module\_fpo\_search\_sentry\_dsn) | ../../../modules/secret/ | n/a |
+| <a name="module_fpo_search_configuration"></a> [fpo\_search\_configuration](#module\_fpo\_search\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_fpo_search_training_pem"></a> [fpo\_search\_training\_pem](#module\_fpo\_search\_training\_pem) | ../../../modules/secret/ | n/a |
 | <a name="module_frontend_configuration"></a> [frontend\_configuration](#module\_frontend\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_identity_configuration"></a> [identity\_configuration](#module\_identity\_configuration) | ../../../modules/secret/ | n/a |
@@ -206,8 +206,6 @@ No outputs.
 | <a name="input_backups_basic_auth"></a> [backups\_basic\_auth](#input\_backups\_basic\_auth) | base64 encoded credentials for backups basic auth. | `string` | n/a | yes |
 | <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | Domain name of the service. | `string` | `"dev.trade-tariff.service.gov.uk"` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Build environment | `string` | `"development"` | no |
-| <a name="input_fpo_search_sentry_dsn"></a> [fpo\_search\_sentry\_dsn](#input\_fpo\_search\_sentry\_dsn) | Value of SENTRY\_DSN for the FPO search lambda. | `string` | n/a | yes |
-| <a name="input_fpo_search_training_pem"></a> [fpo\_search\_training\_pem](#input\_fpo\_search\_training\_pem) | Private ed25519 ssh pem used to generate training model artifacts in EC2. This is development, only. | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region to use. Defaults to `eu-west-2`. | `string` | `"eu-west-2"` | no |
 | <a name="input_slack_notify_lambda_slack_webhook_url"></a> [slack\_notify\_lambda\_slack\_webhook\_url](#input\_slack\_notify\_lambda\_slack\_webhook\_url) | Value of SLACK\_WEB\_HOOK\_URL for the slack notify lambda. | `string` | n/a | yes |
 | <a name="input_waf_rpm_limit"></a> [waf\_rpm\_limit](#input\_waf\_rpm\_limit) | Request per minute limit for the WAF. This limit applies to our main CDN distribution and applies to all aliases on that CDN. | `number` | `2000` | no |

--- a/environments/development/common/iam-policies.tf
+++ b/environments/development/common/iam-policies.tf
@@ -305,7 +305,7 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
           "secretsmanager:GetSecretValue",
         ],
         Resource = [
-          module.fpo_search_sentry_dsn.secret_arn,
+          module.fpo_search_configuration.secret_arn,
         ]
       },
       {

--- a/environments/development/common/secrets.tf
+++ b/environments/development/common/secrets.tf
@@ -86,23 +86,23 @@ module "identity_configuration" {
   create_secret_version = false
 }
 
-######### OLD WORLD SECRETS START HERE ##########
-
-module "fpo_search_sentry_dsn" {
-  source          = "../../../modules/secret/"
-  name            = "fpo-search-sentry-dsn"
-  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window = 7
-  secret_string   = var.fpo_search_sentry_dsn
-}
-
 module "fpo_search_training_pem" {
-  source          = "../../../modules/secret/"
-  name            = "fpo-search-training-pem"
-  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window = 7
-  secret_string   = var.fpo_search_training_pem
+  source                = "../../../modules/secret/"
+  name                  = "fpo-search-training-pem"
+  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window       = 7
+  create_secret_version = false
 }
+
+module "fpo_search_configuration" {
+  source                = "../../../modules/secret/"
+  name                  = "fpo-search-configuration"
+  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window       = 7
+  create_secret_version = false
+}
+
+######### OLD WORLD SECRETS START HERE ##########
 
 module "slack_notify_lambda_slack_webhook_url" {
   source          = "../../../modules/secret/"

--- a/environments/development/common/variables.tf
+++ b/environments/development/common/variables.tf
@@ -35,18 +35,6 @@ variable "waf_rpm_limit" {
 # super secret stuff
 #
 
-variable "fpo_search_sentry_dsn" {
-  description = "Value of SENTRY_DSN for the FPO search lambda."
-  type        = string
-  sensitive   = true
-}
-
-variable "fpo_search_training_pem" {
-  description = "Private ed25519 ssh pem used to generate training model artifacts in EC2. This is development, only."
-  type        = string
-  sensitive   = true
-}
-
 variable "backups_basic_auth" {
   description = "base64 encoded credentials for backups basic auth."
   type        = string

--- a/environments/production/common/README.md
+++ b/environments/production/common/README.md
@@ -49,7 +49,7 @@
 | <a name="module_duty_calculator_configuration"></a> [duty\_calculator\_configuration](#module\_duty\_calculator\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_ecr"></a> [ecr](#module\_ecr) | ../../../modules/ecr/ | n/a |
 | <a name="module_etf_configuration"></a> [etf\_configuration](#module\_etf\_configuration) | ../../../modules/secret/ | n/a |
-| <a name="module_fpo_search_sentry_dsn"></a> [fpo\_search\_sentry\_dsn](#module\_fpo\_search\_sentry\_dsn) | ../../../modules/secret/ | n/a |
+| <a name="module_fpo_search_configuration"></a> [fpo\_search\_configuration](#module\_fpo\_search\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_frontend_configuration"></a> [frontend\_configuration](#module\_frontend\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_logs"></a> [logs](#module\_logs) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v4.6.0 |
 | <a name="module_notify_slack"></a> [notify\_slack](#module\_notify\_slack) | ../../../modules/aws-notify-slack | n/a |
@@ -193,7 +193,6 @@
 | <a name="input_backups_basic_auth"></a> [backups\_basic\_auth](#input\_backups\_basic\_auth) | base64 encoded credentials for backups basic auth. | `string` | n/a | yes |
 | <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | Domain name of the service. | `string` | `"trade-tariff.service.gov.uk"` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Build environment | `string` | `"production"` | no |
-| <a name="input_fpo_search_sentry_dsn"></a> [fpo\_search\_sentry\_dsn](#input\_fpo\_search\_sentry\_dsn) | Value of SENTRY\_DSN for the FPO search lambda. | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region to use. Defaults to `eu-west-2`. | `string` | `"eu-west-2"` | no |
 | <a name="input_slack_notify_lambda_slack_webhook_url"></a> [slack\_notify\_lambda\_slack\_webhook\_url](#input\_slack\_notify\_lambda\_slack\_webhook\_url) | Value of SLACK\_WEB\_HOOK\_URL for the slack notify lambda. | `string` | n/a | yes |
 | <a name="input_waf_rpm_limit"></a> [waf\_rpm\_limit](#input\_waf\_rpm\_limit) | Request per minute limit for the WAF. This limit applies to our main CDN distribution and applies to all aliases on that CDN. | `number` | `500` | no |

--- a/environments/production/common/iam-policies.tf
+++ b/environments/production/common/iam-policies.tf
@@ -340,7 +340,7 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
           "secretsmanager:GetSecretValue",
         ],
         Resource = [
-          module.fpo_search_sentry_dsn.secret_arn,
+          module.fpo_search_configuration.secret_arn,
         ]
       },
       {

--- a/environments/production/common/secrets.tf
+++ b/environments/production/common/secrets.tf
@@ -94,15 +94,15 @@ module "db_replicate_configuration" {
   create_secret_version = false
 }
 
-######### OLD WORLD SECRETS START HERE ##########
-
-module "fpo_search_sentry_dsn" {
-  source          = "../../../modules/secret/"
-  name            = "fpo-search-sentry-dsn"
-  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window = 7
-  secret_string   = var.fpo_search_sentry_dsn
+module "fpo_search_configuration" {
+  source                = "../../../modules/secret/"
+  name                  = "fpo-search-configuration"
+  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window       = 7
+  create_secret_version = false
 }
+
+######### OLD WORLD SECRETS START HERE ##########
 
 module "slack_notify_lambda_slack_webhook_url" {
   source          = "../../../modules/secret/"

--- a/environments/production/common/variables.tf
+++ b/environments/production/common/variables.tf
@@ -35,12 +35,6 @@ variable "waf_rpm_limit" {
 # super secret stuff
 #
 
-variable "fpo_search_sentry_dsn" {
-  description = "Value of SENTRY_DSN for the FPO search lambda."
-  type        = string
-  sensitive   = true
-}
-
 variable "backups_basic_auth" {
   description = "base64 encoded credentials for backups basic auth."
   type        = string

--- a/environments/staging/common/README.md
+++ b/environments/staging/common/README.md
@@ -46,7 +46,7 @@
 | <a name="module_dev"></a> [dev](#module\_dev) | ../../../modules/secret/ | n/a |
 | <a name="module_dev_hub_cognito"></a> [dev\_hub\_cognito](#module\_dev\_hub\_cognito) | ../../../modules/cognito | n/a |
 | <a name="module_duty_calculator_configuration"></a> [duty\_calculator\_configuration](#module\_duty\_calculator\_configuration) | ../../../modules/secret/ | n/a |
-| <a name="module_fpo_search_sentry_dsn"></a> [fpo\_search\_sentry\_dsn](#module\_fpo\_search\_sentry\_dsn) | ../../../modules/secret/ | n/a |
+| <a name="module_fpo_search_configuration"></a> [fpo\_search\_configuration](#module\_fpo\_search\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_frontend_configuration"></a> [frontend\_configuration](#module\_frontend\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_logs"></a> [logs](#module\_logs) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v4.6.0 |
 | <a name="module_notify_slack"></a> [notify\_slack](#module\_notify\_slack) | ../../../modules/aws-notify-slack | n/a |
@@ -175,7 +175,6 @@
 | <a name="input_backups_basic_auth"></a> [backups\_basic\_auth](#input\_backups\_basic\_auth) | base64 encoded credentials for backups basic auth. | `string` | n/a | yes |
 | <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | Domain name of the service. | `string` | `"staging.trade-tariff.service.gov.uk"` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Build environment | `string` | `"staging"` | no |
-| <a name="input_fpo_search_sentry_dsn"></a> [fpo\_search\_sentry\_dsn](#input\_fpo\_search\_sentry\_dsn) | Value of SENTRY\_DSN for the FPO search lambda. | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region to use. Defaults to `eu-west-2`. | `string` | `"eu-west-2"` | no |
 | <a name="input_slack_notify_lambda_slack_webhook_url"></a> [slack\_notify\_lambda\_slack\_webhook\_url](#input\_slack\_notify\_lambda\_slack\_webhook\_url) | Value of SLACK\_WEB\_HOOK\_URL for the slack notify lambda. | `string` | n/a | yes |
 | <a name="input_waf_rpm_limit"></a> [waf\_rpm\_limit](#input\_waf\_rpm\_limit) | Request per minute limit for the WAF. This limit applies to our main CDN distribution and applies to all aliases on that CDN. | `number` | `2000` | no |

--- a/environments/staging/common/iam-policies.tf
+++ b/environments/staging/common/iam-policies.tf
@@ -304,7 +304,7 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
           "secretsmanager:GetSecretValue",
         ],
         Resource = [
-          module.fpo_search_sentry_dsn.secret_arn,
+          module.fpo_search_configuration.secret_arn,
         ]
       },
       {

--- a/environments/staging/common/secrets.tf
+++ b/environments/staging/common/secrets.tf
@@ -79,15 +79,15 @@ module "db_replicate_configuration" {
   create_secret_version = false
 }
 
-######### OLD WORLD SECRETS START HERE ##########
-
-module "fpo_search_sentry_dsn" {
-  source          = "../../../modules/secret/"
-  name            = "fpo-search-sentry-dsn"
-  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window = 7
-  secret_string   = var.fpo_search_sentry_dsn
+module "fpo_search_configuration" {
+  source                = "../../../modules/secret/"
+  name                  = "fpo-search-configuration"
+  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window       = 7
+  create_secret_version = false
 }
+
+######### OLD WORLD SECRETS START HERE ##########
 
 module "slack_notify_lambda_slack_webhook_url" {
   source          = "../../../modules/secret/"

--- a/environments/staging/common/variables.tf
+++ b/environments/staging/common/variables.tf
@@ -35,12 +35,6 @@ variable "waf_rpm_limit" {
 # super secret stuff
 #
 
-variable "fpo_search_sentry_dsn" {
-  description = "Value of SENTRY_DSN for the FPO search lambda."
-  type        = string
-  sensitive   = true
-}
-
 variable "backups_basic_auth" {
   description = "base64 encoded credentials for backups basic auth."
   type        = string


### PR DESCRIPTION
# Jira link

[HMRC-1153](https://transformuk.atlassian.net/browse/HMRC-1153)

## What?

I have:

- Removed unused FPO search secrets and variables
- Removed unused slack-notify secrets and variables
- Removed unused backup auth secrets and variables

## Why?

I am doing this because:

- This simplifies the terraform runs quite a bit
