### PR TITLE
HMRC-1446: Fix S3 DeleteObject permission for Terraform state lockfile

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-terraform 1.11.2
+terraform 1.12.2

--- a/environments/production/common/iam-policies.tf
+++ b/environments/production/common/iam-policies.tf
@@ -109,7 +109,8 @@ resource "aws_iam_policy" "ci_ecs_deployment_policy" {
         Action = [
           "s3:GetObject",
           "s3:PutObject",
-          "s3:ListBucket"
+          "s3:ListBucket",
+          "s3:DeleteObject"
         ],
         Resource = [
           "arn:aws:s3:::terraform-state-${var.environment}-${local.account_id}",

--- a/environments/staging/common/iam-policies.tf
+++ b/environments/staging/common/iam-policies.tf
@@ -109,7 +109,8 @@ resource "aws_iam_policy" "ci_ecs_deployment_policy" {
         Action = [
           "s3:GetObject",
           "s3:PutObject",
-          "s3:ListBucket"
+          "s3:ListBucket",
+          "s3:DeleteObject"
         ],
         Resource = [
           "arn:aws:s3:::terraform-state-${var.environment}-${local.account_id}",


### PR DESCRIPTION
# Jira link
[HMRC-1446](https://transformuk.atlassian.net/browse/HMRC-1446)

## What?

I have:

- Updated IAM permissions for the GitHub Actions deployment role to allow `s3:DeleteObject` on the Terraform state lockfile object in the S3 backend.

## Why?

I am doing this because:

- Without this permission, Terraform cannot release the state lock, leading to errors during planning or applying.

- [Terraform `use_lockfile` docs](https://developer.hashicorp.com/terraform/language/settings/backends/s3#use_lockfile)