### PR TITLE
HMRC-1965: Remove HTTP fallback and tighten security groups

### DIFF
--- a/environments/development/common/alb.tf
+++ b/environments/development/common/alb.tf
@@ -6,7 +6,6 @@ module "alb" {
   public_subnet_ids     = data.terraform_remote_state.base.outputs.public_subnet_ids
   vpc_id                = data.terraform_remote_state.base.outputs.vpc_id
   domain_name           = var.domain_name
-  protocol              = "https"
 
   custom_header = {
     name  = random_password.origin_header[0].result

--- a/environments/production/common/alb.tf
+++ b/environments/production/common/alb.tf
@@ -7,7 +7,6 @@ module "alb" {
   vpc_id                = data.terraform_remote_state.base.outputs.vpc_id
   enable_access_logs    = true
   domain_name           = var.domain_name
-  protocol              = "https"
 
   custom_header = {
     name  = random_password.origin_header[0].result

--- a/environments/staging/common/alb.tf
+++ b/environments/staging/common/alb.tf
@@ -6,7 +6,6 @@ module "alb" {
   public_subnet_ids     = data.terraform_remote_state.base.outputs.public_subnet_ids
   vpc_id                = data.terraform_remote_state.base.outputs.vpc_id
   domain_name           = var.domain_name
-  protocol              = "https"
 
   custom_header = {
     name  = random_password.origin_header[0].result

--- a/modules/application-load-balancer/README.md
+++ b/modules/application-load-balancer/README.md
@@ -51,7 +51,6 @@ No modules.
 | [aws_lb_listener_rule.redirect_http_rules](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener_rule) | resource |
 | [aws_lb_listener_rule.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener_rule) | resource |
 | [aws_lb_target_group.trade_tariff_https_target_groups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
-| [aws_lb_target_group.trade_tariff_target_groups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
 | [aws_s3_bucket.access_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_lifecycle_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
 | [aws_s3_bucket_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
@@ -68,7 +67,6 @@ No modules.
 | <a name="input_access_logs_prefix"></a> [access\_logs\_prefix](#input\_access\_logs\_prefix) | S3 object prefix for access log entries. | `string` | `null` | no |
 | <a name="input_alb_name"></a> [alb\_name](#input\_alb\_name) | The name of the alb | `string` | n/a | yes |
 | <a name="input_alb_security_group_id"></a> [alb\_security\_group\_id](#input\_alb\_security\_group\_id) | Application load balancer security group ID. | `string` | n/a | yes |
-| <a name="input_application_port"></a> [application\_port](#input\_application\_port) | Port the application exposes. | `string` | `8080` | no |
 | <a name="input_certificate_arn"></a> [certificate\_arn](#input\_certificate\_arn) | ARN of the default SSL server certificate. | `string` | n/a | yes |
 | <a name="input_custom_header"></a> [custom\_header](#input\_custom\_header) | Custom header required in all requests to the load balancer. | <pre>object({<br/>    name  = string<br/>    value = string<br/>  })</pre> | n/a | yes |
 | <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | The domain name for the application. | `string` | n/a | yes |
@@ -78,7 +76,6 @@ No modules.
 | <a name="input_gateway_services"></a> [gateway\_services](#input\_gateway\_services) | Map of services to make ALB target groups and listener rules for routable from API Gateway. | <pre>map(<br/>    object({<br/>      healthcheck_path = string<br/>      hosts            = optional(list(string))<br/>      paths            = optional(list(string))<br/>      priority         = number<br/>    })<br/>  )</pre> | `{}` | no |
 | <a name="input_idle_timeout"></a> [idle\_timeout](#input\_idle\_timeout) | The time in seconds that the connection is allowed to be idle. | `string` | `60` | no |
 | <a name="input_listening_port"></a> [listening\_port](#input\_listening\_port) | Port on which the load balancer listens to. | `string` | `443` | no |
-| <a name="input_protocol"></a> [protocol](#input\_protocol) | Protocol the application exposes. | `string` | `"http"` | no |
 | <a name="input_public_subnet_ids"></a> [public\_subnet\_ids](#input\_public\_subnet\_ids) | Public subnet IDs | `list(any)` | n/a | yes |
 | <a name="input_services"></a> [services](#input\_services) | Map of services to make ALB target groups and listener rules for. | <pre>map(<br/>    object({<br/>      healthcheck_path = string<br/>      hosts            = optional(list(string))<br/>      paths            = optional(list(string))<br/>      priority         = number<br/>    })<br/>  )</pre> | n/a | yes |
 | <a name="input_tls_application_port"></a> [tls\_application\_port](#input\_tls\_application\_port) | Port the application exposes on HTTPS. | `string` | `8443` | no |

--- a/modules/application-load-balancer/main.tf
+++ b/modules/application-load-balancer/main.tf
@@ -22,35 +22,6 @@ resource "aws_lb" "application_load_balancer" {
   }
 }
 
-
-/* target group name cannot be longer than 32 chars */
-resource "aws_lb_target_group" "trade_tariff_target_groups" {
-  for_each             = var.services
-  name                 = replace(each.key, "_", "-")
-  port                 = var.application_port
-  protocol             = "HTTP"
-  target_type          = "ip"
-  vpc_id               = var.vpc_id
-  deregistration_delay = 20
-
-  lifecycle {
-    create_before_destroy = true
-  }
-
-  health_check {
-    enabled             = true
-    interval            = 60
-    path                = each.value.healthcheck_path
-    port                = "traffic-port"
-    healthy_threshold   = 3
-    unhealthy_threshold = 3
-    timeout             = 6
-    protocol            = "HTTP"
-    matcher             = "200"
-  }
-}
-
-
 resource "aws_lb_target_group" "trade_tariff_https_target_groups" {
   for_each = var.services
 
@@ -101,19 +72,8 @@ resource "aws_lb_listener_rule" "redirect_http_rules" {
   priority = each.value.priority
 
   action {
-    type = "forward"
-
-    forward {
-      target_group {
-        arn    = aws_lb_target_group.trade_tariff_https_target_groups[each.key].arn
-        weight = lookup(each.value, "target_group_protocol", var.protocol) == "https" ? 100 : 0
-      }
-
-      target_group {
-        arn    = aws_lb_target_group.trade_tariff_target_groups[each.key].arn
-        weight = lookup(each.value, "target_group_protocol", var.protocol) == "https" ? 0 : 100
-      }
-    }
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.trade_tariff_https_target_groups[each.key].arn
   }
 
   dynamic "condition" {
@@ -157,19 +117,8 @@ resource "aws_lb_listener_rule" "this" {
   priority = each.value.priority
 
   action {
-    type = "forward"
-
-    forward {
-      target_group {
-        arn    = aws_lb_target_group.trade_tariff_https_target_groups[each.key].arn
-        weight = var.protocol == "https" ? 100 : 0
-      }
-
-      target_group {
-        arn    = aws_lb_target_group.trade_tariff_target_groups[each.key].arn
-        weight = var.protocol == "https" ? 0 : 100
-      }
-    }
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.trade_tariff_https_target_groups[each.key].arn
   }
 
   dynamic "condition" {

--- a/modules/application-load-balancer/outputs.tf
+++ b/modules/application-load-balancer/outputs.tf
@@ -16,7 +16,7 @@ output "arn_suffix" {
 output "target_groups" {
   description = "List of target groups."
   value = {
-    for tg in aws_lb_target_group.trade_tariff_target_groups :
+    for tg in aws_lb_target_group.trade_tariff_https_target_groups :
     tg.name => {
       name = tg.name,
       arn  = tg.arn

--- a/modules/application-load-balancer/variables.tf
+++ b/modules/application-load-balancer/variables.tf
@@ -3,22 +3,10 @@ variable "alb_security_group_id" {
   type        = string
 }
 
-variable "application_port" {
-  description = "Port the application exposes."
-  type        = string
-  default     = 8080
-}
-
 variable "tls_application_port" {
   description = "Port the application exposes on HTTPS."
   type        = string
   default     = 8443
-}
-
-variable "protocol" {
-  description = "Protocol the application exposes."
-  type        = string
-  default     = "http"
 }
 
 variable "listening_port" {

--- a/modules/security-group/security-group.tf
+++ b/modules/security-group/security-group.tf
@@ -43,15 +43,6 @@ resource "aws_security_group" "ecs_security_group" {
   description = "Allow HTTP/S ingress, all egress"
   vpc_id      = var.vpc_id
 
-  # ingress traffic from alb
-  ingress {
-    description = "HTTPS Access From ALB"
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = ["10.0.0.0/16"]
-  }
-
   ingress {
     description = "8443 access from ALB"
     from_port   = 8443

--- a/modules/security-group/security-group.tf
+++ b/modules/security-group/security-group.tf
@@ -45,25 +45,9 @@ resource "aws_security_group" "ecs_security_group" {
 
   # ingress traffic from alb
   ingress {
-    description = "HTTP Access from ALB"
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = ["10.0.0.0/16"]
-  }
-
-  ingress {
     description = "HTTPS Access From ALB"
     from_port   = 443
     to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = ["10.0.0.0/16"]
-  }
-
-  ingress {
-    description = "8080 access from ALB"
-    from_port   = 8080
-    to_port     = 8080
     protocol    = "tcp"
     cidr_blocks = ["10.0.0.0/16"]
   }


### PR DESCRIPTION
# Jira link
[HMRC-1965](https://transformuk.atlassian.net/browse/HMRC-1965)

## What?
Remove the HTTP listener from all services and close port 8080 in security groups. After this, only encrypted HTTPS traffic reaches the containers.

I have:

- Removed port 8080 ingress rule from ECS security group in modules/security-group/
- Removed application_port and tld_application_port default  to 8443

## Why?

I am doing this because:

- Only encrypted HTTPS traffic allowed in ecs cluster
