### PR TITLE
HMRC-1153: Simplify secrets management and remove slack-notify variable

### DIFF
--- a/.github/workflows/deploy-to-development.yml
+++ b/.github/workflows/deploy-to-development.yml
@@ -61,7 +61,6 @@ jobs:
     environment: development
     env:
       TF_VAR_backups_basic_auth: ${{ secrets.BACKUPS_BASIC_AUTH }}
-      TF_VAR_slack_notify_lambda_slack_webhook_url: ${{ secrets.SLACK_NOTIFY_LAMBDA_SLACK_WEBHOOK_URL }}
 
     runs-on: ubuntu-latest
     steps:
@@ -95,7 +94,6 @@ jobs:
     environment: development
     env:
       TF_VAR_backups_basic_auth: ${{ secrets.BACKUPS_BASIC_AUTH }}
-      TF_VAR_slack_notify_lambda_slack_webhook_url: ${{ secrets.SLACK_NOTIFY_LAMBDA_SLACK_WEBHOOK_URL }}
       TERRAGRUNT_NON_INTERACTIVE: true
       TF_INPUT: false
       TF_IN_AUTOMATION: 1
@@ -161,7 +159,7 @@ jobs:
     environment: staging
     env:
       TF_VAR_backups_basic_auth: ${{ secrets.BACKUPS_BASIC_AUTH }}
-      TF_VAR_slack_notify_lambda_slack_webhook_url: ${{ secrets.SLACK_NOTIFY_LAMBDA_SLACK_WEBHOOK_URL }}
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.0
@@ -193,7 +191,7 @@ jobs:
     environment: production
     env:
       TF_VAR_backups_basic_auth: ${{ secrets.BACKUPS_BASIC_AUTH }}
-      TF_VAR_slack_notify_lambda_slack_webhook_url: ${{ secrets.SLACK_NOTIFY_LAMBDA_SLACK_WEBHOOK_URL }}
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.0

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -24,7 +24,6 @@ jobs:
     environment: production
     env:
       TF_VAR_backups_basic_auth: ${{ secrets.BACKUPS_BASIC_AUTH }}
-      TF_VAR_slack_notify_lambda_slack_webhook_url: ${{ secrets.SLACK_NOTIFY_LAMBDA_SLACK_WEBHOOK_URL }}
       TERRAGRUNT_NON_INTERACTIVE: true
       TF_INPUT: false
       TF_IN_AUTOMATION: 1

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -21,7 +21,6 @@ jobs:
     environment: staging
     env:
       TF_VAR_backups_basic_auth: ${{ secrets.BACKUPS_BASIC_AUTH }}
-      TF_VAR_slack_notify_lambda_slack_webhook_url: ${{ secrets.SLACK_NOTIFY_LAMBDA_SLACK_WEBHOOK_URL }}
       TERRAGRUNT_NON_INTERACTIVE: true
       TF_INPUT: false
       TF_IN_AUTOMATION: 1

--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -196,6 +196,7 @@ No outputs.
 | [aws_iam_policy_document.waf_log_group_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
+| [aws_secretsmanager_secret_version.slack_notify_lambda_slack_webhook_url](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 | [terraform_remote_state.base](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 
 ## Inputs
@@ -207,7 +208,6 @@ No outputs.
 | <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | Domain name of the service. | `string` | `"dev.trade-tariff.service.gov.uk"` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Build environment | `string` | `"development"` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region to use. Defaults to `eu-west-2`. | `string` | `"eu-west-2"` | no |
-| <a name="input_slack_notify_lambda_slack_webhook_url"></a> [slack\_notify\_lambda\_slack\_webhook\_url](#input\_slack\_notify\_lambda\_slack\_webhook\_url) | Value of SLACK\_WEB\_HOOK\_URL for the slack notify lambda. | `string` | n/a | yes |
 | <a name="input_waf_rpm_limit"></a> [waf\_rpm\_limit](#input\_waf\_rpm\_limit) | Request per minute limit for the WAF. This limit applies to our main CDN distribution and applies to all aliases on that CDN. | `number` | `2000` | no |
 
 ## Outputs

--- a/environments/development/common/secrets.tf
+++ b/environments/development/common/secrets.tf
@@ -1,113 +1,97 @@
 module "admin_configuration" {
-  source                = "../../../modules/secret/"
-  name                  = "admin-configuration"
-  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window       = 7
-  create_secret_version = false
+  source          = "../../../modules/secret/"
+  name            = "admin-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
 }
 
 module "commodi_tea_configuration" {
-  source                = "../../../modules/secret/"
-  name                  = "commodi-tea-configuration"
-  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window       = 7
-  create_secret_version = false
+  source          = "../../../modules/secret/"
+  name            = "commodi-tea-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
 }
 
 module "dev_hub_configuration" {
-  source                = "../../../modules/secret/"
-  name                  = "dev-hub-configuration"
-  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window       = 7
-  create_secret_version = false
+  source          = "../../../modules/secret/"
+  name            = "dev-hub-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
 }
 
 module "duty_calculator_configuration" {
-  source                = "../../../modules/secret/"
-  name                  = "duty-calculator-configuration"
-  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window       = 7
-  create_secret_version = false
+  source          = "../../../modules/secret/"
+  name            = "duty-calculator-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
 }
 
 module "frontend_configuration" {
-  source                = "../../../modules/secret/"
-  name                  = "frontend-configuration"
-  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window       = 7
-  create_secret_version = false
+  source          = "../../../modules/secret/"
+  name            = "frontend-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
 }
 
 module "backend_uk_worker_configuration" {
-  source                = "../../../modules/secret/"
-  name                  = "backend-uk-worker-configuration"
-  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window       = 7
-  create_secret_version = false
+  source          = "../../../modules/secret/"
+  name            = "backend-uk-worker-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
 }
 
 module "backend_xi_worker_configuration" {
-  source                = "../../../modules/secret/"
-  name                  = "backend-xi-worker-configuration"
-  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window       = 7
-  create_secret_version = false
+  source          = "../../../modules/secret/"
+  name            = "backend-xi-worker-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
 }
 
 module "backend_uk_api_configuration" {
-  source                = "../../../modules/secret/"
-  name                  = "backend-uk-api-configuration"
-  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window       = 7
-  create_secret_version = false
+  source          = "../../../modules/secret/"
+  name            = "backend-uk-api-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
 }
 
 module "backend_xi_api_configuration" {
-  source                = "../../../modules/secret/"
-  name                  = "backend-xi-api-configuration"
-  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window       = 7
-  create_secret_version = false
+  source          = "../../../modules/secret/"
+  name            = "backend-xi-api-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
 }
 
 module "db_replicate_configuration" {
-  source                = "../../../modules/secret/"
-  name                  = "db-replicate-configuration"
-  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window       = 7
-  create_secret_version = false
+  source          = "../../../modules/secret/"
+  name            = "db-replicate-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
 }
 
 module "identity_configuration" {
-  source                = "../../../modules/secret/"
-  name                  = "identity-configuration"
-  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window       = 7
-  create_secret_version = false
+  source          = "../../../modules/secret/"
+  name            = "identity-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
 }
 
 module "fpo_search_training_pem" {
-  source                = "../../../modules/secret/"
-  name                  = "fpo-search-training-pem"
-  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window       = 7
-  create_secret_version = false
+  source          = "../../../modules/secret/"
+  name            = "fpo-search-training-pem"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
 }
 
 module "fpo_search_configuration" {
-  source                = "../../../modules/secret/"
-  name                  = "fpo-search-configuration"
-  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window       = 7
-  create_secret_version = false
+  source          = "../../../modules/secret/"
+  name            = "fpo-search-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
 }
-
-######### OLD WORLD SECRETS START HERE ##########
 
 module "slack_notify_lambda_slack_webhook_url" {
   source          = "../../../modules/secret/"
   name            = "slack-notify-lambda-slack-webhook-url"
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
   recovery_window = 7
-  secret_string   = var.slack_notify_lambda_slack_webhook_url
 }

--- a/environments/development/common/slack-notify.tf
+++ b/environments/development/common/slack-notify.tf
@@ -6,7 +6,7 @@ module "notify_slack" {
   lambda_function_name = "notify_slack_${var.environment}"
   sns_topic_name       = "slack-topic"
 
-  slack_webhook_url = var.slack_notify_lambda_slack_webhook_url
+  slack_webhook_url = data.aws_secretsmanager_secret_version.slack_notify_lambda_slack_webhook_url.secret_string
   slack_channel     = "non-production-alerts"
   slack_username    = "AWS"
 
@@ -60,4 +60,8 @@ resource "aws_cloudwatch_metric_alarm" "long_response_times" {
     LoadBalancer = module.alb.arn_suffix
     TargetGroup  = each.value.arn
   }
+}
+
+data "aws_secretsmanager_secret_version" "slack_notify_lambda_slack_webhook_url" {
+  secret_id = module.slack_notify_lambda_slack_webhook_url.secret_arn
 }

--- a/environments/development/common/variables.tf
+++ b/environments/development/common/variables.tf
@@ -40,9 +40,3 @@ variable "backups_basic_auth" {
   type        = string
   sensitive   = true
 }
-
-variable "slack_notify_lambda_slack_webhook_url" {
-  description = "Value of SLACK_WEB_HOOK_URL for the slack notify lambda."
-  type        = string
-  sensitive   = true
-}

--- a/environments/production/common/README.md
+++ b/environments/production/common/README.md
@@ -181,6 +181,7 @@
 | [aws_iam_policy_document.waf_log_group_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
+| [aws_secretsmanager_secret_version.slack_notify_lambda_slack_webhook_url](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 | [terraform_remote_state.base](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.development](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.staging](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
@@ -194,7 +195,6 @@
 | <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | Domain name of the service. | `string` | `"trade-tariff.service.gov.uk"` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Build environment | `string` | `"production"` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region to use. Defaults to `eu-west-2`. | `string` | `"eu-west-2"` | no |
-| <a name="input_slack_notify_lambda_slack_webhook_url"></a> [slack\_notify\_lambda\_slack\_webhook\_url](#input\_slack\_notify\_lambda\_slack\_webhook\_url) | Value of SLACK\_WEB\_HOOK\_URL for the slack notify lambda. | `string` | n/a | yes |
 | <a name="input_waf_rpm_limit"></a> [waf\_rpm\_limit](#input\_waf\_rpm\_limit) | Request per minute limit for the WAF. This limit applies to our main CDN distribution and applies to all aliases on that CDN. | `number` | `500` | no |
 
 ## Outputs

--- a/environments/production/common/secrets.tf
+++ b/environments/production/common/secrets.tf
@@ -1,113 +1,97 @@
 module "admin_configuration" {
-  source                = "../../../modules/secret/"
-  name                  = "admin-configuration"
-  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window       = 7
-  create_secret_version = false
+  source          = "../../../modules/secret/"
+  name            = "admin-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
 }
 
 module "commodi_tea_configuration" {
-  source                = "../../../modules/secret/"
-  name                  = "commodi-tea-configuration"
-  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window       = 7
-  create_secret_version = false
+  source          = "../../../modules/secret/"
+  name            = "commodi-tea-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
 }
 
 module "dev_hub_configuration" {
-  source                = "../../../modules/secret/"
-  name                  = "dev-hub-configuration"
-  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window       = 7
-  create_secret_version = false
+  source          = "../../../modules/secret/"
+  name            = "dev-hub-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
 }
 
 module "duty_calculator_configuration" {
-  source                = "../../../modules/secret/"
-  name                  = "duty-calculator-configuration"
-  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window       = 7
-  create_secret_version = false
+  source          = "../../../modules/secret/"
+  name            = "duty-calculator-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
 }
 
 module "frontend_configuration" {
-  source                = "../../../modules/secret/"
-  name                  = "frontend-configuration"
-  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window       = 7
-  create_secret_version = false
+  source          = "../../../modules/secret/"
+  name            = "frontend-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
 }
 
 module "backend_uk_worker_configuration" {
-  source                = "../../../modules/secret/"
-  name                  = "backend-uk-worker-configuration"
-  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window       = 7
-  create_secret_version = false
+  source          = "../../../modules/secret/"
+  name            = "backend-uk-worker-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
 }
 
 module "backend_xi_worker_configuration" {
-  source                = "../../../modules/secret/"
-  name                  = "backend-xi-worker-configuration"
-  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window       = 7
-  create_secret_version = false
+  source          = "../../../modules/secret/"
+  name            = "backend-xi-worker-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
 }
 
 module "backend_uk_api_configuration" {
-  source                = "../../../modules/secret/"
-  name                  = "backend-uk-api-configuration"
-  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window       = 7
-  create_secret_version = false
+  source          = "../../../modules/secret/"
+  name            = "backend-uk-api-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
 }
 
 module "backend_xi_api_configuration" {
-  source                = "../../../modules/secret/"
-  name                  = "backend-xi-api-configuration"
-  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window       = 7
-  create_secret_version = false
+  source          = "../../../modules/secret/"
+  name            = "backend-xi-api-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
 }
 
 module "download_cds_files_configuration" {
-  source                = "../../../modules/secret/"
-  name                  = "download-cds-files-configuration"
-  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window       = 7
-  create_secret_version = false
+  source          = "../../../modules/secret/"
+  name            = "download-cds-files-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
 }
 
 module "etf_configuration" {
-  source                = "../../../modules/secret/"
-  name                  = "electronic-tariff-file-configuration"
-  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window       = 7
-  create_secret_version = false
+  source          = "../../../modules/secret/"
+  name            = "electronic-tariff-file-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
 }
 
 module "db_replicate_configuration" {
-  source                = "../../../modules/secret/"
-  name                  = "db-replicate-configuration"
-  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window       = 7
-  create_secret_version = false
+  source          = "../../../modules/secret/"
+  name            = "db-replicate-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
 }
 
 module "fpo_search_configuration" {
-  source                = "../../../modules/secret/"
-  name                  = "fpo-search-configuration"
-  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window       = 7
-  create_secret_version = false
+  source          = "../../../modules/secret/"
+  name            = "fpo-search-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
 }
-
-######### OLD WORLD SECRETS START HERE ##########
 
 module "slack_notify_lambda_slack_webhook_url" {
   source          = "../../../modules/secret/"
   name            = "slack-notify-lambda-slack-webhook-url"
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
   recovery_window = 7
-  secret_string   = var.slack_notify_lambda_slack_webhook_url
 }

--- a/environments/production/common/slack-notify.tf
+++ b/environments/production/common/slack-notify.tf
@@ -6,7 +6,7 @@ module "notify_slack" {
   lambda_function_name = "notify_slack_${var.environment}"
   sns_topic_name       = "slack-topic"
 
-  slack_webhook_url = var.slack_notify_lambda_slack_webhook_url
+  slack_webhook_url = data.aws_secretsmanager_secret_version.slack_notify_lambda_slack_webhook_url.secret_string
   slack_channel     = "production-alerts"
   slack_username    = "AWS"
 
@@ -60,4 +60,8 @@ resource "aws_cloudwatch_metric_alarm" "long_response_times" {
     LoadBalancer = module.alb.arn_suffix
     TargetGroup  = each.value.arn
   }
+}
+
+data "aws_secretsmanager_secret_version" "slack_notify_lambda_slack_webhook_url" {
+  secret_id = module.slack_notify_lambda_slack_webhook_url.secret_arn
 }

--- a/environments/production/common/variables.tf
+++ b/environments/production/common/variables.tf
@@ -40,9 +40,3 @@ variable "backups_basic_auth" {
   type        = string
   sensitive   = true
 }
-
-variable "slack_notify_lambda_slack_webhook_url" {
-  description = "Value of SLACK_WEB_HOOK_URL for the slack notify lambda."
-  type        = string
-  sensitive   = true
-}

--- a/environments/staging/common/README.md
+++ b/environments/staging/common/README.md
@@ -165,6 +165,7 @@
 | [aws_iam_policy_document.waf_log_group_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
+| [aws_secretsmanager_secret_version.slack_notify_lambda_slack_webhook_url](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 | [terraform_remote_state.base](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 
 ## Inputs
@@ -176,7 +177,6 @@
 | <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | Domain name of the service. | `string` | `"staging.trade-tariff.service.gov.uk"` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Build environment | `string` | `"staging"` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS Region to use. Defaults to `eu-west-2`. | `string` | `"eu-west-2"` | no |
-| <a name="input_slack_notify_lambda_slack_webhook_url"></a> [slack\_notify\_lambda\_slack\_webhook\_url](#input\_slack\_notify\_lambda\_slack\_webhook\_url) | Value of SLACK\_WEB\_HOOK\_URL for the slack notify lambda. | `string` | n/a | yes |
 | <a name="input_waf_rpm_limit"></a> [waf\_rpm\_limit](#input\_waf\_rpm\_limit) | Request per minute limit for the WAF. This limit applies to our main CDN distribution and applies to all aliases on that CDN. | `number` | `2000` | no |
 
 ## Outputs

--- a/environments/staging/common/secrets.tf
+++ b/environments/staging/common/secrets.tf
@@ -1,98 +1,84 @@
 module "admin_configuration" {
-  source                = "../../../modules/secret/"
-  name                  = "admin-configuration"
-  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window       = 7
-  create_secret_version = false
+  source          = "../../../modules/secret/"
+  name            = "admin-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
 }
 
 module "commodi_tea_configuration" {
-  source                = "../../../modules/secret/"
-  name                  = "commodi-tea-configuration"
-  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window       = 7
-  create_secret_version = false
+  source          = "../../../modules/secret/"
+  name            = "commodi-tea-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
 }
 
 # TODO: Correct this secret label -> dev_hub_configuration
 module "dev" {
-  source                = "../../../modules/secret/"
-  name                  = "dev-hub-configuration"
-  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window       = 7
-  create_secret_version = false
+  source          = "../../../modules/secret/"
+  name            = "dev-hub-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
 }
 
 module "duty_calculator_configuration" {
-  source                = "../../../modules/secret/"
-  name                  = "duty-calculator-configuration"
-  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window       = 7
-  create_secret_version = false
+  source          = "../../../modules/secret/"
+  name            = "duty-calculator-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
 }
 
 module "frontend_configuration" {
-  source                = "../../../modules/secret/"
-  name                  = "frontend-configuration"
-  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window       = 7
-  create_secret_version = false
+  source          = "../../../modules/secret/"
+  name            = "frontend-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
 }
 
 module "backend_uk_worker_configuration" {
-  source                = "../../../modules/secret/"
-  name                  = "backend-uk-worker-configuration"
-  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window       = 7
-  create_secret_version = false
+  source          = "../../../modules/secret/"
+  name            = "backend-uk-worker-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
 }
 
 module "backend_xi_worker_configuration" {
-  source                = "../../../modules/secret/"
-  name                  = "backend-xi-worker-configuration"
-  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window       = 7
-  create_secret_version = false
+  source          = "../../../modules/secret/"
+  name            = "backend-xi-worker-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
 }
 
 module "backend_uk_api_configuration" {
-  source                = "../../../modules/secret/"
-  name                  = "backend-uk-api-configuration"
-  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window       = 7
-  create_secret_version = false
+  source          = "../../../modules/secret/"
+  name            = "backend-uk-api-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
 }
 
 module "backend_xi_api_configuration" {
-  source                = "../../../modules/secret/"
-  name                  = "backend-xi-api-configuration"
-  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window       = 7
-  create_secret_version = false
+  source          = "../../../modules/secret/"
+  name            = "backend-xi-api-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
 }
 
 module "db_replicate_configuration" {
-  source                = "../../../modules/secret/"
-  name                  = "db-replicate-configuration"
-  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window       = 7
-  create_secret_version = false
+  source          = "../../../modules/secret/"
+  name            = "db-replicate-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
 }
 
 module "fpo_search_configuration" {
-  source                = "../../../modules/secret/"
-  name                  = "fpo-search-configuration"
-  kms_key_arn           = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window       = 7
-  create_secret_version = false
+  source          = "../../../modules/secret/"
+  name            = "fpo-search-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
 }
-
-######### OLD WORLD SECRETS START HERE ##########
 
 module "slack_notify_lambda_slack_webhook_url" {
   source          = "../../../modules/secret/"
   name            = "slack-notify-lambda-slack-webhook-url"
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
   recovery_window = 7
-  secret_string   = var.slack_notify_lambda_slack_webhook_url
 }

--- a/environments/staging/common/slack-notify.tf
+++ b/environments/staging/common/slack-notify.tf
@@ -6,7 +6,7 @@ module "notify_slack" {
   lambda_function_name = "notify_slack_${var.environment}"
   sns_topic_name       = "slack-topic"
 
-  slack_webhook_url = var.slack_notify_lambda_slack_webhook_url
+  slack_webhook_url = data.aws_secretsmanager_secret_version.slack_notify_lambda_slack_webhook_url.secret_string
   slack_channel     = "non-production-alerts"
   slack_username    = "AWS"
 
@@ -60,4 +60,8 @@ resource "aws_cloudwatch_metric_alarm" "long_response_times" {
     LoadBalancer = module.alb.arn_suffix
     TargetGroup  = each.value.arn
   }
+}
+
+data "aws_secretsmanager_secret_version" "slack_notify_lambda_slack_webhook_url" {
+  secret_id = module.slack_notify_lambda_slack_webhook_url.secret_arn
 }

--- a/environments/staging/common/variables.tf
+++ b/environments/staging/common/variables.tf
@@ -40,9 +40,3 @@ variable "backups_basic_auth" {
   type        = string
   sensitive   = true
 }
-
-variable "slack_notify_lambda_slack_webhook_url" {
-  description = "Value of SLACK_WEB_HOOK_URL for the slack notify lambda."
-  type        = string
-  sensitive   = true
-}

--- a/modules/secret/README.md
+++ b/modules/secret/README.md
@@ -29,7 +29,6 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_create_secret_version"></a> [create\_secret\_version](#input\_create\_secret\_version) | Whether to create a secret version. Set to false to create a secret without a version. | `bool` | `true` | no |
 | <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | KMS Key ARN with which to encrypt the secret. | `string` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | Name of the secret. | `string` | n/a | yes |
 | <a name="input_recovery_window"></a> [recovery\_window](#input\_recovery\_window) | Recovery window in days for the secret. | `string` | n/a | yes |

--- a/modules/secret/main.tf
+++ b/modules/secret/main.tf
@@ -5,7 +5,7 @@ resource "aws_secretsmanager_secret" "this" {
 }
 
 resource "aws_secretsmanager_secret_version" "this" {
-  count         = var.create_secret_version ? 1 : 0
+  count         = var.secret_string != "" ? 1 : 0
   secret_id     = aws_secretsmanager_secret.this.id
   secret_string = var.secret_string
 }

--- a/modules/secret/variables.tf
+++ b/modules/secret/variables.tf
@@ -19,9 +19,3 @@ variable "recovery_window" {
   description = "Recovery window in days for the secret."
   type        = string
 }
-
-variable "create_secret_version" {
-  description = "Whether to create a secret version. Set to false to create a secret without a version."
-  type        = bool
-  default     = true
-}


### PR DESCRIPTION
# Jira link

[HMRC-1153](https://transformuk.atlassian.net/browse/HMRC-1153)

## What?

I have:

- Removed create_secret_version and instead we do this implicitly when a secret string is provided
- Removed slack-notify variable since this is already populated
- Removed version management in the slack-notify secret

## Why?

I am doing this because:

- Creating a secret string version should be implicit/a convention that happens when you supply a changing secret string
- This simplifies builds quite a bit and we're only one secret away from having no variables at all
