### PR TITLE
HMRC-1568: Add lambdas error alarm

### DIFF
--- a/environments/development/common/locals.tf
+++ b/environments/development/common/locals.tf
@@ -6,4 +6,13 @@ locals {
     "../../../modules/cloudfront-auth.js.tpl",
     { base64 = data.aws_secretsmanager_secret_version.backups_basic_auth.secret_string }
   )
+
+  monitored_lambdas = {
+    database-backups      = "database-backups-development-backup"
+    fpo-search            = "trade-tariff-lambdas-fpo-search-development-fpo_search"
+    fpo-garbage-collector = "fpo-model-garbage-collection-development-collector"
+    verify-auth-challenge = "trade-tariff-identity-verify-auth-challenge-response"
+    create-auth-challenge = "trade-tariff-identity-create-auth-challenge"
+    define-auth-challenge = "trade-tariff-identity-define-auth-challenge"
+  }
 }

--- a/environments/production/common/locals.tf
+++ b/environments/production/common/locals.tf
@@ -6,4 +6,13 @@ locals {
     "../../../modules/cloudfront-auth.js.tpl",
     { base64 = data.aws_secretsmanager_secret_version.backups_basic_auth.secret_string }
   )
+
+  monitored_lambdas = {
+    database-backups      = "database-backups-production-backup"
+    fpo-search            = "trade-tariff-lambdas-fpo-search-production-fpo_search"
+    fpo-garbage-collector = "fpo-model-garbage-collection-production-collector"
+    verify-auth-challenge = "trade-tariff-identity-verify-auth-challenge-response"
+    create-auth-challenge = "trade-tariff-identity-create-auth-challenge"
+    define-auth-challenge = "trade-tariff-identity-define-auth-challenge"
+  }
 }

--- a/environments/staging/common/locals.tf
+++ b/environments/staging/common/locals.tf
@@ -6,4 +6,13 @@ locals {
     "../../../modules/cloudfront-auth.js.tpl",
     { base64 = data.aws_secretsmanager_secret_version.backups_basic_auth.secret_string }
   )
+
+  monitored_lambdas = {
+    database-backups      = "database-backups-staging-backup"
+    fpo-search            = "trade-tariff-lambdas-fpo-search-staging-fpo_search"
+    fpo-garbage-collector = "fpo-model-garbage-collection-staging-collector"
+    verify-auth-challenge = "trade-tariff-identity-verify-auth-challenge-response"
+    create-auth-challenge = "trade-tariff-identity-create-auth-challenge"
+    define-auth-challenge = "trade-tariff-identity-define-auth-challenge"
+  }
 }


### PR DESCRIPTION
# Jira link

[HMRC-1568](https://transformuk.atlassian.net/browse/HMRC-1568)

## What?

I have:

- Added CloudWatch alerts for Lambda functions in all three environments (dev, staging, production).

## Why?

I am doing this because:

- See Jira ticket above
