### PR TITLE
HMRC-694: Tidy up duty calculator infrastructure

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: terragrunt-hclfmt
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.99.1
+    rev: v1.99.2
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/environments/development/common/.terraform.lock.hcl
+++ b/environments/development/common/.terraform.lock.hcl
@@ -1,12 +1,9 @@
-# This file is maintained automatically by "terraform init".
-# Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/archive" {
   version     = "2.4.0"
   constraints = "2.4.0"
   hashes = [
     "h1:EtN1lnoHoov3rASpgGmh6zZ/W6aRCTgKC7iMwvFY1yc=",
-    "h1:cJokkjeH1jfpG4QEHdRx0t2j8rr52H33A7C/oX73Ok4=",
     "zh:18e408596dd53048f7fc8229098d0e3ad940b92036a24287eff63e2caec72594",
     "zh:392d4216ecd1a1fd933d23f4486b642a8480f934c13e2cae3c13b6b6a7e34a7b",
     "zh:655dd1fa5ca753a4ace21d0de3792d96fff429445717f2ce31c125d19c38f3ff",
@@ -27,7 +24,6 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = "5.97.0"
   hashes = [
     "h1:lI0I9GziJsdymNBcj+MJloqwD8fbogJw3EiR60j5FYU=",
-    "h1:rUDE0OgA+6IiEA+w0cPp3/QQNH4SpjFjYcQ6p7byKS4=",
     "zh:02790ad98b767d8f24d28e8be623f348bcb45590205708334d52de2fb14f5a95",
     "zh:088b4398a161e45762dc28784fcc41c4fa95bd6549cb708b82de577f2d39ffc7",
     "zh:0c381a457b7af391c43fc0167919443f6105ad2702bde4d02ddea9fd7c9d3539",
@@ -50,7 +46,6 @@ provider "registry.terraform.io/hashicorp/external" {
   version     = "2.3.5"
   constraints = "2.3.5"
   hashes = [
-    "h1:FnUk98MI5nOh3VJ16cHf8mchQLewLfN1qZG/MqNgPrI=",
     "h1:smKSos4zs57pJjQrNuvGBpSWth2el9SgePPbPHo0aps=",
     "zh:6e89509d056091266532fa64de8c06950010498adf9070bf6ff85bc485a82562",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
@@ -72,7 +67,6 @@ provider "registry.terraform.io/hashicorp/local" {
   constraints = "2.5.3"
   hashes = [
     "h1:1Nkh16jQJMp0EuDmvP/96f5Unnir0z12WyDuoR6HjMo=",
-    "h1:MCzg+hs1/ZQ32u56VzJMWP9ONRQPAAqAjuHuzbyshvI=",
     "zh:284d4b5b572eacd456e605e94372f740f6de27b71b4e1fd49b63745d8ecd4927",
     "zh:40d9dfc9c549e406b5aab73c023aa485633c1b6b730c933d7bcc2fa67fd1ae6e",
     "zh:6243509bb208656eb9dc17d3c525c89acdd27f08def427a0dce22d5db90a4c8b",
@@ -92,7 +86,6 @@ provider "registry.terraform.io/hashicorp/null" {
   version     = "3.2.4"
   constraints = "3.2.4"
   hashes = [
-    "h1:L5V05xwp/Gto1leRryuesxjMfgZwjb7oool4WS1UEFQ=",
     "h1:hkf5w5B6q8e2A42ND2CjAvgvSN3puAosDmOJb3zCVQM=",
     "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
@@ -114,7 +107,6 @@ provider "registry.terraform.io/hashicorp/random" {
   constraints = "3.7.2"
   hashes = [
     "h1:356j/3XnXEKr9nyicLUufzoF4Yr6hRy481KIxRVpK0c=",
-    "h1:KG4NuIBl1mRWU0KD/BGfCi1YN/j3F7H4YgeeM7iSdNs=",
     "zh:14829603a32e4bc4d05062f059e545a91e27ff033756b48afbae6b3c835f508f",
     "zh:1527fb07d9fea400d70e9e6eb4a2b918d5060d604749b6f1c361518e7da546dc",
     "zh:1e86bcd7ebec85ba336b423ba1db046aeaa3c0e5f921039b3f1a6fc2f978feab",

--- a/environments/development/common/.terraform.lock.hcl
+++ b/environments/development/common/.terraform.lock.hcl
@@ -3,7 +3,7 @@
 
 provider "registry.terraform.io/hashicorp/archive" {
   version     = "2.4.0"
-  constraints = ">= 2.0.0, 2.4.0"
+  constraints = "2.4.0"
   hashes = [
     "h1:EtN1lnoHoov3rASpgGmh6zZ/W6aRCTgKC7iMwvFY1yc=",
     "h1:cJokkjeH1jfpG4QEHdRx0t2j8rr52H33A7C/oX73Ok4=",
@@ -24,7 +24,7 @@ provider "registry.terraform.io/hashicorp/archive" {
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.97.0"
-  constraints = ">= 3.72.0, >= 4.9.0, >= 4.40.0, >= 5.0.0, >= 5.3.0, >= 5.70.0, >= 5.83.0, < 5.98.0, < 6.0.0"
+  constraints = "5.97.0"
   hashes = [
     "h1:lI0I9GziJsdymNBcj+MJloqwD8fbogJw3EiR60j5FYU=",
     "h1:rUDE0OgA+6IiEA+w0cPp3/QQNH4SpjFjYcQ6p7byKS4=",
@@ -48,7 +48,7 @@ provider "registry.terraform.io/hashicorp/aws" {
 
 provider "registry.terraform.io/hashicorp/external" {
   version     = "2.3.5"
-  constraints = ">= 1.0.0"
+  constraints = "2.3.5"
   hashes = [
     "h1:FnUk98MI5nOh3VJ16cHf8mchQLewLfN1qZG/MqNgPrI=",
     "h1:smKSos4zs57pJjQrNuvGBpSWth2el9SgePPbPHo0aps=",
@@ -69,7 +69,7 @@ provider "registry.terraform.io/hashicorp/external" {
 
 provider "registry.terraform.io/hashicorp/local" {
   version     = "2.5.3"
-  constraints = ">= 1.0.0"
+  constraints = "2.5.3"
   hashes = [
     "h1:1Nkh16jQJMp0EuDmvP/96f5Unnir0z12WyDuoR6HjMo=",
     "h1:MCzg+hs1/ZQ32u56VzJMWP9ONRQPAAqAjuHuzbyshvI=",
@@ -90,7 +90,7 @@ provider "registry.terraform.io/hashicorp/local" {
 
 provider "registry.terraform.io/hashicorp/null" {
   version     = "3.2.4"
-  constraints = ">= 2.0.0, >= 3.0.0"
+  constraints = "3.2.4"
   hashes = [
     "h1:L5V05xwp/Gto1leRryuesxjMfgZwjb7oool4WS1UEFQ=",
     "h1:hkf5w5B6q8e2A42ND2CjAvgvSN3puAosDmOJb3zCVQM=",
@@ -111,7 +111,7 @@ provider "registry.terraform.io/hashicorp/null" {
 
 provider "registry.terraform.io/hashicorp/random" {
   version     = "3.7.2"
-  constraints = ">= 3.0.0"
+  constraints = "3.7.2"
   hashes = [
     "h1:356j/3XnXEKr9nyicLUufzoF4Yr6hRy481KIxRVpK0c=",
     "h1:KG4NuIBl1mRWU0KD/BGfCi1YN/j3F7H4YgeeM7iSdNs=",

--- a/environments/development/common/iam-roles.tf
+++ b/environments/development/common/iam-roles.tf
@@ -221,7 +221,6 @@ resource "aws_iam_role" "ci_ecs_deployments_role" {
               "repo:trade-tariff/trade-tariff-backend:*",
               "repo:trade-tariff/trade-tariff-commodi-tea:*",
               "repo:trade-tariff/trade-tariff-dev-hub:*",
-              "repo:trade-tariff/trade-tariff-duty-calculator:*",
               "repo:trade-tariff/trade-tariff-frontend:*",
             ]
           }

--- a/environments/development/common/secrets.tf
+++ b/environments/development/common/secrets.tf
@@ -19,13 +19,6 @@ module "dev_hub_configuration" {
   recovery_window = 7
 }
 
-module "duty_calculator_configuration" {
-  source          = "../../../modules/secret/"
-  name            = "duty-calculator-configuration"
-  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window = 7
-}
-
 module "frontend_configuration" {
   source          = "../../../modules/secret/"
   name            = "frontend-configuration"

--- a/environments/production/applications/locals.tf
+++ b/environments/production/applications/locals.tf
@@ -5,7 +5,6 @@ locals {
     "backend",
     "database-backups",
     "dev-hub",
-    "duty-calculator",
     "fpo-search",
     "frontend",
     "identity",

--- a/environments/production/common/iam-roles.tf
+++ b/environments/production/common/iam-roles.tf
@@ -287,7 +287,6 @@ resource "aws_iam_role" "ci_ecs_deployments_role" {
               "repo:trade-tariff/trade-tariff-backend:*",
               "repo:trade-tariff/trade-tariff-commodi-tea:*",
               "repo:trade-tariff/trade-tariff-dev-hub:*",
-              "repo:trade-tariff/trade-tariff-duty-calculator:*",
               "repo:trade-tariff/trade-tariff-frontend:*",
             ]
           }

--- a/environments/production/common/secrets.tf
+++ b/environments/production/common/secrets.tf
@@ -19,13 +19,6 @@ module "dev_hub_configuration" {
   recovery_window = 7
 }
 
-module "duty_calculator_configuration" {
-  source          = "../../../modules/secret/"
-  name            = "duty-calculator-configuration"
-  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window = 7
-}
-
 module "frontend_configuration" {
   source          = "../../../modules/secret/"
   name            = "frontend-configuration"

--- a/environments/staging/applications/locals.tf
+++ b/environments/staging/applications/locals.tf
@@ -3,7 +3,6 @@ locals {
   applications = [
     "admin",
     "backend",
-    "duty-calculator",
     "dev-hub",
     "frontend",
     "identity",

--- a/environments/staging/common/iam-roles.tf
+++ b/environments/staging/common/iam-roles.tf
@@ -218,7 +218,6 @@ resource "aws_iam_role" "ci_ecs_deployments_role" {
               "repo:trade-tariff/trade-tariff-backend:*",
               "repo:trade-tariff/trade-tariff-commodi-tea:*",
               "repo:trade-tariff/trade-tariff-dev-hub:*",
-              "repo:trade-tariff/trade-tariff-duty-calculator:*",
               "repo:trade-tariff/trade-tariff-frontend:*",
             ]
           }

--- a/environments/staging/common/secrets.tf
+++ b/environments/staging/common/secrets.tf
@@ -20,13 +20,6 @@ module "dev" {
   recovery_window = 7
 }
 
-module "duty_calculator_configuration" {
-  source          = "../../../modules/secret/"
-  name            = "duty-calculator-configuration"
-  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window = 7
-}
-
 module "frontend_configuration" {
   source          = "../../../modules/secret/"
   name            = "frontend-configuration"

--- a/modules/ecr/locals.tf
+++ b/modules/ecr/locals.tf
@@ -36,11 +36,6 @@ locals {
       production_images_to_keep  = 5
       development_images_to_keep = 30
     },
-    "duty-calculator" = {
-      lifecycle_policy           = true
-      production_images_to_keep  = 30
-      development_images_to_keep = 30
-    },
     "frontend" = {
       lifecycle_policy           = true
       production_images_to_keep  = 5


### PR DESCRIPTION
# Jira link

[HMRC-694](https://transformuk.atlassian.net/browse/HMRC-694)

## What?

I have:

- Tidy up duty calculator in development
- Tidy up duty-calculator in staging
- Tidy up duty calculator in production
- Remove duty calculator from ECR locals

## Why?

I am doing this because:

- These are no longer required
