### PR TITLE
HMRC-1495: Differentiate authenticated cached requests for SPIMM

### DIFF
--- a/environments/development/common/cloudfront-policy.tf
+++ b/environments/development/common/cloudfront-policy.tf
@@ -19,7 +19,11 @@ resource "aws_cloudfront_cache_policy" "very_very_long_cache" {
     headers_config {
       header_behavior = "whitelist"
       headers {
-        items = ["Accept"]
+        items = [
+          "Accept",        # Routes to specific versions of our apis
+          "Authorization", # Enables differentiated caching for authenticated users
+          "X-Api-Key"      # Enables differentiated caching for authenticated users
+        ]
       }
     }
     query_strings_config { query_string_behavior = "all" }
@@ -37,7 +41,11 @@ resource "aws_cloudfront_cache_policy" "long_cache" {
     headers_config {
       header_behavior = "whitelist"
       headers {
-        items = ["Accept"]
+        items = [
+          "Accept",        # Routes to specific versions of our apis
+          "Authorization", # Enables differentiated caching for authenticated users
+          "X-Api-Key"      # Enables differentiated caching for authenticated users
+        ]
       }
     }
     query_strings_config { query_string_behavior = "all" }
@@ -55,7 +63,11 @@ resource "aws_cloudfront_cache_policy" "medium_cache" {
     headers_config {
       header_behavior = "whitelist"
       headers {
-        items = ["Accept"]
+        items = [
+          "Accept",        # Routes to specific versions of our apis
+          "Authorization", # Enables differentiated caching for authenticated users
+          "X-Api-Key"      # Enables differentiated caching for authenticated users
+        ]
       }
     }
     query_strings_config { query_string_behavior = "all" }
@@ -73,7 +85,11 @@ resource "aws_cloudfront_cache_policy" "short_cache" {
     headers_config {
       header_behavior = "whitelist"
       headers {
-        items = ["Accept"]
+        items = [
+          "Accept",        # Routes to specific versions of our apis
+          "Authorization", # Enables differentiated caching for authenticated users
+          "X-Api-Key"      # Enables differentiated caching for authenticated users
+        ]
       }
     }
     query_strings_config { query_string_behavior = "all" }

--- a/environments/development/common/cloudfront-policy.tf
+++ b/environments/development/common/cloudfront-policy.tf
@@ -153,30 +153,6 @@ resource "aws_cloudfront_origin_request_policy" "s3" {
   }
 }
 
-resource "aws_cloudfront_cache_policy" "s3" {
-  name = "s3"
-
-  comment = "Enables caching s3 buckets. Bucket policies restrict specific cloudfront distributions."
-
-  default_ttl = 86400
-  max_ttl     = 31536000
-  min_ttl     = 1
-
-  parameters_in_cache_key_and_forwarded_to_origin {
-    cookies_config {
-      cookie_behavior = "none"
-    }
-
-    headers_config {
-      header_behavior = "none"
-    }
-
-    query_strings_config {
-      query_string_behavior = "all"
-    }
-  }
-}
-
 resource "aws_cloudfront_origin_access_control" "s3" {
   name                              = "s3"
   description                       = "Enables accessing s3 buckets. Bucket policies restrict specific cloudfront distributions."

--- a/environments/development/common/cloudfront.tf
+++ b/environments/development/common/cloudfront.tf
@@ -60,48 +60,8 @@ module "cdn" {
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     },
-    {
-      name                       = "uk_api_spimm"
-      path_pattern               = "/uk/api/v2/green_lanes/*"
-      target_origin_id           = "alb"
-      cache_policy_id            = aws_cloudfront_cache_policy.short_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "uk_api_spimm_unversioned"
-      path_pattern               = "/uk/api/green_lanes/*"
-      target_origin_id           = "alb"
-      cache_policy_id            = aws_cloudfront_cache_policy.short_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "default_api_spimm"
-      path_pattern               = "/api/v2/green_lanes/*"
-      target_origin_id           = "alb"
-      cache_policy_id            = aws_cloudfront_cache_policy.short_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
 
     # Exchange rate endpoints
-    {
-      name                       = "xi_api_exchange_rates"
-      path_pattern               = "/xi/api/v2/exchange_rates/*"
-      target_origin_id           = "alb"
-      cache_policy_id            = aws_cloudfront_cache_policy.medium_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "xi_api_exchange_rates_unversioned"
-      path_pattern               = "/xi/api/exchange_rates/*"
-      target_origin_id           = "alb"
-      cache_policy_id            = aws_cloudfront_cache_policy.medium_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
     {
       name                       = "uk_api_exchange_rates"
       path_pattern               = "/uk/api/v2/exchange_rates/*"
@@ -130,14 +90,6 @@ module "cdn" {
     # Search reference endpoints
     {
       name                       = "xi_api_search_references"
-      path_pattern               = "/xi/api/v2/search_references"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "xi_api_search_references_unversioned"
       path_pattern               = "/xi/api/search_references"
       target_origin_id           = "alb"
       cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
@@ -146,23 +98,7 @@ module "cdn" {
     },
     {
       name                       = "uk_api_search_references"
-      path_pattern               = "/uk/api/v2/search_references"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "uk_api_search_references_unversioned"
       path_pattern               = "/uk/api/search_references"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "default_api_search_references"
-      path_pattern               = "/api/v2/search_references"
       target_origin_id           = "alb"
       cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
@@ -171,82 +107,8 @@ module "cdn" {
 
     # News endpoints
     {
-      name                       = "xi_api_news"
-      path_pattern               = "/xi/api/v2/news*"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "xi_api_news_unversioned"
-      path_pattern               = "/xi/api/news*"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
       name                       = "uk_api_news"
-      path_pattern               = "/uk/api/v2/news*"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "uk_api_news_unversioned"
       path_pattern               = "/uk/api/news*"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "default_api_news"
-      path_pattern               = "/api/v2/news*"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-
-    # Live Issues endpoints
-    {
-      name                       = "xi_api_live_issues"
-      path_pattern               = "/xi/api/v2/live_issues*"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "xi_api_live_issues_unversioned"
-      path_pattern               = "/xi/api/live_issues*"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "uk_api_live_issues"
-      path_pattern               = "/uk/api/v2/live_issues*"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "uk_api_live_issues_unversioned"
-      path_pattern               = "/uk/api/live_issues*"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "default_api_live_issues"
-      path_pattern               = "/api/v2/live_issues*"
       target_origin_id           = "alb"
       cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
@@ -256,14 +118,6 @@ module "cdn" {
     # Healthcheck endpoints
     {
       name                       = "xi_api_healthcheck"
-      path_pattern               = "/xi/api/v2/healthcheck"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "xi_api_healthcheck_unversioned"
       path_pattern               = "/xi/api/healthcheck"
       target_origin_id           = "alb"
       cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
@@ -272,23 +126,7 @@ module "cdn" {
     },
     {
       name                       = "uk_api_healthcheck"
-      path_pattern               = "/uk/api/v2/healthcheck"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "uk_api_healthcheck_unversioned"
       path_pattern               = "/uk/api/healthcheck"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "default_api_healthcheck"
-      path_pattern               = "/api/v2/healthcheck"
       target_origin_id           = "alb"
       cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id

--- a/environments/production/common/cloudfront-policy.tf
+++ b/environments/production/common/cloudfront-policy.tf
@@ -19,7 +19,11 @@ resource "aws_cloudfront_cache_policy" "very_very_long_cache" {
     headers_config {
       header_behavior = "whitelist"
       headers {
-        items = ["Accept"]
+        items = [
+          "Accept",        # Routes to specific versions of our apis
+          "Authorization", # Enables differentiated caching for authenticated users
+          "X-Api-Key"      # Enables differentiated caching for authenticated users
+        ]
       }
     }
     query_strings_config { query_string_behavior = "all" }
@@ -37,7 +41,11 @@ resource "aws_cloudfront_cache_policy" "long_cache" {
     headers_config {
       header_behavior = "whitelist"
       headers {
-        items = ["Accept"]
+        items = [
+          "Accept",        # Routes to specific versions of our apis
+          "Authorization", # Enables differentiated caching for authenticated users
+          "X-Api-Key"      # Enables differentiated caching for authenticated users
+        ]
       }
     }
     query_strings_config { query_string_behavior = "all" }
@@ -55,7 +63,11 @@ resource "aws_cloudfront_cache_policy" "medium_cache" {
     headers_config {
       header_behavior = "whitelist"
       headers {
-        items = ["Accept"]
+        items = [
+          "Accept",        # Routes to specific versions of our apis
+          "Authorization", # Enables differentiated caching for authenticated users
+          "X-Api-Key"      # Enables differentiated caching for authenticated users
+        ]
       }
     }
     query_strings_config { query_string_behavior = "all" }
@@ -73,7 +85,11 @@ resource "aws_cloudfront_cache_policy" "short_cache" {
     headers_config {
       header_behavior = "whitelist"
       headers {
-        items = ["Accept"]
+        items = [
+          "Accept",        # Routes to specific versions of our apis
+          "Authorization", # Enables differentiated caching for authenticated users
+          "X-Api-Key"      # Enables differentiated caching for authenticated users
+        ]
       }
     }
     query_strings_config { query_string_behavior = "all" }

--- a/environments/production/common/cloudfront-policy.tf
+++ b/environments/production/common/cloudfront-policy.tf
@@ -153,30 +153,6 @@ resource "aws_cloudfront_origin_request_policy" "s3" {
   }
 }
 
-resource "aws_cloudfront_cache_policy" "s3" {
-  name = "s3"
-
-  comment = "Enables caching s3 buckets. Bucket policies restrict specific cloudfront distributions."
-
-  default_ttl = 86400
-  max_ttl     = 31536000
-  min_ttl     = 1
-
-  parameters_in_cache_key_and_forwarded_to_origin {
-    cookies_config {
-      cookie_behavior = "none"
-    }
-
-    headers_config {
-      header_behavior = "none"
-    }
-
-    query_strings_config {
-      query_string_behavior = "all"
-    }
-  }
-}
-
 resource "aws_cloudfront_origin_access_control" "s3" {
   name                              = "s3"
   description                       = "Enables accessing s3 buckets. Bucket policies restrict specific cloudfront distributions."

--- a/environments/production/common/cloudfront.tf
+++ b/environments/production/common/cloudfront.tf
@@ -61,48 +61,8 @@ module "cdn" {
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     },
-    {
-      name                       = "uk_api_spimm"
-      path_pattern               = "/uk/api/v2/green_lanes/*"
-      target_origin_id           = "alb"
-      cache_policy_id            = aws_cloudfront_cache_policy.short_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "uk_api_spimm_unversioned"
-      path_pattern               = "/uk/api/green_lanes/*"
-      target_origin_id           = "alb"
-      cache_policy_id            = aws_cloudfront_cache_policy.short_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "default_api_spimm"
-      path_pattern               = "/api/v2/green_lanes/*"
-      target_origin_id           = "alb"
-      cache_policy_id            = aws_cloudfront_cache_policy.short_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
 
     # Exchange rate endpoints
-    {
-      name                       = "xi_api_exchange_rates"
-      path_pattern               = "/xi/api/v2/exchange_rates/*"
-      target_origin_id           = "alb"
-      cache_policy_id            = aws_cloudfront_cache_policy.medium_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "xi_api_exchange_rates_unversioned"
-      path_pattern               = "/xi/api/exchange_rates/*"
-      target_origin_id           = "alb"
-      cache_policy_id            = aws_cloudfront_cache_policy.medium_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
     {
       name                       = "uk_api_exchange_rates"
       path_pattern               = "/uk/api/v2/exchange_rates/*"
@@ -131,14 +91,6 @@ module "cdn" {
     # Search reference endpoints
     {
       name                       = "xi_api_search_references"
-      path_pattern               = "/xi/api/v2/search_references"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "xi_api_search_references_unversioned"
       path_pattern               = "/xi/api/search_references"
       target_origin_id           = "alb"
       cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
@@ -147,23 +99,7 @@ module "cdn" {
     },
     {
       name                       = "uk_api_search_references"
-      path_pattern               = "/uk/api/v2/search_references"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "uk_api_search_references_unversioned"
       path_pattern               = "/uk/api/search_references"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "default_api_search_references"
-      path_pattern               = "/api/v2/search_references"
       target_origin_id           = "alb"
       cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
@@ -172,82 +108,8 @@ module "cdn" {
 
     # News endpoints
     {
-      name                       = "xi_api_news"
-      path_pattern               = "/xi/api/v2/news*"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "xi_api_news_unversioned"
-      path_pattern               = "/xi/api/news*"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
       name                       = "uk_api_news"
-      path_pattern               = "/uk/api/v2/news*"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "uk_api_news_unversioned"
       path_pattern               = "/uk/api/news*"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "default_api_news"
-      path_pattern               = "/api/v2/news*"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-
-    # Live Issues endpoints
-    {
-      name                       = "xi_api_live_issues"
-      path_pattern               = "/xi/api/v2/live_issues*"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "xi_api_live_issues_unversioned"
-      path_pattern               = "/xi/api/live_issues*"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "uk_api_live_issues"
-      path_pattern               = "/uk/api/v2/live_issues*"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "uk_api_live_issues_unversioned"
-      path_pattern               = "/uk/api/live_issues*"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "default_api_live_issues"
-      path_pattern               = "/api/v2/live_issues*"
       target_origin_id           = "alb"
       cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
@@ -257,14 +119,6 @@ module "cdn" {
     # Healthcheck endpoints
     {
       name                       = "xi_api_healthcheck"
-      path_pattern               = "/xi/api/v2/healthcheck"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "xi_api_healthcheck_unversioned"
       path_pattern               = "/xi/api/healthcheck"
       target_origin_id           = "alb"
       cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
@@ -273,23 +127,7 @@ module "cdn" {
     },
     {
       name                       = "uk_api_healthcheck"
-      path_pattern               = "/uk/api/v2/healthcheck"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "uk_api_healthcheck_unversioned"
       path_pattern               = "/uk/api/healthcheck"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "default_api_healthcheck"
-      path_pattern               = "/api/v2/healthcheck"
       target_origin_id           = "alb"
       cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id

--- a/environments/staging/common/cloudfront-policy.tf
+++ b/environments/staging/common/cloudfront-policy.tf
@@ -19,7 +19,11 @@ resource "aws_cloudfront_cache_policy" "very_very_long_cache" {
     headers_config {
       header_behavior = "whitelist"
       headers {
-        items = ["Accept"]
+        items = [
+          "Accept",        # Routes to specific versions of our apis
+          "Authorization", # Enables differentiated caching for authenticated users
+          "X-Api-Key"      # Enables differentiated caching for authenticated users
+        ]
       }
     }
     query_strings_config { query_string_behavior = "all" }
@@ -37,7 +41,11 @@ resource "aws_cloudfront_cache_policy" "long_cache" {
     headers_config {
       header_behavior = "whitelist"
       headers {
-        items = ["Accept"]
+        items = [
+          "Accept",        # Routes to specific versions of our apis
+          "Authorization", # Enables differentiated caching for authenticated users
+          "X-Api-Key"      # Enables differentiated caching for authenticated users
+        ]
       }
     }
     query_strings_config { query_string_behavior = "all" }
@@ -55,7 +63,11 @@ resource "aws_cloudfront_cache_policy" "medium_cache" {
     headers_config {
       header_behavior = "whitelist"
       headers {
-        items = ["Accept"]
+        items = [
+          "Accept",        # Routes to specific versions of our apis
+          "Authorization", # Enables differentiated caching for authenticated users
+          "X-Api-Key"      # Enables differentiated caching for authenticated users
+        ]
       }
     }
     query_strings_config { query_string_behavior = "all" }
@@ -73,7 +85,11 @@ resource "aws_cloudfront_cache_policy" "short_cache" {
     headers_config {
       header_behavior = "whitelist"
       headers {
-        items = ["Accept"]
+        items = [
+          "Accept",        # Routes to specific versions of our apis
+          "Authorization", # Enables differentiated caching for authenticated users
+          "X-Api-Key"      # Enables differentiated caching for authenticated users
+        ]
       }
     }
     query_strings_config { query_string_behavior = "all" }

--- a/environments/staging/common/cloudfront-policy.tf
+++ b/environments/staging/common/cloudfront-policy.tf
@@ -153,30 +153,6 @@ resource "aws_cloudfront_origin_request_policy" "s3" {
   }
 }
 
-resource "aws_cloudfront_cache_policy" "s3" {
-  name = "s3"
-
-  comment = "Enables caching s3 buckets. Bucket policies restrict specific cloudfront distributions."
-
-  default_ttl = 86400
-  max_ttl     = 31536000
-  min_ttl     = 1
-
-  parameters_in_cache_key_and_forwarded_to_origin {
-    cookies_config {
-      cookie_behavior = "none"
-    }
-
-    headers_config {
-      header_behavior = "none"
-    }
-
-    query_strings_config {
-      query_string_behavior = "all"
-    }
-  }
-}
-
 resource "aws_cloudfront_origin_access_control" "s3" {
   name                              = "s3"
   description                       = "Enables accessing s3 buckets. Bucket policies restrict specific cloudfront distributions."

--- a/environments/staging/common/cloudfront.tf
+++ b/environments/staging/common/cloudfront.tf
@@ -60,48 +60,8 @@ module "cdn" {
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     },
-    {
-      name                       = "uk_api_spimm"
-      path_pattern               = "/uk/api/v2/green_lanes/*"
-      target_origin_id           = "alb"
-      cache_policy_id            = aws_cloudfront_cache_policy.short_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "uk_api_spimm_unversioned"
-      path_pattern               = "/uk/api/green_lanes/*"
-      target_origin_id           = "alb"
-      cache_policy_id            = aws_cloudfront_cache_policy.short_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "default_api_spimm"
-      path_pattern               = "/api/v2/green_lanes/*"
-      target_origin_id           = "alb"
-      cache_policy_id            = aws_cloudfront_cache_policy.short_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
 
     # Exchange rate endpoints
-    {
-      name                       = "xi_api_exchange_rates"
-      path_pattern               = "/xi/api/v2/exchange_rates/*"
-      target_origin_id           = "alb"
-      cache_policy_id            = aws_cloudfront_cache_policy.medium_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "xi_api_exchange_rates_unversioned"
-      path_pattern               = "/xi/api/exchange_rates/*"
-      target_origin_id           = "alb"
-      cache_policy_id            = aws_cloudfront_cache_policy.medium_cache.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
     {
       name                       = "uk_api_exchange_rates"
       path_pattern               = "/uk/api/v2/exchange_rates/*"
@@ -130,14 +90,6 @@ module "cdn" {
     # Search reference endpoints
     {
       name                       = "xi_api_search_references"
-      path_pattern               = "/xi/api/v2/search_references"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "xi_api_search_references_unversioned"
       path_pattern               = "/xi/api/search_references"
       target_origin_id           = "alb"
       cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
@@ -146,23 +98,7 @@ module "cdn" {
     },
     {
       name                       = "uk_api_search_references"
-      path_pattern               = "/uk/api/v2/search_references"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "uk_api_search_references_unversioned"
       path_pattern               = "/uk/api/search_references"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "default_api_search_references"
-      path_pattern               = "/api/v2/search_references"
       target_origin_id           = "alb"
       cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
@@ -171,82 +107,8 @@ module "cdn" {
 
     # News endpoints
     {
-      name                       = "xi_api_news"
-      path_pattern               = "/xi/api/v2/news*"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "xi_api_news_unversioned"
-      path_pattern               = "/xi/api/news*"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
       name                       = "uk_api_news"
-      path_pattern               = "/uk/api/v2/news*"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "uk_api_news_unversioned"
       path_pattern               = "/uk/api/news*"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "default_api_news"
-      path_pattern               = "/api/v2/news*"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-
-    # Live Issues endpoints
-    {
-      name                       = "xi_api_live_issues"
-      path_pattern               = "/xi/api/v2/live_issues*"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "xi_api_live_issues_unversioned"
-      path_pattern               = "/xi/api/live_issues*"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "uk_api_live_issues"
-      path_pattern               = "/uk/api/v2/live_issues*"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "uk_api_live_issues_unversioned"
-      path_pattern               = "/uk/api/live_issues*"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "default_api_live_issues"
-      path_pattern               = "/api/v2/live_issues*"
       target_origin_id           = "alb"
       cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
@@ -256,14 +118,6 @@ module "cdn" {
     # Healthcheck endpoints
     {
       name                       = "xi_api_healthcheck"
-      path_pattern               = "/xi/api/v2/healthcheck"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "xi_api_healthcheck_unversioned"
       path_pattern               = "/xi/api/healthcheck"
       target_origin_id           = "alb"
       cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
@@ -272,23 +126,7 @@ module "cdn" {
     },
     {
       name                       = "uk_api_healthcheck"
-      path_pattern               = "/uk/api/v2/healthcheck"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "uk_api_healthcheck_unversioned"
       path_pattern               = "/uk/api/healthcheck"
-      target_origin_id           = "alb"
-      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
-      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    },
-    {
-      name                       = "default_api_healthcheck"
-      path_pattern               = "/api/v2/healthcheck"
       target_origin_id           = "alb"
       cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
@@ -485,7 +323,7 @@ module "api_cdn" {
       cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.s3.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
-    }
+    },
   ]
 
   viewer_certificate = {


### PR DESCRIPTION
# Jira link

[HMRC-1495](https://transformuk.atlassian.net/browse/HMRC-1495)

## What?

I have:

- Added Authorization and X-Api-Key headers to all caching policies
- Removes unused aws_cloudfront_cache_policy in all environments
- Rationalised a bunch of policies for APIs that are either service specific, only called (correctly) via the frontend or manually called by developers of the service

## Why?

I am doing this because:

- We need to differentiate between requests from developers with different Authorization and X-Api-Key headers for the lifecycle of (specifically SPIMM but harmless for other) requests
- The s3 aws_cloudfront_cache_policy isn't referenced/used anywhere so this was an easy tidy
- We having caching policies for apis that are largely used by the frontend and if they're used via regular API users they'll be refreshed anyway on a 24 hour cadenc.
- We also have caching policies that are service specific (e.g. news, user scoped apis) and only consumed by the frontend so these were safe to clear up
- We have a live issues API who cache policy is set to no_cache by the backend which overrides the configuration here, anyway, so we can simplify
- Finally we have healthcheck endpoints that were used exclusively by me and the release notes process so we're safe to specify only the new Accept-header variants with explicit prefixes
