### PR TITLE
HMRC-1363: Route adjustments

### DIFF
--- a/environments/development/common/alb.tf
+++ b/environments/development/common/alb.tf
@@ -30,30 +30,29 @@ module "alb" {
       priority         = 10
     }
 
+    backend_xi = {
+      paths = [
+        "/api/xi*",
+        "/xi*",
+      ]
+      healthcheck_path = "/healthcheckz"
+      priority         = 23
+    }
+
     backend_uk = {
       paths = [
         "/api/*",
         "/sidekiq*",
-        "/uk/api/*",
-        "/user/*",
+        "/uk*",
       ]
       healthcheck_path = "/healthcheckz"
-      priority         = 20
-    }
-
-    backend_xi = {
-      paths = [
-        "/xi/api/*",
-        "/xi/sidekiq*",
-      ]
-      healthcheck_path = "/healthcheckz"
-      priority         = 21
+      priority         = 24
     }
 
     hub = {
       hosts            = ["hub.*"]
       healthcheck_path = "/healthcheckz"
-      priority         = 22
+      priority         = 25
     }
 
     frontend = {

--- a/environments/production/common/alb.tf
+++ b/environments/production/common/alb.tf
@@ -30,22 +30,30 @@ module "alb" {
       priority         = 10
     }
 
-    backend_uk = {
-      paths            = ["/user/*", "/api/*", "/uk/api/*"]
+    backend_xi = {
+      paths = [
+        "/api/xi/*",
+        "/xi/api/*"
+      ]
       healthcheck_path = "/healthcheckz"
-      priority         = 20
+      priority         = 23
     }
 
-    backend_xi = {
-      paths            = ["/xi/api/*"]
+    backend_uk = {
+      paths = [
+        "/api/*",
+        "/uk/api/*",
+        "/uk/user/*",
+        "/user/*"
+      ]
       healthcheck_path = "/healthcheckz"
-      priority         = 21
+      priority         = 24
     }
 
     hub = {
       hosts            = ["hub.*"]
       healthcheck_path = "/healthcheckz"
-      priority         = 22
+      priority         = 25
     }
 
     frontend = {

--- a/environments/staging/common/alb.tf
+++ b/environments/staging/common/alb.tf
@@ -30,30 +30,29 @@ module "alb" {
       priority         = 10
     }
 
+    backend_xi = {
+      paths = [
+        "/api/xi*",
+        "/xi*",
+      ]
+      healthcheck_path = "/healthcheckz"
+      priority         = 23
+    }
+
     backend_uk = {
       paths = [
         "/api/*",
         "/sidekiq*",
-        "/uk/api/*",
-        "/user/*",
+        "/uk*",
       ]
       healthcheck_path = "/healthcheckz"
-      priority         = 20
-    }
-
-    backend_xi = {
-      paths = [
-        "/xi/api/*",
-        "/xi/sidekiq*",
-      ]
-      healthcheck_path = "/healthcheckz"
-      priority         = 21
+      priority         = 24
     }
 
     hub = {
       hosts            = ["hub.*"]
       healthcheck_path = "/healthcheckz"
-      priority         = 22
+      priority         = 25
     }
 
     frontend = {


### PR DESCRIPTION
# Jira link

[HMRC-1363](https://transformuk.atlassian.net/browse/HMRC-1363)

## What?

I have:

- Added additional routes that are supported for versioned header variants of API endpoints

## Why?

I am doing this because:

- This is required to support the new routes
