### PR TITLE
HMRC-1441: Support lifecycle rules for email buckets

### DIFF
--- a/environments/development/common/s3.tf
+++ b/environments/development/common/s3.tf
@@ -12,6 +12,18 @@ locals {
   buckets_with_versioning = {
     persistence = local.buckets.persistence
   }
+  buckets_to_rotate = {
+    database-backups = {
+      bucket = local.buckets.database-backups
+      days   = 60
+      prefix = ""
+    }
+    ses-inbound = {
+      bucket = local.buckets.ses-inbound
+      days   = 1
+      prefix = "inbound/"
+    }
+  }
 }
 
 resource "aws_kms_key" "s3" {
@@ -163,16 +175,20 @@ resource "aws_iam_role_policy" "ses_s3_policy" {
   })
 }
 
-resource "aws_s3_bucket_lifecycle_configuration" "database_backups_rotation" {
-  bucket = aws_s3_bucket.this["database-backups"].id
+resource "aws_s3_bucket_lifecycle_configuration" "this" {
+  for_each = local.buckets_to_rotate
+  bucket   = each.value.bucket
 
   rule {
-    id = "rotate-database-backups"
+    id     = "Rotate ${each.key} bucket"
+    status = "Enabled"
 
     expiration {
-      days = 60
+      days = each.value.days
     }
 
-    status = "Enabled"
+    filter {
+      prefix = each.value.prefix
+    }
   }
 }


### PR DESCRIPTION
# Jira link

[HMRC-1441](https://transformuk.atlassian.net/browse/HMRC-1441)

## What?

I have:

- Added lifecycle rules for development inbound ses bucket
- Added lifecycle rules for staging inbound ses bucket

## Why?

I am doing this because:

- This makes finding targeted emails as part of e2e testing much easier - we currently have a lot of emails to walk through in dev and staging environments
