### PR TITLE
BAU: Adds dev hub repo to run FPO tests

### DIFF
--- a/environments/development/common/iam-roles.tf
+++ b/environments/development/common/iam-roles.tf
@@ -357,6 +357,7 @@ resource "aws_iam_role" "e2e_testing_ci_role" {
               "repo:trade-tariff/trade-tariff-admin:*",
               "repo:trade-tariff/trade-tariff-backend:*",
               "repo:trade-tariff/trade-tariff-commodi-tea:*",
+              "repo:trade-tariff/trade-tariff-dev-hub:*",
               "repo:trade-tariff/trade-tariff-e2e-tests:*",
               "repo:trade-tariff/trade-tariff-fpo-dev-hub-e2e:*",
               "repo:trade-tariff/trade-tariff-frontend:*",

--- a/environments/development/common/iam-roles.tf
+++ b/environments/development/common/iam-roles.tf
@@ -361,6 +361,7 @@ resource "aws_iam_role" "e2e_testing_ci_role" {
               "repo:trade-tariff/trade-tariff-e2e-tests:*",
               "repo:trade-tariff/trade-tariff-fpo-dev-hub-e2e:*",
               "repo:trade-tariff/trade-tariff-frontend:*",
+              "repo:trade-tariff/trade-tariff-lambdas-fpo-search:*",
               "repo:trade-tariff/trade-tariff-platform-aws-terraform:*",
             ]
           }

--- a/environments/staging/common/iam-roles.tf
+++ b/environments/staging/common/iam-roles.tf
@@ -287,6 +287,7 @@ resource "aws_iam_role" "e2e_testing_ci_role" {
               "repo:trade-tariff/trade-tariff-admin:*",
               "repo:trade-tariff/trade-tariff-backend:*",
               "repo:trade-tariff/trade-tariff-commodi-tea:*",
+              "repo:trade-tariff/trade-tariff-dev-hub:*",
               "repo:trade-tariff/trade-tariff-e2e-tests:*",
               "repo:trade-tariff/trade-tariff-fpo-dev-hub-e2e:*",
               "repo:trade-tariff/trade-tariff-frontend:*",

--- a/environments/staging/common/iam-roles.tf
+++ b/environments/staging/common/iam-roles.tf
@@ -291,6 +291,7 @@ resource "aws_iam_role" "e2e_testing_ci_role" {
               "repo:trade-tariff/trade-tariff-e2e-tests:*",
               "repo:trade-tariff/trade-tariff-fpo-dev-hub-e2e:*",
               "repo:trade-tariff/trade-tariff-frontend:*",
+              "repo:trade-tariff/trade-tariff-lambdas-fpo-search:*",
               "repo:trade-tariff/trade-tariff-platform-aws-terraform:*",
             ]
           }


### PR DESCRIPTION
# Jira link

BAU

## What?

I have:

- Added dev hub to repos that can assume e2e tests role

## Why?

I am doing this because:

- This is needed to run the FPO tests there
