### PR TITLE
Bootstrap dev-hub-job-configuration secret version in staging

### DIFF
--- a/environments/staging/common/.terraform.lock.hcl
+++ b/environments/staging/common/.terraform.lock.hcl
@@ -1,9 +1,12 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/archive" {
   version     = "2.7.1"
-  constraints = ">= 2.0.0"
+  constraints = ">= 2.0.0, 2.7.1"
   hashes = [
     "h1:62VrkalDPMKB9zerCBS4iKTbvxejwnAWn/XXYZZQWD4=",
+    "h1:A7EnRBVm4h9ryO9LwxYnKr4fy7ExPMwD5a1DsY7m1Y0=",
     "zh:19881bb356a4a656a865f48aee70c0b8a03c35951b7799b6113883f67f196e8e",
     "zh:2fcfbf6318dd514863268b09bbe19bfc958339c636bcbcc3664b45f2b8bf5cc6",
     "zh:3323ab9a504ce0a115c28e64d0739369fe85151291a2ce480d51ccbb0c381ac5",
@@ -21,8 +24,9 @@ provider "registry.terraform.io/hashicorp/archive" {
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "6.36.0"
-  constraints = ">= 6.0.0"
+  constraints = ">= 4.9.0, >= 6.0.0"
   hashes = [
+    "h1:UYt6mrz0d3PfTJRbJAxe+fLcJt7voXJCLLdwfHrApGk=",
     "h1:r9icn1WEZVvEXiy6ZKexLzAPnXkkt+22jJ9WQYPfKB0=",
     "zh:0eb4481315564aaeec4905a804fd0df22c40f509ad2af63615eeaa90abacf81c",
     "zh:12c3cddc461a8dbaa04387fe83420b64c4c05cb5479d181674168ca7daefcc38",
@@ -44,8 +48,9 @@ provider "registry.terraform.io/hashicorp/aws" {
 
 provider "registry.terraform.io/hashicorp/external" {
   version     = "2.3.5"
-  constraints = ">= 2.3.5"
+  constraints = ">= 1.0.0, >= 2.3.5"
   hashes = [
+    "h1:FnUk98MI5nOh3VJ16cHf8mchQLewLfN1qZG/MqNgPrI=",
     "h1:smKSos4zs57pJjQrNuvGBpSWth2el9SgePPbPHo0aps=",
     "zh:6e89509d056091266532fa64de8c06950010498adf9070bf6ff85bc485a82562",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
@@ -64,9 +69,10 @@ provider "registry.terraform.io/hashicorp/external" {
 
 provider "registry.terraform.io/hashicorp/local" {
   version     = "2.7.0"
-  constraints = "2.7.0"
+  constraints = ">= 1.0.0"
   hashes = [
     "h1:2RYa3j7m/0WmET2fqotY4CHxE1Hpk0fgn47/126l+Og=",
+    "h1:sSwlfp2etjCaE9hIF7bJBDjRIhDCVFglEOVyiCI7vgs=",
     "zh:261fec71bca13e0a7812dc0d8ae9af2b4326b24d9b2e9beab3d2400fab5c5f9a",
     "zh:308da3b5376a9ede815042deec5af1050ec96a5a5410a2206ae847d82070a23e",
     "zh:3d056924c420464dc8aba10e1915956b2e5c4d55b11ffff79aa8be563fbfe298",
@@ -84,8 +90,9 @@ provider "registry.terraform.io/hashicorp/local" {
 
 provider "registry.terraform.io/hashicorp/null" {
   version     = "3.2.4"
-  constraints = "3.2.4"
+  constraints = ">= 2.0.0, >= 3.0.0"
   hashes = [
+    "h1:L5V05xwp/Gto1leRryuesxjMfgZwjb7oool4WS1UEFQ=",
     "h1:hkf5w5B6q8e2A42ND2CjAvgvSN3puAosDmOJb3zCVQM=",
     "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
@@ -107,6 +114,7 @@ provider "registry.terraform.io/hashicorp/random" {
   constraints = ">= 3.0.0"
   hashes = [
     "h1:Eexl06+6J+s75uD46+WnZtpJZYRVUMB0AiuPBifK6Jc=",
+    "h1:u8AKlWVDTH5r9YLSeswoVEjiY72Rt4/ch7U+61ZDkiQ=",
     "zh:08dd03b918c7b55713026037c5400c48af5b9f468f483463321bd18e17b907b4",
     "zh:0eee654a5542dc1d41920bbf2419032d6f0d5625b03bd81339e5b33394a3e0ae",
     "zh:229665ddf060aa0ed315597908483eee5b818a17d09b6417a0f52fd9405c4f57",
@@ -127,6 +135,7 @@ provider "registry.terraform.io/hashicorp/tls" {
   constraints = ">= 4.0.0"
   hashes = [
     "h1:F5d6bQY8UlBo0D71Sv7CsV+3aZOFz0yeNF+vufog7h4=",
+    "h1:akFNuHwvrtnYMBofieoeXhPJDhYZzJVu/Q/BgZK2fgg=",
     "zh:0d1e7d07ac973b97fa228f46596c800de830820506ee145626f079dd6bbf8d8a",
     "zh:5c7e3d4348cb4861ab812973ef493814a4b224bdd3e9d534a7c8a7c992382b86",
     "zh:7c6d4a86cd7a4e9c1025c6b3a3a6a45dea202af85d870cddbab455fb1bd568ad",
@@ -147,6 +156,7 @@ provider "registry.terraform.io/newrelic/newrelic" {
   constraints = ">= 3.78.0"
   hashes = [
     "h1:G2Ie0sSjDLNV4sxodzmH9USaeU1cN8VIlyGqdGfiFU8=",
+    "h1:Woy32ks9+zjLZEz8XH+Co4M2hQBDArmWbJiYaIPLRYU=",
     "zh:0af973805868bcfe093375c5f3572cfdf1d237c28405a7bcde25a2749e392481",
     "zh:144e3ac38e15115c1bb5c490d9ed88b5dcbc864d5cb4908e0211affff25fa791",
     "zh:1617e14a29ae815aa0a502a23cc69463fcc15b2ae8538ecfa2dabcef2ce9c133",

--- a/environments/staging/common/secrets.tf
+++ b/environments/staging/common/secrets.tf
@@ -25,6 +25,10 @@ module "dev_hub_job_configuration" {
   name            = "dev-hub-job-configuration"
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
   recovery_window = 7
+
+  # Bootstrap AWSCURRENT so dev-hub Terraform can read the secret; values are managed in the console.
+  secret_string                = "{}"
+  ignore_secret_string_changes = true
 }
 
 module "frontend_configuration" {

--- a/modules/secret/README.md
+++ b/modules/secret/README.md
@@ -23,12 +23,14 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_secretsmanager_secret.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
-| [aws_secretsmanager_secret_version.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
+| [aws_secretsmanager_secret_version.bootstrap](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
+| [aws_secretsmanager_secret_version.managed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_ignore_secret_string_changes"></a> [ignore\_secret\_string\_changes](#input\_ignore\_secret\_string\_changes) | If true, ignore drift on secret\_string after creation (for console-managed configuration secrets). | `bool` | `false` | no |
 | <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | KMS Key ARN with which to encrypt the secret. | `string` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | Name of the secret. | `string` | n/a | yes |
 | <a name="input_recovery_window"></a> [recovery\_window](#input\_recovery\_window) | Recovery window in days for the secret. | `string` | n/a | yes |

--- a/modules/secret/main.tf
+++ b/modules/secret/main.tf
@@ -4,8 +4,23 @@ resource "aws_secretsmanager_secret" "this" {
   name                    = var.name
 }
 
-resource "aws_secretsmanager_secret_version" "this" {
-  count         = var.secret_string != "" ? 1 : 0
+moved {
+  from = aws_secretsmanager_secret_version.this
+  to   = aws_secretsmanager_secret_version.managed
+}
+
+resource "aws_secretsmanager_secret_version" "managed" {
+  count         = var.secret_string != "" && !var.ignore_secret_string_changes ? 1 : 0
   secret_id     = aws_secretsmanager_secret.this.id
   secret_string = var.secret_string
+}
+
+resource "aws_secretsmanager_secret_version" "bootstrap" {
+  count         = var.secret_string != "" && var.ignore_secret_string_changes ? 1 : 0
+  secret_id     = aws_secretsmanager_secret.this.id
+  secret_string = var.secret_string
+
+  lifecycle {
+    ignore_changes = [secret_string]
+  }
 }

--- a/modules/secret/variables.tf
+++ b/modules/secret/variables.tf
@@ -5,6 +5,12 @@ variable "secret_string" {
   default     = ""
 }
 
+variable "ignore_secret_string_changes" {
+  description = "If true, ignore drift on secret_string after creation (for console-managed configuration secrets)."
+  type        = bool
+  default     = false
+}
+
 variable "name" {
   description = "Name of the secret."
   type        = string


### PR DESCRIPTION
Adds an initial {} secret version for dev-hub-job-configuration in staging so AWSCURRENT exists for dev-hub Terraform. Extends the secret module with optional ignore_secret_string_changes and a moved block so existing managed secrets are not recreated when renaming the version resource.
