### PR TITLE
Enable user api route in all environments

### DIFF
--- a/environments/development/common/alb.tf
+++ b/environments/development/common/alb.tf
@@ -37,18 +37,13 @@ module "alb" {
     }
 
     backend_uk = {
-      paths = [
-        "/users/*",
-        "/api/*",
-        "/uk/api/*",
-        "/uk/users/*"
-      ]
+      paths            = ["/user/*", "/api/*", "/uk/api/*"]
       healthcheck_path = "/healthcheckz"
       priority         = 20
     }
 
     backend_xi = {
-      paths            = ["/xi/api/*", "/xi/users/*"]
+      paths            = ["/xi/api/*"]
       healthcheck_path = "/healthcheckz"
       priority         = 21
     }

--- a/environments/production/common/alb.tf
+++ b/environments/production/common/alb.tf
@@ -37,7 +37,7 @@ module "alb" {
     }
 
     backend_uk = {
-      paths            = ["/api/*", "/uk/api/*"]
+      paths            = ["/user/*", "/api/*", "/uk/api/*"]
       healthcheck_path = "/healthcheckz"
       priority         = 20
     }

--- a/environments/staging/common/alb.tf
+++ b/environments/staging/common/alb.tf
@@ -37,7 +37,7 @@ module "alb" {
     }
 
     backend_uk = {
-      paths            = ["/api/*", "/uk/api/*"]
+      paths            = ["/user/*", "/api/*", "/uk/api/*"]
       healthcheck_path = "/healthcheckz"
       priority         = 20
     }


### PR DESCRIPTION
I have:

- Fixed routes in development
- Added user api routes in staging and production


## Why?

I am doing this because:

- To make myott service work in all environments
