### PR TITLE
HMRC-1526: Removes unused consumer/cognito group

### DIFF
--- a/common/lambda/trade-tariff-identity-create-auth-challenge/lambda_function.rb
+++ b/common/lambda/trade-tariff-identity-create-auth-challenge/lambda_function.rb
@@ -7,9 +7,8 @@ def lambda_handler(event:, context:)
   api_key = ENV['GOVUK_NOTIFY_API_KEY']
   notify = Notifications::Client.new(api_key)
   email = event.dig('request', 'userAttributes', 'email')
-  consumer = 'myott'
   token = SecureRandom.hex(32)
-  auth_link = "#{url}/passwordless/callback?email=#{CGI.escape(email)}&token=#{token}&consumer=#{consumer}"
+  auth_link = "#{url}/passwordless/callback?email=#{CGI.escape(email)}&token=#{token}"
 
   notify.send_email(
     email_address: email,

--- a/environments/development/common/cognito-identity.tf
+++ b/environments/development/common/cognito-identity.tf
@@ -53,6 +53,14 @@ module "identity_cognito" {
     {
       name        = "myott"
       description = "MyOTT user group"
+    },
+    {
+      name        = "admin"
+      description = "Admin user group. See https://admin.trade-tariff.service.gov.uk"
+    },
+    {
+      name        = "portal"
+      description = "Developer Portal user group. See https://portal.trade-tariff.service.gov.uk"
     }
   ]
 }


### PR DESCRIPTION
# Jira link

[HMRC-1526](https://transformuk.atlassian.net/browse/HMRC-1526)

## What?

I have:

- HMRC-1526: Removes consumer from create-auth-challenge lambda
- HMRC-1527: Adds admin and portal consumer to identity cognito portal

## Why?

I am doing this because:

- This is part of the configuration of passwordless authentication for both the admin and portal applications
