### PR TITLE
HMRC-1402: Adds cache policies for live issues

### DIFF
--- a/environments/development/common/cloudfront.tf
+++ b/environments/development/common/cloudfront.tf
@@ -222,6 +222,32 @@ module "cdn" {
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
 
+    # Live Issues endpoints
+    xi_api_live_issues = {
+      target_origin_id           = "alb"
+      path_pattern               = "/xi/api/v2/live_issues*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+    uk_api_live_issues = {
+      target_origin_id           = "alb"
+      path_pattern               = "/uk/api/v2/live_issues*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+    default_api_live_issues = {
+      target_origin_id           = "alb"
+      path_pattern               = "/api/v2/live_issues*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+
     # API healthcheck endpoints
     xi_api_healthcheck = {
       target_origin_id           = "alb"

--- a/environments/production/common/cloudfront.tf
+++ b/environments/production/common/cloudfront.tf
@@ -222,6 +222,32 @@ module "cdn" {
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
 
+    # Live Issues endpoints
+    xi_api_live_issues = {
+      target_origin_id           = "alb"
+      path_pattern               = "/xi/api/v2/live_issues*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+    uk_api_live_issues = {
+      target_origin_id           = "alb"
+      path_pattern               = "/uk/api/v2/live_issues*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+    default_api_live_issues = {
+      target_origin_id           = "alb"
+      path_pattern               = "/api/v2/live_issues*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+
     # API healthcheck endpoints
     xi_api_healthcheck = {
       target_origin_id           = "alb"

--- a/environments/staging/common/cloudfront.tf
+++ b/environments/staging/common/cloudfront.tf
@@ -222,6 +222,32 @@ module "cdn" {
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     }
 
+    # Live Issues endpoints
+    xi_api_live_issues = {
+      target_origin_id           = "alb"
+      path_pattern               = "/xi/api/v2/live_issues*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+    uk_api_live_issues = {
+      target_origin_id           = "alb"
+      path_pattern               = "/uk/api/v2/live_issues*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+    default_api_live_issues = {
+      target_origin_id           = "alb"
+      path_pattern               = "/api/v2/live_issues*"
+      viewer_protocol_policy     = "redirect-to-https"
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+
     # API healthcheck endpoints
     xi_api_healthcheck = {
       target_origin_id           = "alb"


### PR DESCRIPTION
# Jira link

[HMRC-1402](https://transformuk.atlassian.net/browse/HMRC-1402)

## What?

I have:

- Added cache policies for live issues

## Why?

I am doing this because:

- This content gets authored at random times and is pretty light weight so fine to not cache for now
