### PR TITLE
HMRC-1288: Adds tools repo access when assuming a role for ECS deployments

### DIFF
--- a/environments/development/common/iam-roles.tf
+++ b/environments/development/common/iam-roles.tf
@@ -222,6 +222,7 @@ resource "aws_iam_role" "ci_ecs_deployments_role" {
               "repo:trade-tariff/trade-tariff-commodi-tea:*",
               "repo:trade-tariff/trade-tariff-dev-hub:*",
               "repo:trade-tariff/trade-tariff-frontend:*",
+              "repo:trade-tariff/trade-tariff-tools:*",
             ]
           }
         }


### PR DESCRIPTION
# Jira link

[HMRC-1288](https://transformuk.atlassian.net/browse/HMRC-1288)

## What?

I have:

- Added permissions to deploy with ECS role in tools workflows in development
- Added permissions to deploy with ECS role in tools workflows in staging
- Added permissions to deploy with ECS role in tools workflows in production

## Why?

I am doing this because:

- This is required for shared workflows in the tools repos that generate tokens for workflow_runs (see https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/about-security-hardening-with-openid-connect#understanding-the-oidc-token)
