### PR TITLE
HMRC-694: Drop duty-calculator routes

### DIFF
--- a/environments/development/common/alb.tf
+++ b/environments/development/common/alb.tf
@@ -30,12 +30,6 @@ module "alb" {
       priority         = 10
     }
 
-    duty_calculator = {
-      paths            = ["/duty-calculator/*"]
-      healthcheck_path = "/healthcheckz"
-      priority         = 17
-    }
-
     backend_uk = {
       paths            = ["/user/*", "/api/*", "/uk/api/*"]
       healthcheck_path = "/healthcheckz"

--- a/environments/development/common/ecr.tf
+++ b/environments/development/common/ecr.tf
@@ -1,7 +1,0 @@
-resource "aws_ssm_parameter" "ecr_url" {
-  for_each    = toset(local.applications)
-  name        = "/${var.environment}/${replace(upper(each.key), "-", "_")}_ECR_URL"
-  description = "${title(each.key)} ECR repository URL."
-  type        = "SecureString"
-  value       = "${var.account_ids["production"]}.dkr.ecr.${var.region}.amazonaws.com/tariff-${each.key}-production"
-}

--- a/environments/development/common/iam-policies.tf
+++ b/environments/development/common/iam-policies.tf
@@ -311,15 +311,6 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
       {
         Effect = "Allow",
         Action = [
-          "ssm:DescribeParameters",
-          "ssm:GetParameter",
-          "ssm:GetParameters"
-        ],
-        Resource = [for v in aws_ssm_parameter.ecr_url : v.arn]
-      },
-      {
-        Effect = "Allow",
-        Action = [
           "ecr:BatchCheckLayerAvailability",
           "ecr:BatchGetImage",
           "ecr:CompleteLayerUpload",

--- a/environments/development/common/locals.tf
+++ b/environments/development/common/locals.tf
@@ -2,20 +2,6 @@ locals {
   account_id         = data.aws_caller_identity.current.account_id
   origin_domain_name = "origin.${var.domain_name}"
 
-  applications = [
-    "admin",
-    "backend",
-    "database-backups",
-    "database-replication",
-    "duty-calculator",
-    "fpo-developer-hub-backend",
-    "fpo-developer-hub-frontend",
-    "fpo-search",
-    "frontend",
-    "identity",
-    "tea"
-  ]
-
   cloudfront_auth = templatefile(
     "../../../modules/cloudfront-auth.js.tpl",
     { base64 = data.aws_secretsmanager_secret_version.backups_basic_auth.secret_string }

--- a/environments/development/common/variables.tf
+++ b/environments/development/common/variables.tf
@@ -16,15 +16,6 @@ variable "region" {
   default     = "eu-west-2"
 }
 
-variable "account_ids" {
-  type = map(string)
-  default = {
-    "development" = "844815912454"
-    "staging"     = "451934005581"
-    "production"  = "382373577178"
-  }
-}
-
 variable "waf_rpm_limit" {
   description = "Request per minute limit for the WAF. This limit applies to our main CDN distribution and applies to all aliases on that CDN. "
   type        = number

--- a/environments/production/common/alb.tf
+++ b/environments/production/common/alb.tf
@@ -30,12 +30,6 @@ module "alb" {
       priority         = 10
     }
 
-    duty_calculator = {
-      paths            = ["/duty-calculator/*"]
-      healthcheck_path = "/healthcheckz"
-      priority         = 17
-    }
-
     backend_uk = {
       paths            = ["/user/*", "/api/*", "/uk/api/*"]
       healthcheck_path = "/healthcheckz"

--- a/environments/production/common/ecr.tf
+++ b/environments/production/common/ecr.tf
@@ -57,14 +57,6 @@ module "ecr" {
   environment = var.environment
 }
 
-resource "aws_ssm_parameter" "ecr_url" {
-  for_each    = module.ecr.repository_urls
-  name        = "/${var.environment}/${replace(upper(each.key), "-", "_")}_ECR_URL"
-  description = "${title(each.key)} ECR repository URL."
-  type        = "SecureString"
-  value       = each.value
-}
-
 resource "aws_ecr_repository_policy" "ecr_allow_staging_and_development" {
   for_each   = module.ecr.repository_urls
   repository = "tariff-${each.key}-${var.environment}"

--- a/environments/production/common/iam-policies.tf
+++ b/environments/production/common/iam-policies.tf
@@ -346,15 +346,6 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
       {
         Effect = "Allow",
         Action = [
-          "ssm:DescribeParameters",
-          "ssm:GetParameter",
-          "ssm:GetParameters"
-        ],
-        Resource = [for v in aws_ssm_parameter.ecr_url : v.arn]
-      },
-      {
-        Effect = "Allow",
-        Action = [
           "ecr:BatchCheckLayerAvailability",
           "ecr:BatchGetImage",
           "ecr:CompleteLayerUpload",

--- a/environments/staging/common/alb.tf
+++ b/environments/staging/common/alb.tf
@@ -30,12 +30,6 @@ module "alb" {
       priority         = 10
     }
 
-    duty_calculator = {
-      paths            = ["/duty-calculator/*"]
-      healthcheck_path = "/healthcheckz"
-      priority         = 17
-    }
-
     backend_uk = {
       paths            = ["/user/*", "/api/*", "/uk/api/*"]
       healthcheck_path = "/healthcheckz"

--- a/environments/staging/common/ecr.tf
+++ b/environments/staging/common/ecr.tf
@@ -1,7 +1,0 @@
-resource "aws_ssm_parameter" "ecr_url" {
-  for_each    = toset(local.applications)
-  name        = "/${var.environment}/${replace(upper(each.key), "-", "_")}_ECR_URL"
-  description = "${title(each.key)} ECR repository URL."
-  type        = "SecureString"
-  value       = "${var.account_ids["production"]}.dkr.ecr.${var.region}.amazonaws.com/tariff-${each.key}-production"
-}

--- a/environments/staging/common/iam-policies.tf
+++ b/environments/staging/common/iam-policies.tf
@@ -310,15 +310,6 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
       {
         Effect = "Allow",
         Action = [
-          "ssm:DescribeParameters",
-          "ssm:GetParameter",
-          "ssm:GetParameters"
-        ],
-        Resource = [for v in aws_ssm_parameter.ecr_url : v.arn]
-      },
-      {
-        Effect = "Allow",
-        Action = [
           "ecr:BatchCheckLayerAvailability",
           "ecr:BatchGetImage",
           "ecr:CompleteLayerUpload",

--- a/environments/staging/common/locals.tf
+++ b/environments/staging/common/locals.tf
@@ -2,20 +2,6 @@ locals {
   account_id         = data.aws_caller_identity.current.account_id
   origin_domain_name = "origin.${var.domain_name}"
 
-  applications = [
-    "admin",
-    "backend",
-    "database-backups",
-    "database-replication",
-    "duty-calculator",
-    "fpo-developer-hub-backend",
-    "fpo-developer-hub-frontend",
-    "fpo-search",
-    "frontend",
-    "identity",
-    "tea"
-  ]
-
   cloudfront_auth = templatefile(
     "../../../modules/cloudfront-auth.js.tpl",
     { base64 = data.aws_secretsmanager_secret_version.backups_basic_auth.secret_string }

--- a/environments/staging/common/variables.tf
+++ b/environments/staging/common/variables.tf
@@ -16,15 +16,6 @@ variable "region" {
   default     = "eu-west-2"
 }
 
-variable "account_ids" {
-  type = map(string)
-  default = {
-    "development" = "844815912454"
-    "staging"     = "451934005581"
-    "production"  = "382373577178"
-  }
-}
-
 variable "waf_rpm_limit" {
   description = "Request per minute limit for the WAF. This limit applies to our main CDN distribution and applies to all aliases on that CDN. "
   type        = number


### PR DESCRIPTION
# Jira link

[HMRC-694](https://transformuk.atlassian.net/browse/HMRC-694)

## What?

I have:

- Removed duty calculator route in development ALB
- Removed duty calculator route in staging ALB
- Removed duty calculator route in production ALB
- Removed unused non-secret SSM parameters for ECR repo

## Why?

I am doing this because:

- We're merging the duty calculator into the frontend (see https://github.com/trade-tariff/trade-tariff-frontend/pull/2339)
