### PR TITLE
MyOTT-544 Rotate files with data/export prefix in s3 Persistence Bucket

### DIFF
--- a/environments/development/common/s3.tf
+++ b/environments/development/common/s3.tf
@@ -23,6 +23,11 @@ locals {
       days   = 1
       prefix = "inbound/"
     }
+    persistence = {
+      bucket = local.buckets.persistence
+      days   = 30
+      prefix = "data/export/"
+    }
   }
 }
 

--- a/environments/production/common/s3.tf
+++ b/environments/production/common/s3.tf
@@ -157,6 +157,23 @@ resource "aws_s3_bucket_lifecycle_configuration" "firehose_backups_rotation" {
   }
 }
 
+resource "aws_s3_bucket_lifecycle_configuration" "persistence_rotation" {
+  bucket = aws_s3_bucket.this["persistence"].id
+
+  rule {
+    id     = "rotate-persistence-export"
+    status = "Enabled"
+
+    filter {
+      prefix = "data/export/"
+    }
+
+    expiration {
+      days = 30
+    }
+  }
+}
+
 # NOTE: READONLY cross-account access for persistence bucket to allow backend jobs to replicate exchange rate data
 data "aws_iam_policy_document" "persistence_cross_account_policy" {
   statement {

--- a/environments/staging/common/.terraform.lock.hcl
+++ b/environments/staging/common/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/archive" {
   version     = "2.7.1"
   constraints = ">= 2.0.0, 2.7.1"
   hashes = [
+    "h1:A7EnRBVm4h9ryO9LwxYnKr4fy7ExPMwD5a1DsY7m1Y0=",
     "h1:Tr6LvLbm30zX4BRNPHhXo8SnOP0vg5UKAeunRNfnas8=",
     "zh:19881bb356a4a656a865f48aee70c0b8a03c35951b7799b6113883f67f196e8e",
     "zh:2fcfbf6318dd514863268b09bbe19bfc958339c636bcbcc3664b45f2b8bf5cc6",
@@ -26,6 +27,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = ">= 4.9.0, >= 6.0.0"
   hashes = [
     "h1:tG2N7S54admlDbTjy5/T8QzGivR0WUcBOEahlZRnxUw=",
+    "h1:wXPejniDcbqRtL2zzaeZsmjLe7NekeYD5QjlIzUOylI=",
     "zh:1e49dc96bf50633583e3cbe23bb357642e7e9afe135f54e061e26af6310e50d2",
     "zh:45651bb4dad681f17782d99d9324de182a7bb9fbe9dd22f120fdb7fe42969cc9",
     "zh:5880c306a427128124585b460c53bbcab9fb3767f26f796eae204f65f111a927",
@@ -49,6 +51,7 @@ provider "registry.terraform.io/hashicorp/external" {
   constraints = ">= 1.0.0, >= 2.3.5"
   hashes = [
     "h1:1JSWWSmVSxzHGbD4RmaNUsdGsr2hPo+WwYaluyWv7vY=",
+    "h1:FnUk98MI5nOh3VJ16cHf8mchQLewLfN1qZG/MqNgPrI=",
     "zh:6e89509d056091266532fa64de8c06950010498adf9070bf6ff85bc485a82562",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
     "zh:86868aec05b58dc0aa1904646a2c26b9367d69b890c9ad70c33c0d3aa7b1485a",
@@ -69,6 +72,7 @@ provider "registry.terraform.io/hashicorp/local" {
   constraints = ">= 1.0.0"
   hashes = [
     "h1:SY06ZmR7rY7QMGoVEkeFrERVitBp2GKl/ATz9tbjXlk=",
+    "h1:sSwlfp2etjCaE9hIF7bJBDjRIhDCVFglEOVyiCI7vgs=",
     "zh:261fec71bca13e0a7812dc0d8ae9af2b4326b24d9b2e9beab3d2400fab5c5f9a",
     "zh:308da3b5376a9ede815042deec5af1050ec96a5a5410a2206ae847d82070a23e",
     "zh:3d056924c420464dc8aba10e1915956b2e5c4d55b11ffff79aa8be563fbfe298",
@@ -89,6 +93,7 @@ provider "registry.terraform.io/hashicorp/null" {
   constraints = ">= 2.0.0, >= 3.0.0"
   hashes = [
     "h1:127ts0CG8hFk1bHIfrBsKxcnt9bAYQCq3udWM+AACH8=",
+    "h1:L5V05xwp/Gto1leRryuesxjMfgZwjb7oool4WS1UEFQ=",
     "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
     "zh:795c897119ff082133150121d39ff26cb5f89a730a2c8c26f3a9c1abf81a9c43",
@@ -109,6 +114,7 @@ provider "registry.terraform.io/hashicorp/random" {
   constraints = ">= 3.0.0"
   hashes = [
     "h1:fdfOl1HabDT42XLH8qjmfTbVZpgQZ5lyOyOa+GQhm0w=",
+    "h1:u8AKlWVDTH5r9YLSeswoVEjiY72Rt4/ch7U+61ZDkiQ=",
     "zh:08dd03b918c7b55713026037c5400c48af5b9f468f483463321bd18e17b907b4",
     "zh:0eee654a5542dc1d41920bbf2419032d6f0d5625b03bd81339e5b33394a3e0ae",
     "zh:229665ddf060aa0ed315597908483eee5b818a17d09b6417a0f52fd9405c4f57",
@@ -128,6 +134,7 @@ provider "registry.terraform.io/hashicorp/tls" {
   version     = "4.2.1"
   constraints = ">= 4.0.0"
   hashes = [
+    "h1:akFNuHwvrtnYMBofieoeXhPJDhYZzJVu/Q/BgZK2fgg=",
     "h1:wTIzrwUB7NINYwLFYLdWkJQwg1r9XT6rVOGrZ1+lMmI=",
     "zh:0d1e7d07ac973b97fa228f46596c800de830820506ee145626f079dd6bbf8d8a",
     "zh:5c7e3d4348cb4861ab812973ef493814a4b224bdd3e9d534a7c8a7c992382b86",
@@ -148,6 +155,7 @@ provider "registry.terraform.io/newrelic/newrelic" {
   version     = "3.80.2"
   constraints = ">= 3.78.0"
   hashes = [
+    "h1:27JrzUDK8ac582u/2ry3be21x7Ee6CNLTMhlH7xsddo=",
     "h1:qRM9Ws16wk4qDZ7uO8NxmrMPo/g6xSl0zCc5OsE3GQk=",
     "zh:0cc5bf8802e3364e2b1cbb246cf013852e0faf3cdc8c9d997a67cb46cf1458f5",
     "zh:13380982c9f48de2e2987da0a1ce1094a337df0d1098cc8be7b7940682315dc5",

--- a/environments/staging/common/s3.tf
+++ b/environments/staging/common/s3.tf
@@ -24,6 +24,11 @@ locals {
       days   = 5
       prefix = "inbound/"
     }
+    persistence = {
+      bucket = local.buckets.persistence
+      days   = 30
+      prefix = "data/export/"
+    }
   }
 }
 


### PR DESCRIPTION
# Jira link

[MyOTT-544](https://transformuk.atlassian.net/browse/MYOTT-544)

## What?

I have:

- Added 30 day rotation for exported data files in persistence s3 bucket

## Why?

I am doing this because:

- We want to periodically clear out old exported data files
