### PR TITLE
HMRC-1140: Shrink maximum ACUs in aurora development/staging postgres

### DIFF
--- a/environments/development/common/rds.tf
+++ b/environments/development/common/rds.tf
@@ -47,7 +47,7 @@ module "postgres_aurora" {
   username       = "tariff"
 
   min_capacity = 0.5
-  max_capacity = 256
+  max_capacity = 2.0
 
   security_group_ids = [module.alb-security-group.be_to_rds_security_group_id]
   private_subnet_ids = data.terraform_remote_state.base.outputs.private_subnet_ids

--- a/environments/staging/common/rds.tf
+++ b/environments/staging/common/rds.tf
@@ -47,7 +47,7 @@ module "postgres_aurora" {
   username       = "tariff"
 
   min_capacity = 0.5
-  max_capacity = 256
+  max_capacity = 10
 
   security_group_ids = [module.alb-security-group.be_to_rds_security_group_id]
   private_subnet_ids = data.terraform_remote_state.base.outputs.private_subnet_ids


### PR DESCRIPTION
# Jira link

[HMRC-1140](https://transformuk.atlassian.net/browse/HMRC-1140)

## What?

I have:

- Altered the ACU max (previously 512 GB of memory) in development
- Altered the ACU max (previously 512 GB of memory) in staging

## Why?

I am doing this because:

- This amount of total scalable capacity is insane for any of our environments
