### PR TITLE
HMRC-1207: Enable sidekiq web in staging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ skip-deprovision
 **/builds
 **/tmp
 *.zip
+
+common/lambda/trade-tariff-identity-create-auth-challenge/.bundle/
+common/lambda/trade-tariff-identity-create-auth-challenge/vendor/

--- a/environments/staging/common/alb.tf
+++ b/environments/staging/common/alb.tf
@@ -31,13 +31,21 @@ module "alb" {
     }
 
     backend_uk = {
-      paths            = ["/user/*", "/api/*", "/uk/api/*"]
+      paths = [
+        "/api/*",
+        "/sidekiq*",
+        "/uk/api/*",
+        "/user/*",
+      ]
       healthcheck_path = "/healthcheckz"
       priority         = 20
     }
 
     backend_xi = {
-      paths            = ["/xi/api/*"]
+      paths = [
+        "/xi/api/*",
+        "/xi/sidekiq*",
+      ]
       healthcheck_path = "/healthcheckz"
       priority         = 21
     }


### PR DESCRIPTION
# Jira link

[HMRC-1207](https://transformuk.atlassian.net/browse/HMRC-1207)

## What?

I have:

- Enabled sidekiq web in staging

## Why?

I am doing this because:

- This is for diagnostic purposes and sidekiq web is behind basic auth
