### PR TITLE
BAU: Add admin repo to the e2e test role

### DIFF
--- a/environments/development/common/iam-roles.tf
+++ b/environments/development/common/iam-roles.tf
@@ -359,6 +359,7 @@ resource "aws_iam_role" "e2e_testing_ci_role" {
               "repo:trade-tariff/trade-tariff-frontend:*",
               "repo:trade-tariff/trade-tariff-platform-aws-terraform:*",
               "repo:trade-tariff/trade-tariff-commodi-tea:*",
+              "repo:trade-tariff/trade-tariff-admin:*",
             ]
           }
         }

--- a/environments/staging/common/iam-roles.tf
+++ b/environments/staging/common/iam-roles.tf
@@ -288,6 +288,7 @@ resource "aws_iam_role" "e2e_testing_ci_role" {
               "repo:trade-tariff/trade-tariff-frontend:*",
               "repo:trade-tariff/trade-tariff-platform-aws-terraform:*",
               "repo:trade-tariff/trade-tariff-commodi-tea:*",
+              "repo:trade-tariff/trade-tariff-admin:*",
             ]
           }
         }


### PR DESCRIPTION
# Jira link

## What?

I have:

- Added `trade-tariff-admin` to the list of access allowed repos in the e2e testing role in staging and dev

## Why?

I am doing this because:

- We need that to enable the e2e test run for the admin app
