### PR TITLE
HMRC-1352: Add trade-tariff-admin to preview app OIDC allowed repos

### DIFF
--- a/environments/development/common/iam-roles.tf
+++ b/environments/development/common/iam-roles.tf
@@ -320,6 +320,7 @@ resource "aws_iam_role" "ci_preview_app_role" {
             "${aws_iam_openid_connect_provider.github_oidc.url}:sub" = [
               "repo:trade-tariff/trade-tariff-frontend:*",
               "repo:trade-tariff/trade-tariff-admin:*",
+              "repo:trade-tariff/trade-tariff-tools:*",
             ]
           }
         }

--- a/environments/development/common/iam-roles.tf
+++ b/environments/development/common/iam-roles.tf
@@ -319,6 +319,7 @@ resource "aws_iam_role" "ci_preview_app_role" {
           StringLike = {
             "${aws_iam_openid_connect_provider.github_oidc.url}:sub" = [
               "repo:trade-tariff/trade-tariff-frontend:*",
+              "repo:trade-tariff/trade-tariff-admin:*",
             ]
           }
         }

--- a/environments/development/common/rds.tf
+++ b/environments/development/common/rds.tf
@@ -65,41 +65,6 @@ module "rw_aurora_connection_string" {
   secret_string   = module.postgres_aurora.rw_connection_string
 }
 
-module "postgres_admin_aurora" {
-  source = "../../../modules/rds_cluster"
-
-  cluster_name      = "admin-aurora-${var.environment}"
-  engine            = "aurora-postgresql"
-  engine_version    = "13.18"
-  engine_mode       = "provisioned"
-  cluster_instances = 1
-  apply_immediately = true
-
-  instance_class = "db.serverless"
-  database_name  = "PostgresAdmin"
-  username       = "tariff"
-
-  encryption_at_rest = true
-
-  min_capacity = 0.5
-  max_capacity = 2
-
-  security_group_ids = [module.alb-security-group.be_to_rds_security_group_id]
-  private_subnet_ids = data.terraform_remote_state.base.outputs.private_subnet_ids
-
-  tags = {
-    "RDS_Type" = "Aurora"
-  }
-}
-
-module "admin_connection_string" {
-  source          = "../../../modules/secret/"
-  name            = "admin-connection-string"
-  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window = 7
-  secret_string   = module.postgres_admin_aurora.rw_connection_string
-}
-
 module "postgres_developer_hub" {
   source = "../../../modules/rds"
 

--- a/environments/staging/common/rds.tf
+++ b/environments/staging/common/rds.tf
@@ -65,41 +65,6 @@ module "rw_aurora_connection_string" {
   secret_string   = module.postgres_aurora.rw_connection_string
 }
 
-module "postgres_admin_aurora" {
-  source = "../../../modules/rds_cluster"
-
-  cluster_name      = "admin-aurora-${var.environment}"
-  engine            = "aurora-postgresql"
-  engine_version    = "13.18"
-  engine_mode       = "provisioned"
-  cluster_instances = 1
-  apply_immediately = true
-
-  instance_class = "db.serverless"
-  database_name  = "PostgresAdmin"
-  username       = "tariff"
-
-  encryption_at_rest = true
-
-  min_capacity = 0.5
-  max_capacity = 2
-
-  security_group_ids = [module.alb-security-group.be_to_rds_security_group_id]
-  private_subnet_ids = data.terraform_remote_state.base.outputs.private_subnet_ids
-
-  tags = {
-    "RDS_Type" = "Aurora"
-  }
-}
-
-module "admin_connection_string" {
-  source          = "../../../modules/secret/"
-  name            = "admin-connection-string"
-  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window = 7
-  secret_string   = module.postgres_admin_aurora.rw_connection_string
-}
-
 module "postgres_developer_hub" {
   source = "../../../modules/rds"
 


### PR DESCRIPTION
# Jira link
[HMRC-1352](https://transformuk.atlassian.net/browse/HMRC-1352)

## What?

I have:

- Added `trade-tariff-admin` repo to the `preview` app OIDC allowed repos
- Edit provider versions
- Deleted the now-unused Aurora clusters for the admin database in development and staging environments

## Why?

I am doing this because:

- This is needed as part of the preview app replication in the admin repo 
- The admin app has migrated to SQLite3, making these database clusters redundant.

