### PR TITLE
Add permissions for myott cognito lambdas

### DIFF
--- a/environments/development/common/README.md
+++ b/environments/development/common/README.md
@@ -132,7 +132,6 @@ No outputs.
 | [aws_iam_policy.ci_reporting_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.ci_tech_docs_persistence_readwrite_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.ci_terraform_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.lambda_ses](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.appendix5a_ci_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.breakglass](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.ci_api_docs_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
@@ -199,7 +198,6 @@ No outputs.
 | [aws_iam_policy_document.backups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.breakglass_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.ci_build_ami_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.lambda_ses](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.logs_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.reporting](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.s3_kms_key_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/environments/development/common/lambda.tf
+++ b/environments/development/common/lambda.tf
@@ -36,8 +36,14 @@ module "create_auth_challenge" {
   memory_size      = 512
 
   environment_variables = local.create_auth_challenge_configuration_secret_map
+}
 
-  additional_policy_arns = [aws_iam_policy.lambda_ses.arn]
+resource "aws_lambda_permission" "allow_cognito_invoke_create_auth_challenge" {
+  statement_id  = "AllowExecutionFromCognitoCreateAuthChallenge"
+  action        = "lambda:InvokeFunction"
+  function_name = module.create_auth_challenge.lambda_arn
+  principal     = "cognito-idp.amazonaws.com"
+  source_arn    = "arn:aws:cognito-idp:${var.region}:${local.account_id}:userpool/${module.myott_cognito.user_pool_id}"
 }
 
 module "define_auth_challenge" {
@@ -51,6 +57,14 @@ module "define_auth_challenge" {
   memory_size      = 512
 }
 
+resource "aws_lambda_permission" "allow_cognito_invoke_define_auth_challenge" {
+  statement_id  = "AllowExecutionFromCognitoDefineAuthChallenge"
+  action        = "lambda:InvokeFunction"
+  function_name = module.define_auth_challenge.lambda_arn
+  principal     = "cognito-idp.amazonaws.com"
+  source_arn    = "arn:aws:cognito-idp:${var.region}:${local.account_id}:userpool/${module.myott_cognito.user_pool_id}"
+}
+
 module "verify_auth_challenge" {
   source = "../../../modules/lambda"
 
@@ -62,20 +76,10 @@ module "verify_auth_challenge" {
   memory_size      = 512
 }
 
-data "aws_iam_policy_document" "lambda_ses" {
-  statement {
-    sid    = 1
-    effect = "Allow"
-    actions = [
-      "ses:SendEmail",
-      "ses:SendRawEmail"
-    ]
-    resources = ["*"]
-  }
-}
-
-resource "aws_iam_policy" "lambda_ses" {
-  name   = "lambda-ses-policy"
-  path   = "/"
-  policy = data.aws_iam_policy_document.lambda_ses.json
+resource "aws_lambda_permission" "allow_cognito_invoke_verify_auth_challenge" {
+  statement_id  = "AllowExecutionFromCognitoVerifyAuthChallenge"
+  action        = "lambda:InvokeFunction"
+  function_name = module.verify_auth_challenge.lambda_arn
+  principal     = "cognito-idp.amazonaws.com"
+  source_arn    = "arn:aws:cognito-idp:${var.region}:${local.account_id}:userpool/${module.myott_cognito.user_pool_id}"
 }

--- a/environments/production/common/README.md
+++ b/environments/production/common/README.md
@@ -111,7 +111,6 @@
 | [aws_iam_policy.ci_tech_docs_persistence_readwrite_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.ci_terraform_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.ci_terraform_teams_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.lambda_ses](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.appendix5a_ci_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.breakglass](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.ci_api_docs_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
@@ -182,7 +181,6 @@
 | [aws_iam_policy_document.breakglass_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.ecr_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.fpo_model_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.lambda_ses](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.logs_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.reporting](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.s3_kms_key_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/environments/production/common/lambda.tf
+++ b/environments/production/common/lambda.tf
@@ -36,8 +36,6 @@ module "create_auth_challenge" {
   memory_size      = 512
 
   environment_variables = local.create_auth_challenge_configuration_secret_map
-
-  additional_policy_arns = [aws_iam_policy.lambda_ses.arn]
 }
 
 module "define_auth_challenge" {
@@ -62,20 +60,26 @@ module "verify_auth_challenge" {
   memory_size      = 512
 }
 
-data "aws_iam_policy_document" "lambda_ses" {
-  statement {
-    sid    = 1
-    effect = "Allow"
-    actions = [
-      "ses:SendEmail",
-      "ses:SendRawEmail"
-    ]
-    resources = ["*"]
-  }
+resource "aws_lambda_permission" "allow_cognito_invoke_create_auth_challenge" {
+  statement_id  = "AllowExecutionFromCognitoCreateAuthChallenge"
+  action        = "lambda:InvokeFunction"
+  function_name = module.create_auth_challenge.lambda_arn
+  principal     = "cognito-idp.amazonaws.com"
+  source_arn    = "arn:aws:cognito-idp:${var.region}:${local.account_id}:userpool/${module.myott_cognito.user_pool_id}"
 }
 
-resource "aws_iam_policy" "lambda_ses" {
-  name   = "lambda-ses-policy"
-  path   = "/"
-  policy = data.aws_iam_policy_document.lambda_ses.json
+resource "aws_lambda_permission" "allow_cognito_invoke_define_auth_challenge" {
+  statement_id  = "AllowExecutionFromCognitoDefineAuthChallenge"
+  action        = "lambda:InvokeFunction"
+  function_name = module.define_auth_challenge.lambda_arn
+  principal     = "cognito-idp.amazonaws.com"
+  source_arn    = "arn:aws:cognito-idp:${var.region}:${local.account_id}:userpool/${module.myott_cognito.user_pool_id}"
+}
+
+resource "aws_lambda_permission" "allow_cognito_invoke_verify_auth_challenge" {
+  statement_id  = "AllowExecutionFromCognitoVerifyAuthChallenge"
+  action        = "lambda:InvokeFunction"
+  function_name = module.verify_auth_challenge.lambda_arn
+  principal     = "cognito-idp.amazonaws.com"
+  source_arn    = "arn:aws:cognito-idp:${var.region}:${local.account_id}:userpool/${module.myott_cognito.user_pool_id}"
 }

--- a/environments/staging/common/README.md
+++ b/environments/staging/common/README.md
@@ -104,7 +104,6 @@
 | [aws_iam_policy.ci_reporting_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.ci_tech_docs_persistence_readwrite_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.ci_terraform_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.lambda_ses](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.appendix5a_ci_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.breakglass](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.ci_api_docs_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
@@ -166,7 +165,6 @@
 | [aws_iam_policy_document.api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.backups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.breakglass_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.lambda_ses](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.logs_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.reporting](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.s3_kms_key_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/environments/staging/common/lambda.tf
+++ b/environments/staging/common/lambda.tf
@@ -36,8 +36,6 @@ module "create_auth_challenge" {
   memory_size      = 512
 
   environment_variables = local.create_auth_challenge_configuration_secret_map
-
-  additional_policy_arns = [aws_iam_policy.lambda_ses.arn]
 }
 
 module "define_auth_challenge" {
@@ -62,20 +60,26 @@ module "verify_auth_challenge" {
   memory_size      = 512
 }
 
-data "aws_iam_policy_document" "lambda_ses" {
-  statement {
-    sid    = 1
-    effect = "Allow"
-    actions = [
-      "ses:SendEmail",
-      "ses:SendRawEmail"
-    ]
-    resources = ["*"]
-  }
+resource "aws_lambda_permission" "allow_cognito_invoke_create_auth_challenge" {
+  statement_id  = "AllowExecutionFromCognitoCreateAuthChallenge"
+  action        = "lambda:InvokeFunction"
+  function_name = module.create_auth_challenge.lambda_arn
+  principal     = "cognito-idp.amazonaws.com"
+  source_arn    = "arn:aws:cognito-idp:${var.region}:${local.account_id}:userpool/${module.myott_cognito.user_pool_id}"
 }
 
-resource "aws_iam_policy" "lambda_ses" {
-  name   = "lambda-ses-policy"
-  path   = "/"
-  policy = data.aws_iam_policy_document.lambda_ses.json
+resource "aws_lambda_permission" "allow_cognito_invoke_define_auth_challenge" {
+  statement_id  = "AllowExecutionFromCognitoDefineAuthChallenge"
+  action        = "lambda:InvokeFunction"
+  function_name = module.define_auth_challenge.lambda_arn
+  principal     = "cognito-idp.amazonaws.com"
+  source_arn    = "arn:aws:cognito-idp:${var.region}:${local.account_id}:userpool/${module.myott_cognito.user_pool_id}"
+}
+
+resource "aws_lambda_permission" "allow_cognito_invoke_verify_auth_challenge" {
+  statement_id  = "AllowExecutionFromCognitoVerifyAuthChallenge"
+  action        = "lambda:InvokeFunction"
+  function_name = module.verify_auth_challenge.lambda_arn
+  principal     = "cognito-idp.amazonaws.com"
+  source_arn    = "arn:aws:cognito-idp:${var.region}:${local.account_id}:userpool/${module.myott_cognito.user_pool_id}"
 }


### PR DESCRIPTION
## What?

I have:

- Added permissions so that passwordless lambdas can interact with Cognito
- Removed SES permissions from the lambdas

## Why?

I am doing this because:

- Lambdas need to work with Cognito
- We no longer use SES with the passwordless flow
