### PR TITLE
BAU: Upgrade gateway Security policy

### DIFF
--- a/modules/api-gateway/domain.tf
+++ b/modules/api-gateway/domain.tf
@@ -1,6 +1,8 @@
 resource "aws_api_gateway_domain_name" "api" {
   domain_name              = "api.${var.domain_name}"
   regional_certificate_arn = var.validated_certificate_arn
+  security_policy          = "SecurityPolicy_TLS13_1_2_2021_06"
+  endpoint_access_mode     = "BASIC" # TODO After you validate your traffic and access logs, set the endpoint access mode to STRICT
 
   endpoint_configuration {
     types = ["REGIONAL"]


### PR DESCRIPTION
# Jira link

## What?

I have:

- Updated the API Gateway custom domain security policy from `TLS_1_2` (legacy default) to `SecurityPolicy_TLS13_1_2_2021_06` in `aws_api_gateway_domain_name.api.`

## Why?

I am doing this because:

- To enforce stronger, modern TLS standards, improve security posture, ensure better encryption, and align with current compliance requirements.

Link to AWS Docs
- [Choose a security policy for your custom domain in API Gateway](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-custom-domain-tls-version.html)
- [Security policies for REST APIs in API Gateway](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-security-policies.html#apigateway-security-policies-endpoint-access-mode)