### PR TITLE
Fix: Firehose delivery stream logging configuration

### DIFF
--- a/modules/firehose_delivery/main.tf
+++ b/modules/firehose_delivery/main.tf
@@ -38,9 +38,14 @@ resource "aws_iam_role_policy" "firehose_policy" {
         {
           Effect = "Allow"
           Action = [
-            "logs:PutLogEvents"
+            "logs:PutLogEvents",
+            "logs:CreateLogStream",
+            "logs:DescribeLogStreams"
           ]
-          Resource = ["*"]
+          Resource = [
+            aws_cloudwatch_log_group.firehose_log_group.arn,       # log group
+            "${aws_cloudwatch_log_group.firehose_log_group.arn}:*" # streams under log group
+          ]
         },
         {
           Effect = "Allow"
@@ -78,8 +83,9 @@ resource "aws_kinesis_firehose_delivery_stream" "nr_stream" {
       compression_format = "GZIP"
 
       cloudwatch_logging_options {
-        enabled        = true
-        log_group_name = aws_cloudwatch_log_group.firehose_log_group.name
+        enabled         = true
+        log_group_name  = aws_cloudwatch_log_group.firehose_log_group.name
+        log_stream_name = "s3-backup-delivery"
       }
     }
 
@@ -88,8 +94,9 @@ resource "aws_kinesis_firehose_delivery_stream" "nr_stream" {
     }
 
     cloudwatch_logging_options {
-      enabled        = true
-      log_group_name = aws_cloudwatch_log_group.firehose_log_group.name
+      enabled         = true
+      log_group_name  = aws_cloudwatch_log_group.firehose_log_group.name
+      log_stream_name = "http-endpoint-delivery"
     }
   }
 }


### PR DESCRIPTION
# Jira link

## What?

I have:

- Added `log_stream_name` to both `cloudwatch_logging_options` blocks (HTTP endpoint and S3 backup).
- Updated IAM policy to include:
  - `logs:CreateLogStream`
  - `logs:DescribeLogStreams`

## Why?

I am doing this because:

- AWS Firehose requires a log stream name when CloudWatch logging is enabled. Without it, `terraform apply` fails during `UpdateDestination`.
