### PR TITLE
HMRC-947: Update terraform IAM policy

### DIFF
--- a/environments/production/common/iam-policies.tf
+++ b/environments/production/common/iam-policies.tf
@@ -22,6 +22,7 @@ resource "aws_iam_policy" "ci_terraform_policy" {
           "elasticloadbalancing:*",
           "es:*",
           "events:*",
+          "firehose:*",
           "iam:*",
           "kms:*",
           "lambda:*",


### PR DESCRIPTION
# Jira link
(HMRC-947[https://transformuk.atlassian.net/browse/HMRC-947]
## What?

I have:

- Added firehose:* permissions to the CI Terraform IAM policy.

## Why?

I am doing this because:

- The workflow needs Firehose permissions to create and tag Kinesis delivery streams for New Relic integration.
