### PR TITLE
HMRC-1604: Postgres 17

### DIFF
--- a/environments/development/common/rds.tf
+++ b/environments/development/common/rds.tf
@@ -37,7 +37,7 @@ module "postgres_aurora" {
 
   cluster_name      = "postgres-aurora-${var.environment}"
   engine            = "aurora-postgresql"
-  engine_version    = "17.6"
+  engine_version    = "17.5"
   engine_mode       = "provisioned"
   cluster_instances = 2
   apply_immediately = true

--- a/environments/development/common/rds.tf
+++ b/environments/development/common/rds.tf
@@ -4,7 +4,7 @@ module "postgres_commodi_tea" {
   environment    = var.environment
   name           = "PostgresCommodiTea"
   engine         = "postgres"
-  engine_version = "16.8"
+  engine_version = "17.6"
 
   deletion_protection = false
   multi_az            = false
@@ -37,7 +37,7 @@ module "postgres_aurora" {
 
   cluster_name      = "postgres-aurora-${var.environment}"
   engine            = "aurora-postgresql"
-  engine_version    = "16.8"
+  engine_version    = "17.6"
   engine_mode       = "provisioned"
   cluster_instances = 2
   apply_immediately = true
@@ -71,7 +71,7 @@ module "postgres_developer_hub" {
   environment    = var.environment
   name           = "PostgresDeveloperHub"
   engine         = "postgres"
-  engine_version = "17.4"
+  engine_version = "17.6"
 
   deletion_protection = false
   multi_az            = false

--- a/environments/staging/common/rds.tf
+++ b/environments/staging/common/rds.tf
@@ -37,7 +37,7 @@ module "postgres_aurora" {
 
   cluster_name      = "postgres-aurora-${var.environment}"
   engine            = "aurora-postgresql"
-  engine_version    = "17.6"
+  engine_version    = "17.5"
   engine_mode       = "provisioned"
   cluster_instances = 2
   apply_immediately = true

--- a/environments/staging/common/rds.tf
+++ b/environments/staging/common/rds.tf
@@ -4,7 +4,7 @@ module "postgres_commodi_tea" {
   environment    = var.environment
   name           = "PostgresCommodiTea"
   engine         = "postgres"
-  engine_version = "16.8"
+  engine_version = "17.6"
 
   deletion_protection = false
   multi_az            = false
@@ -37,7 +37,7 @@ module "postgres_aurora" {
 
   cluster_name      = "postgres-aurora-${var.environment}"
   engine            = "aurora-postgresql"
-  engine_version    = "16.8"
+  engine_version    = "17.6"
   engine_mode       = "provisioned"
   cluster_instances = 2
   apply_immediately = true
@@ -71,7 +71,7 @@ module "postgres_developer_hub" {
   environment    = var.environment
   name           = "PostgresDeveloperHub"
   engine         = "postgres"
-  engine_version = "17.4"
+  engine_version = "17.6"
 
   deletion_protection = false
   multi_az            = false

--- a/environments/staging/common/rds.tf
+++ b/environments/staging/common/rds.tf
@@ -4,7 +4,7 @@ module "postgres_commodi_tea" {
   environment    = var.environment
   name           = "PostgresCommodiTea"
   engine         = "postgres"
-  engine_version = "17.6"
+  engine_version = "16.8"
 
   deletion_protection = false
   multi_az            = false
@@ -37,7 +37,7 @@ module "postgres_aurora" {
 
   cluster_name      = "postgres-aurora-${var.environment}"
   engine            = "aurora-postgresql"
-  engine_version    = "17.5"
+  engine_version    = "16.8"
   engine_mode       = "provisioned"
   cluster_instances = 2
   apply_immediately = true
@@ -71,7 +71,7 @@ module "postgres_developer_hub" {
   environment    = var.environment
   name           = "PostgresDeveloperHub"
   engine         = "postgres"
-  engine_version = "17.6"
+  engine_version = "17.4"
 
   deletion_protection = false
   multi_az            = false


### PR DESCRIPTION
# Jira link

[HMRC-1604](https://transformuk.atlassian.net/browse/HMRC-1604)

## What?

I have:

- Bumps postgresql to 17.6 in development
- Bumps postgresql to 17.6 in staging

## Why?

I am doing this because:

- This is required to prove 17 in live environments before we promote to production
