### PR TITLE
HMRC-1077: Adds secrets for create-auth-challenge lambda

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
       - id: check-merge-conflict
 
   - repo: https://github.com/trufflesecurity/trufflehog
-    rev: v3.88.29
+    rev: v3.88.34
     hooks:
       - id: trufflehog
 

--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -76,6 +76,7 @@ No outputs.
 | <a name="module_fpo_search_training_pem"></a> [fpo\_search\_training\_pem](#module\_fpo\_search\_training\_pem) | ../../../modules/secret/ | n/a |
 | <a name="module_frontend_configuration"></a> [frontend\_configuration](#module\_frontend\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_identity_configuration"></a> [identity\_configuration](#module\_identity\_configuration) | ../../../modules/secret/ | n/a |
+| <a name="module_identity_create_auth_challenge_configuration"></a> [identity\_create\_auth\_challenge\_configuration](#module\_identity\_create\_auth\_challenge\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_logs"></a> [logs](#module\_logs) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v4.5.0 |
 | <a name="module_notify_slack"></a> [notify\_slack](#module\_notify\_slack) | ../../../modules/aws-notify-slack | n/a |
 | <a name="module_opensearch"></a> [opensearch](#module\_opensearch) | ../../../modules/opensearch | n/a |

--- a/environments/development/common/secrets.tf
+++ b/environments/development/common/secrets.tf
@@ -103,3 +103,10 @@ module "backups_basic_auth" {
   recovery_window = 7
   secret_string   = var.backups_basic_auth
 }
+
+module "identity_create_auth_challenge_configuration" {
+  source          = "../../../modules/secret/"
+  name            = "identity-create-auth-challenge-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+}

--- a/environments/production/common/README.md
+++ b/environments/production/common/README.md
@@ -52,6 +52,7 @@
 | <a name="module_etf_configuration"></a> [etf\_configuration](#module\_etf\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_fpo_search_configuration"></a> [fpo\_search\_configuration](#module\_fpo\_search\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_frontend_configuration"></a> [frontend\_configuration](#module\_frontend\_configuration) | ../../../modules/secret/ | n/a |
+| <a name="module_identity_create_auth_challenge_configuration"></a> [identity\_create\_auth\_challenge\_configuration](#module\_identity\_create\_auth\_challenge\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_logs"></a> [logs](#module\_logs) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v4.6.0 |
 | <a name="module_notify_slack"></a> [notify\_slack](#module\_notify\_slack) | ../../../modules/aws-notify-slack | n/a |
 | <a name="module_opensearch"></a> [opensearch](#module\_opensearch) | ../../../modules/opensearch | n/a |

--- a/environments/production/common/secrets.tf
+++ b/environments/production/common/secrets.tf
@@ -103,3 +103,10 @@ module "backups_basic_auth" {
   recovery_window = 7
   secret_string   = var.backups_basic_auth
 }
+
+module "identity_create_auth_challenge_configuration" {
+  source          = "../../../modules/secret/"
+  name            = "identity-create-auth-challenge-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+}

--- a/environments/staging/common/README.md
+++ b/environments/staging/common/README.md
@@ -49,6 +49,7 @@
 | <a name="module_duty_calculator_configuration"></a> [duty\_calculator\_configuration](#module\_duty\_calculator\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_fpo_search_configuration"></a> [fpo\_search\_configuration](#module\_fpo\_search\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_frontend_configuration"></a> [frontend\_configuration](#module\_frontend\_configuration) | ../../../modules/secret/ | n/a |
+| <a name="module_identity_create_auth_challenge_configuration"></a> [identity\_create\_auth\_challenge\_configuration](#module\_identity\_create\_auth\_challenge\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_logs"></a> [logs](#module\_logs) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v4.6.0 |
 | <a name="module_notify_slack"></a> [notify\_slack](#module\_notify\_slack) | ../../../modules/aws-notify-slack | n/a |
 | <a name="module_opensearch"></a> [opensearch](#module\_opensearch) | ../../../modules/opensearch | n/a |

--- a/environments/staging/common/secrets.tf
+++ b/environments/staging/common/secrets.tf
@@ -90,3 +90,10 @@ module "backups_basic_auth" {
   recovery_window = 7
   secret_string   = var.backups_basic_auth
 }
+
+module "identity_create_auth_challenge_configuration" {
+  source          = "../../../modules/secret/"
+  name            = "identity-create-auth-challenge-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+}


### PR DESCRIPTION
# Jira link

[HMRC-1077](https://transformuk.atlassian.net/browse/HMRC-1077)

## What?

I have:

- Added secret for create-auth-challenge lambda in development
- Added secret for create-auth-challenge lambda in staging
- Added secret for create-auth-challenge lambda in production

## Why?

I am doing this because:

- This is to simplify the creation of these secrets and referencing their versions and generally to avoid a tug of war rerunning terraform apply
