### PR TITLE
HMRC-1077: Bring myott cognito up in staging and production

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -39,6 +39,11 @@ jobs:
         with:
           ssh-key: ${{ secrets.PRIVATE_SSH_KEY }}
 
+      - uses: ruby/setup-ruby@v1
+
+      - run: bundle config set path 'vendor/bundle' && bundle install
+        working-directory: common/lambda/trade-tariff-identity-create-auth-challenge
+
       - uses: autero1/action-terragrunt@v3
         with:
           terragrunt-version: ${{ env.TERRAGRUNT_VERSION }}

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -36,6 +36,11 @@ jobs:
         with:
           ssh-key: ${{ secrets.PRIVATE_SSH_KEY }}
 
+      - uses: ruby/setup-ruby@v1
+
+      - run: bundle config set path 'vendor/bundle' && bundle install
+        working-directory: common/lambda/trade-tariff-identity-create-auth-challenge
+
       - uses: autero1/action-terragrunt@v3
         with:
           terragrunt-version: ${{ env.TERRAGRUNT_VERSION }}

--- a/environments/production/common/README.md
+++ b/environments/production/common/README.md
@@ -6,6 +6,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
+| <a name="requirement_archive"></a> [archive](#requirement\_archive) | >= 2 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 5.98.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3 |
 
@@ -13,6 +14,7 @@
 
 | Name | Version |
 |------|---------|
+| <a name="provider_archive"></a> [archive](#provider\_archive) | 2.4.0 |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 5.97.0 |
 | <a name="provider_aws.us_east_1"></a> [aws.us\_east\_1](#provider\_aws.us\_east\_1) | 5.97.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.7.2 |
@@ -43,7 +45,9 @@
 | <a name="module_cognito_client_secret"></a> [cognito\_client\_secret](#module\_cognito\_client\_secret) | ../../../modules/secret/ | n/a |
 | <a name="module_commodi_tea_cognito"></a> [commodi\_tea\_cognito](#module\_commodi\_tea\_cognito) | ../../../modules/cognito | n/a |
 | <a name="module_commodi_tea_configuration"></a> [commodi\_tea\_configuration](#module\_commodi\_tea\_configuration) | ../../../modules/secret/ | n/a |
+| <a name="module_create_auth_challenge"></a> [create\_auth\_challenge](#module\_create\_auth\_challenge) | ../../../modules/lambda | n/a |
 | <a name="module_db_replicate_configuration"></a> [db\_replicate\_configuration](#module\_db\_replicate\_configuration) | ../../../modules/secret/ | n/a |
+| <a name="module_define_auth_challenge"></a> [define\_auth\_challenge](#module\_define\_auth\_challenge) | ../../../modules/lambda | n/a |
 | <a name="module_dev_hub_cognito"></a> [dev\_hub\_cognito](#module\_dev\_hub\_cognito) | ../../../modules/cognito | n/a |
 | <a name="module_dev_hub_configuration"></a> [dev\_hub\_configuration](#module\_dev\_hub\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_download_cds_files_configuration"></a> [download\_cds\_files\_configuration](#module\_download\_cds\_files\_configuration) | ../../../modules/secret/ | n/a |
@@ -54,6 +58,7 @@
 | <a name="module_frontend_configuration"></a> [frontend\_configuration](#module\_frontend\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_identity_create_auth_challenge_configuration"></a> [identity\_create\_auth\_challenge\_configuration](#module\_identity\_create\_auth\_challenge\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_logs"></a> [logs](#module\_logs) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v4.6.0 |
+| <a name="module_myott_cognito"></a> [myott\_cognito](#module\_myott\_cognito) | ../../../modules/cognito | n/a |
 | <a name="module_notify_slack"></a> [notify\_slack](#module\_notify\_slack) | ../../../modules/aws-notify-slack | n/a |
 | <a name="module_opensearch"></a> [opensearch](#module\_opensearch) | ../../../modules/opensearch | n/a |
 | <a name="module_opensearch_packages_bucket"></a> [opensearch\_packages\_bucket](#module\_opensearch\_packages\_bucket) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v4.6.0 |
@@ -71,6 +76,7 @@
 | <a name="module_tea_cognito_client_secret"></a> [tea\_cognito\_client\_secret](#module\_tea\_cognito\_client\_secret) | ../../../modules/secret/ | n/a |
 | <a name="module_tea_cognito_secret"></a> [tea\_cognito\_secret](#module\_tea\_cognito\_secret) | ../../../modules/secret/ | n/a |
 | <a name="module_tech_docs_cdn"></a> [tech\_docs\_cdn](#module\_tech\_docs\_cdn) | ../../../modules/cloudfront | n/a |
+| <a name="module_verify_auth_challenge"></a> [verify\_auth\_challenge](#module\_verify\_auth\_challenge) | ../../../modules/lambda | n/a |
 | <a name="module_waf"></a> [waf](#module\_waf) | ../../../modules/waf | n/a |
 
 ## Resources
@@ -107,6 +113,7 @@
 | [aws_iam_policy.ci_tech_docs_persistence_readwrite_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.ci_terraform_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.ci_terraform_teams_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.lambda_ses](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.appendix5a_ci_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.breakglass](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.ci_api_docs_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
@@ -169,6 +176,9 @@
 | [aws_wafv2_web_acl_logging_configuration.waf_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_logging_configuration) | resource |
 | [random_password.origin_header](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [random_password.tea_cognito_secret](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+| [archive_file.create_auth_challenge](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
+| [archive_file.define_auth_challenge](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
+| [archive_file.verify_auth_challenge](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_cloudfront_cache_policy.caching_disabled](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudfront_cache_policy) | data source |
 | [aws_iam_policy_document.api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -176,6 +186,7 @@
 | [aws_iam_policy_document.breakglass_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.ecr_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.fpo_model_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.lambda_ses](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.logs_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.reporting](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.s3_kms_key_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -184,6 +195,7 @@
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 | [aws_secretsmanager_secret_version.backups_basic_auth](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
+| [aws_secretsmanager_secret_version.identity_create_auth_challenge_configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 | [aws_secretsmanager_secret_version.slack_notify_lambda_slack_webhook_url](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 | [terraform_remote_state.base](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.development](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |

--- a/environments/production/common/cognito-myott.tf
+++ b/environments/production/common/cognito-myott.tf
@@ -1,0 +1,87 @@
+module "myott_cognito" {
+  source = "../../../modules/cognito"
+
+  pool_name      = "trade-tariff-identity-user-pool"
+  user_pool_tier = "ESSENTIALS"
+
+  allow_user_registration  = true
+  auto_verified_attributes = ["email"]
+  mfa_configuration        = "OFF"
+  allow_software_mfa_token = false
+
+  username_attributes = ["email"]
+
+  password_policy = {
+    minimum_length                   = 12
+    password_history_size            = 0
+    require_lowercase                = true
+    require_numbers                  = true
+    require_uppercase                = true
+    require_symbols                  = true
+    temporary_password_validity_days = 7
+  }
+
+  schemata = [
+    {
+      name      = "email"
+      data_type = "String"
+      required  = true
+    }
+  ]
+
+  recovery_mechanisms = [
+    {
+      name     = "verified_email"
+      priority = 1
+    },
+    {
+      name     = "verified_phone_number"
+      priority = 2
+    }
+  ]
+
+  lambda_create_auth_challenge_arn      = module.create_auth_challenge.lambda_arn
+  lambda_define_auth_challenge          = module.define_auth_challenge.lambda_arn
+  lambda_verify_auth_challenge_response = module.verify_auth_challenge.lambda_arn
+
+  # Client options
+
+  client_name = "identity-client"
+  client_auth_flows = [
+    "ALLOW_CUSTOM_AUTH",
+    "ALLOW_REFRESH_TOKEN_AUTH"
+  ]
+
+  client_oauth_flow_allowed = true
+  client_oauth_grant_types  = ["code"]
+
+  client_oauth_scopes = [
+    "email",
+    "openid",
+    "phone"
+  ]
+
+  client_auth_session_validity   = 15
+  client_enable_token_revocation = false
+
+  client_token_validity = {
+    access_token = {
+      length = 1
+      units  = "days"
+    }
+    id_token = {
+      length = 1
+      units  = "days"
+    }
+    refresh_token = {
+      length = 5
+      units  = "days"
+    }
+  }
+
+  client_callback_urls = [
+    "https://id.${var.domain_name}/auth"
+  ]
+
+  client_identity_providers = ["COGNITO"]
+}

--- a/environments/production/common/cognito.tf
+++ b/environments/production/common/cognito.tf
@@ -60,6 +60,7 @@ module "commodi_tea_cognito" {
   source = "../../../modules/cognito"
 
   pool_name              = "commodi-tea-user-pool"
+  user_pool_tier         = "ESSENTIALS"
   domain                 = "auth.tea.${var.domain_name}"
   domain_certificate_arn = module.acm.validated_certificate_arn
 
@@ -112,6 +113,12 @@ module "commodi_tea_cognito" {
     "ALLOW_USER_SRP_AUTH",
     "ALLOW_REFRESH_TOKEN_AUTH",
   ]
+
+  client_token_validity = {
+    refresh_token = {
+      units = "days"
+    }
+  }
 
   invite_message_template = {
     email_subject = "Your New 'Commodi-Tea' Account"

--- a/environments/production/common/lambda.tf
+++ b/environments/production/common/lambda.tf
@@ -1,0 +1,81 @@
+locals {
+  create_auth_challenge_configuration_secret_value = try(data.aws_secretsmanager_secret_version.identity_create_auth_challenge_configuration.secret_string, "{}")
+  create_auth_challenge_configuration_secret_map   = jsondecode(local.create_auth_challenge_configuration_secret_value)
+}
+
+data "archive_file" "create_auth_challenge" {
+  type        = "zip"
+  source_dir  = "../../../common/lambda/trade-tariff-identity-create-auth-challenge"
+  output_path = "lambda_create_auth_challenge.zip"
+}
+
+data "archive_file" "define_auth_challenge" {
+  type        = "zip"
+  source_dir  = "../../../common/lambda/trade-tariff-identity-define-auth-challenge"
+  output_path = "lambda_define_auth_challenge.zip"
+}
+
+data "archive_file" "verify_auth_challenge" {
+  type        = "zip"
+  source_dir  = "../../../common/lambda/trade-tariff-identity-verify-auth-challenge-response"
+  output_path = "lambda_verify_auth_challenge_response.zip"
+}
+
+data "aws_secretsmanager_secret_version" "identity_create_auth_challenge_configuration" {
+  secret_id = module.identity_create_auth_challenge_configuration.secret_arn
+}
+
+module "create_auth_challenge" {
+  source = "../../../modules/lambda"
+
+  function_name    = "trade-tariff-identity-create-auth-challenge"
+  filename         = "lambda_create_auth_challenge.zip"
+  handler          = "lambda_function.lambda_handler"
+  runtime          = "ruby3.4"
+  source_code_hash = data.archive_file.create_auth_challenge.output_base64sha256
+  memory_size      = 512
+
+  environment_variables = local.create_auth_challenge_configuration_secret_map
+
+  additional_policy_arns = [aws_iam_policy.lambda_ses.arn]
+}
+
+module "define_auth_challenge" {
+  source = "../../../modules/lambda"
+
+  function_name    = "trade-tariff-identity-define-auth-challenge"
+  filename         = "lambda_define_auth_challenge.zip"
+  handler          = "lambda_function.lambda_handler"
+  runtime          = "ruby3.4"
+  source_code_hash = data.archive_file.define_auth_challenge.output_base64sha256
+  memory_size      = 512
+}
+
+module "verify_auth_challenge" {
+  source = "../../../modules/lambda"
+
+  function_name    = "trade-tariff-identity-verify-auth-challenge-response"
+  filename         = "lambda_verify_auth_challenge_response.zip"
+  handler          = "lambda_function.lambda_handler"
+  runtime          = "ruby3.4"
+  source_code_hash = data.archive_file.verify_auth_challenge.output_base64sha256
+  memory_size      = 512
+}
+
+data "aws_iam_policy_document" "lambda_ses" {
+  statement {
+    sid    = 1
+    effect = "Allow"
+    actions = [
+      "ses:SendEmail",
+      "ses:SendRawEmail"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "lambda_ses" {
+  name   = "lambda-ses-policy"
+  path   = "/"
+  policy = data.aws_iam_policy_document.lambda_ses.json
+}

--- a/environments/production/common/versions.tf
+++ b/environments/production/common/versions.tf
@@ -11,6 +11,11 @@ terraform {
       source  = "hashicorp/random"
       version = ">= 3"
     }
+
+    archive = {
+      source  = "hashicorp/archive"
+      version = ">= 2"
+    }
   }
 }
 

--- a/environments/staging/common/README.md
+++ b/environments/staging/common/README.md
@@ -6,6 +6,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.11 |
+| <a name="requirement_archive"></a> [archive](#requirement\_archive) | >= 2 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | < 5.98.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3 |
 
@@ -13,6 +14,7 @@
 
 | Name | Version |
 |------|---------|
+| <a name="provider_archive"></a> [archive](#provider\_archive) | 2.4.0 |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 5.97.0 |
 | <a name="provider_aws.us_east_1"></a> [aws.us\_east\_1](#provider\_aws.us\_east\_1) | 5.97.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.7.2 |
@@ -43,7 +45,9 @@
 | <a name="module_cognito_client_secret"></a> [cognito\_client\_secret](#module\_cognito\_client\_secret) | ../../../modules/secret/ | n/a |
 | <a name="module_commodi_tea_cognito"></a> [commodi\_tea\_cognito](#module\_commodi\_tea\_cognito) | ../../../modules/cognito | n/a |
 | <a name="module_commodi_tea_configuration"></a> [commodi\_tea\_configuration](#module\_commodi\_tea\_configuration) | ../../../modules/secret/ | n/a |
+| <a name="module_create_auth_challenge"></a> [create\_auth\_challenge](#module\_create\_auth\_challenge) | ../../../modules/lambda | n/a |
 | <a name="module_db_replicate_configuration"></a> [db\_replicate\_configuration](#module\_db\_replicate\_configuration) | ../../../modules/secret/ | n/a |
+| <a name="module_define_auth_challenge"></a> [define\_auth\_challenge](#module\_define\_auth\_challenge) | ../../../modules/lambda | n/a |
 | <a name="module_dev"></a> [dev](#module\_dev) | ../../../modules/secret/ | n/a |
 | <a name="module_dev_hub_cognito"></a> [dev\_hub\_cognito](#module\_dev\_hub\_cognito) | ../../../modules/cognito | n/a |
 | <a name="module_duty_calculator_configuration"></a> [duty\_calculator\_configuration](#module\_duty\_calculator\_configuration) | ../../../modules/secret/ | n/a |
@@ -51,6 +55,7 @@
 | <a name="module_frontend_configuration"></a> [frontend\_configuration](#module\_frontend\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_identity_create_auth_challenge_configuration"></a> [identity\_create\_auth\_challenge\_configuration](#module\_identity\_create\_auth\_challenge\_configuration) | ../../../modules/secret/ | n/a |
 | <a name="module_logs"></a> [logs](#module\_logs) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v4.6.0 |
+| <a name="module_myott_cognito"></a> [myott\_cognito](#module\_myott\_cognito) | ../../../modules/cognito | n/a |
 | <a name="module_notify_slack"></a> [notify\_slack](#module\_notify\_slack) | ../../../modules/aws-notify-slack | n/a |
 | <a name="module_opensearch"></a> [opensearch](#module\_opensearch) | ../../../modules/opensearch | n/a |
 | <a name="module_opensearch_packages_bucket"></a> [opensearch\_packages\_bucket](#module\_opensearch\_packages\_bucket) | git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git | v4.6.0 |
@@ -68,6 +73,7 @@
 | <a name="module_tea_cognito_client_secret"></a> [tea\_cognito\_client\_secret](#module\_tea\_cognito\_client\_secret) | ../../../modules/secret/ | n/a |
 | <a name="module_tea_cognito_secret"></a> [tea\_cognito\_secret](#module\_tea\_cognito\_secret) | ../../../modules/secret/ | n/a |
 | <a name="module_tech_docs_cdn"></a> [tech\_docs\_cdn](#module\_tech\_docs\_cdn) | ../../../modules/cloudfront | n/a |
+| <a name="module_verify_auth_challenge"></a> [verify\_auth\_challenge](#module\_verify\_auth\_challenge) | ../../../modules/lambda | n/a |
 | <a name="module_waf"></a> [waf](#module\_waf) | ../../../modules/waf | n/a |
 
 ## Resources
@@ -100,6 +106,7 @@
 | [aws_iam_policy.ci_reporting_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.ci_tech_docs_persistence_readwrite_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.ci_terraform_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.lambda_ses](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.appendix5a_ci_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.breakglass](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.ci_api_docs_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
@@ -155,11 +162,15 @@
 | [aws_wafv2_web_acl_logging_configuration.waf_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_logging_configuration) | resource |
 | [random_password.origin_header](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [random_password.tea_cognito_secret](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+| [archive_file.create_auth_challenge](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
+| [archive_file.define_auth_challenge](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
+| [archive_file.verify_auth_challenge](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_cloudfront_cache_policy.caching_disabled](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudfront_cache_policy) | data source |
 | [aws_iam_policy_document.api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.backups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.breakglass_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.lambda_ses](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.logs_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.reporting](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.s3_kms_key_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -168,6 +179,7 @@
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 | [aws_secretsmanager_secret_version.backups_basic_auth](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
+| [aws_secretsmanager_secret_version.identity_create_auth_challenge_configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 | [aws_secretsmanager_secret_version.slack_notify_lambda_slack_webhook_url](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 | [terraform_remote_state.base](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 

--- a/environments/staging/common/cognito-myott.tf
+++ b/environments/staging/common/cognito-myott.tf
@@ -1,0 +1,87 @@
+module "myott_cognito" {
+  source = "../../../modules/cognito"
+
+  pool_name      = "trade-tariff-identity-user-pool"
+  user_pool_tier = "ESSENTIALS"
+
+  allow_user_registration  = true
+  auto_verified_attributes = ["email"]
+  mfa_configuration        = "OFF"
+  allow_software_mfa_token = false
+
+  username_attributes = ["email"]
+
+  password_policy = {
+    minimum_length                   = 12
+    password_history_size            = 0
+    require_lowercase                = true
+    require_numbers                  = true
+    require_uppercase                = true
+    require_symbols                  = true
+    temporary_password_validity_days = 7
+  }
+
+  schemata = [
+    {
+      name      = "email"
+      data_type = "String"
+      required  = true
+    }
+  ]
+
+  recovery_mechanisms = [
+    {
+      name     = "verified_email"
+      priority = 1
+    },
+    {
+      name     = "verified_phone_number"
+      priority = 2
+    }
+  ]
+
+  lambda_create_auth_challenge_arn      = module.create_auth_challenge.lambda_arn
+  lambda_define_auth_challenge          = module.define_auth_challenge.lambda_arn
+  lambda_verify_auth_challenge_response = module.verify_auth_challenge.lambda_arn
+
+  # Client options
+
+  client_name = "identity-client"
+  client_auth_flows = [
+    "ALLOW_CUSTOM_AUTH",
+    "ALLOW_REFRESH_TOKEN_AUTH"
+  ]
+
+  client_oauth_flow_allowed = true
+  client_oauth_grant_types  = ["code"]
+
+  client_oauth_scopes = [
+    "email",
+    "openid",
+    "phone"
+  ]
+
+  client_auth_session_validity   = 15
+  client_enable_token_revocation = false
+
+  client_token_validity = {
+    access_token = {
+      length = 1
+      units  = "days"
+    }
+    id_token = {
+      length = 1
+      units  = "days"
+    }
+    refresh_token = {
+      length = 5
+      units  = "days"
+    }
+  }
+
+  client_callback_urls = [
+    "https://id.${var.domain_name}/auth"
+  ]
+
+  client_identity_providers = ["COGNITO"]
+}

--- a/environments/staging/common/cognito.tf
+++ b/environments/staging/common/cognito.tf
@@ -60,6 +60,7 @@ module "commodi_tea_cognito" {
   source = "../../../modules/cognito"
 
   pool_name              = "commodi-tea-user-pool"
+  user_pool_tier         = "ESSENTIALS"
   domain                 = "auth.tea.${var.domain_name}"
   domain_certificate_arn = module.acm.validated_certificate_arn
 
@@ -112,6 +113,12 @@ module "commodi_tea_cognito" {
     "ALLOW_USER_SRP_AUTH",
     "ALLOW_REFRESH_TOKEN_AUTH",
   ]
+
+  client_token_validity = {
+    refresh_token = {
+      units = "days"
+    }
+  }
 
   invite_message_template = {
     email_subject = "Your New 'Commodi-Tea Staging' Account"

--- a/environments/staging/common/lambda.tf
+++ b/environments/staging/common/lambda.tf
@@ -1,0 +1,81 @@
+locals {
+  create_auth_challenge_configuration_secret_value = try(data.aws_secretsmanager_secret_version.identity_create_auth_challenge_configuration.secret_string, "{}")
+  create_auth_challenge_configuration_secret_map   = jsondecode(local.create_auth_challenge_configuration_secret_value)
+}
+
+data "archive_file" "create_auth_challenge" {
+  type        = "zip"
+  source_dir  = "../../../common/lambda/trade-tariff-identity-create-auth-challenge"
+  output_path = "lambda_create_auth_challenge.zip"
+}
+
+data "archive_file" "define_auth_challenge" {
+  type        = "zip"
+  source_dir  = "../../../common/lambda/trade-tariff-identity-define-auth-challenge"
+  output_path = "lambda_define_auth_challenge.zip"
+}
+
+data "archive_file" "verify_auth_challenge" {
+  type        = "zip"
+  source_dir  = "../../../common/lambda/trade-tariff-identity-verify-auth-challenge-response"
+  output_path = "lambda_verify_auth_challenge_response.zip"
+}
+
+data "aws_secretsmanager_secret_version" "identity_create_auth_challenge_configuration" {
+  secret_id = module.identity_create_auth_challenge_configuration.secret_arn
+}
+
+module "create_auth_challenge" {
+  source = "../../../modules/lambda"
+
+  function_name    = "trade-tariff-identity-create-auth-challenge"
+  filename         = "lambda_create_auth_challenge.zip"
+  handler          = "lambda_function.lambda_handler"
+  runtime          = "ruby3.4"
+  source_code_hash = data.archive_file.create_auth_challenge.output_base64sha256
+  memory_size      = 512
+
+  environment_variables = local.create_auth_challenge_configuration_secret_map
+
+  additional_policy_arns = [aws_iam_policy.lambda_ses.arn]
+}
+
+module "define_auth_challenge" {
+  source = "../../../modules/lambda"
+
+  function_name    = "trade-tariff-identity-define-auth-challenge"
+  filename         = "lambda_define_auth_challenge.zip"
+  handler          = "lambda_function.lambda_handler"
+  runtime          = "ruby3.4"
+  source_code_hash = data.archive_file.define_auth_challenge.output_base64sha256
+  memory_size      = 512
+}
+
+module "verify_auth_challenge" {
+  source = "../../../modules/lambda"
+
+  function_name    = "trade-tariff-identity-verify-auth-challenge-response"
+  filename         = "lambda_verify_auth_challenge_response.zip"
+  handler          = "lambda_function.lambda_handler"
+  runtime          = "ruby3.4"
+  source_code_hash = data.archive_file.verify_auth_challenge.output_base64sha256
+  memory_size      = 512
+}
+
+data "aws_iam_policy_document" "lambda_ses" {
+  statement {
+    sid    = 1
+    effect = "Allow"
+    actions = [
+      "ses:SendEmail",
+      "ses:SendRawEmail"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "lambda_ses" {
+  name   = "lambda-ses-policy"
+  path   = "/"
+  policy = data.aws_iam_policy_document.lambda_ses.json
+}

--- a/environments/staging/common/versions.tf
+++ b/environments/staging/common/versions.tf
@@ -11,6 +11,11 @@ terraform {
       source  = "hashicorp/random"
       version = ">= 3"
     }
+
+    archive = {
+      source  = "hashicorp/archive"
+      version = ">= 2"
+    }
   }
 }
 


### PR DESCRIPTION
# Jira link

[HMRC-1077](https://transformuk.atlassian.net/browse/HMRC-1077)

## What?

I have:

- Adds myott cognito user pool and lambdas for staging
- Adds myott cognito user pool and lambdas for production

## Why?

I am doing this because:

- This is required to enable passwordless authentication flows in staging and production environments
