### PR TITLE
HMRC-2158: Update db insights

### DIFF
--- a/environments/development/common/rds.tf
+++ b/environments/development/common/rds.tf
@@ -119,6 +119,37 @@ module "postgres_commodi_tea" {
   }
 }
 
+module "postgres_developer_hub" {
+  source = "../../../modules/rds"
+
+  environment    = var.environment
+  name           = "PostgresDeveloperHub"
+  engine         = "postgres"
+  engine_version = "18.3"
+
+  multi_az = false
+
+  instance_type           = "db.t3.micro"
+  backup_window           = "22:00-23:00"
+  maintenance_window      = "Fri:23:00-Sat:01:00"
+  backup_retention_period = 7
+  private_subnet_ids      = data.terraform_remote_state.base.outputs.private_subnet_ids
+
+  allocated_storage  = 10
+  security_group_ids = [module.alb-security-group.be_to_rds_security_group_id]
+
+  secret_kms_key_arn = aws_kms_key.secretsmanager_kms_key.arn
+
+  depends_on = [
+    module.alb-security-group
+  ]
+
+  tags = {
+    Name       = "DeveloperHubPostgres${title(var.environment)}"
+    "RDS_Type" = "Instance"
+  }
+}
+
 # Aurora cluster
 module "postgres_aurora" {
   source = "../../../modules/rds_cluster"
@@ -192,37 +223,6 @@ module "admin_connection_string" {
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
   recovery_window = 7
   secret_string   = module.postgres_admin_aurora.rw_connection_string
-}
-
-module "postgres_developer_hub" {
-  source = "../../../modules/rds"
-
-  environment    = var.environment
-  name           = "PostgresDeveloperHub"
-  engine         = "postgres"
-  engine_version = "18.3"
-
-  multi_az = false
-
-  instance_type           = "db.t3.micro"
-  backup_window           = "22:00-23:00"
-  maintenance_window      = "Fri:23:00-Sat:01:00"
-  backup_retention_period = 7
-  private_subnet_ids      = data.terraform_remote_state.base.outputs.private_subnet_ids
-
-  allocated_storage  = 10
-  security_group_ids = [module.alb-security-group.be_to_rds_security_group_id]
-
-  secret_kms_key_arn = aws_kms_key.secretsmanager_kms_key.arn
-
-  depends_on = [
-    module.alb-security-group
-  ]
-
-  tags = {
-    Name       = "DeveloperHubPostgres${title(var.environment)}"
-    "RDS_Type" = "Instance"
-  }
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/environments/production/common/rds.tf
+++ b/environments/production/common/rds.tf
@@ -104,6 +104,39 @@ module "postgres_commodi_tea" {
   }
 }
 
+module "postgres_developer_hub" {
+  source = "../../../modules/rds"
+
+  environment    = var.environment
+  name           = "PostgresDeveloperHub"
+  engine         = "postgres"
+  engine_version = "18.3"
+
+  multi_az = false
+
+  instance_type           = "db.t3.micro"
+  backup_window           = "22:00-23:00"
+  maintenance_window      = "Fri:23:00-Sat:01:00"
+  backup_retention_period = 7
+  private_subnet_ids      = data.terraform_remote_state.base.outputs.private_subnet_ids
+
+  allocated_storage  = 10
+  security_group_ids = [module.alb-security-group.be_to_rds_security_group_id]
+
+  secret_kms_key_arn = aws_kms_key.secretsmanager_kms_key.arn
+
+  performance_insights_enabled = true
+
+  depends_on = [
+    module.alb-security-group
+  ]
+
+  tags = {
+    Name       = "DeveloperHubPostgres${title(var.environment)}"
+    "RDS_Type" = "Instance"
+  }
+}
+
 # Aurora cluster
 module "postgres_aurora" {
   source = "../../../modules/rds_cluster"
@@ -192,39 +225,6 @@ module "admin_connection_string" {
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
   recovery_window = 7
   secret_string   = module.postgres_admin_aurora.rw_connection_string
-}
-
-module "postgres_developer_hub" {
-  source = "../../../modules/rds"
-
-  environment    = var.environment
-  name           = "PostgresDeveloperHub"
-  engine         = "postgres"
-  engine_version = "18.3"
-
-  multi_az = false
-
-  instance_type           = "db.t3.micro"
-  backup_window           = "22:00-23:00"
-  maintenance_window      = "Fri:23:00-Sat:01:00"
-  backup_retention_period = 7
-  private_subnet_ids      = data.terraform_remote_state.base.outputs.private_subnet_ids
-
-  allocated_storage  = 10
-  security_group_ids = [module.alb-security-group.be_to_rds_security_group_id]
-
-  secret_kms_key_arn = aws_kms_key.secretsmanager_kms_key.arn
-
-  performance_insights_enabled = true
-
-  depends_on = [
-    module.alb-security-group
-  ]
-
-  tags = {
-    Name       = "DeveloperHubPostgres${title(var.environment)}"
-    "RDS_Type" = "Instance"
-  }
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/environments/production/common/rds.tf
+++ b/environments/production/common/rds.tf
@@ -91,6 +91,8 @@ module "postgres_commodi_tea" {
 
   secret_kms_key_arn = aws_kms_key.secretsmanager_kms_key.arn
 
+  performance_insights_enabled = true
+
   depends_on = [
     module.alb-security-group
   ]
@@ -120,7 +122,8 @@ module "postgres_aurora" {
   encryption_at_rest = true
 
   performance_insights_enabled          = true
-  performance_insights_retention_period = 465
+  performance_insights_retention_period = 465 # minimum required for Advanced
+  database_insights_mode                = "advanced"
 
   min_capacity = 2
   max_capacity = 64
@@ -168,6 +171,8 @@ module "postgres_admin_aurora" {
 
   encryption_at_rest = true
 
+  performance_insights_enabled = true
+
   min_capacity = 0.5
   max_capacity = 2
 
@@ -209,6 +214,8 @@ module "postgres_developer_hub" {
   security_group_ids = [module.alb-security-group.be_to_rds_security_group_id]
 
   secret_kms_key_arn = aws_kms_key.secretsmanager_kms_key.arn
+
+  performance_insights_enabled = true
 
   depends_on = [
     module.alb-security-group

--- a/environments/staging/common/rds.tf
+++ b/environments/staging/common/rds.tf
@@ -119,6 +119,37 @@ module "postgres_commodi_tea" {
   }
 }
 
+module "postgres_developer_hub" {
+  source = "../../../modules/rds"
+
+  environment    = var.environment
+  name           = "PostgresDeveloperHub"
+  engine         = "postgres"
+  engine_version = "18.3"
+
+  multi_az = false
+
+  instance_type           = "db.t3.micro"
+  backup_window           = "22:00-23:00"
+  maintenance_window      = "Fri:23:00-Sat:01:00"
+  backup_retention_period = 7
+  private_subnet_ids      = data.terraform_remote_state.base.outputs.private_subnet_ids
+
+  allocated_storage  = 10
+  security_group_ids = [module.alb-security-group.be_to_rds_security_group_id]
+
+  secret_kms_key_arn = aws_kms_key.secretsmanager_kms_key.arn
+
+  depends_on = [
+    module.alb-security-group
+  ]
+
+  tags = {
+    Name       = "DeveloperHubPostgres${title(var.environment)}"
+    "RDS_Type" = "Instance"
+  }
+}
+
 # Aurora cluster
 module "postgres_aurora" {
   source = "../../../modules/rds_cluster"
@@ -192,37 +223,6 @@ module "admin_connection_string" {
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
   recovery_window = 7
   secret_string   = module.postgres_admin_aurora.rw_connection_string
-}
-
-module "postgres_developer_hub" {
-  source = "../../../modules/rds"
-
-  environment    = var.environment
-  name           = "PostgresDeveloperHub"
-  engine         = "postgres"
-  engine_version = "18.3"
-
-  multi_az = false
-
-  instance_type           = "db.t3.micro"
-  backup_window           = "22:00-23:00"
-  maintenance_window      = "Fri:23:00-Sat:01:00"
-  backup_retention_period = 7
-  private_subnet_ids      = data.terraform_remote_state.base.outputs.private_subnet_ids
-
-  allocated_storage  = 10
-  security_group_ids = [module.alb-security-group.be_to_rds_security_group_id]
-
-  secret_kms_key_arn = aws_kms_key.secretsmanager_kms_key.arn
-
-  depends_on = [
-    module.alb-security-group
-  ]
-
-  tags = {
-    Name       = "DeveloperHubPostgres${title(var.environment)}"
-    "RDS_Type" = "Instance"
-  }
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/modules/rds/README.md
+++ b/modules/rds/README.md
@@ -44,6 +44,7 @@ No modules.
 | <a name="input_allocated_storage"></a> [allocated\_storage](#input\_allocated\_storage) | Storage to allocate initially to the instance in gibibytes (i.e. 2^30 bytes). Can autoscale. | `number` | `5` | no |
 | <a name="input_backup_retention_period"></a> [backup\_retention\_period](#input\_backup\_retention\_period) | Amount of time, in days, (between 0 and 35) that backups should be retained for. | `number` | `30` | no |
 | <a name="input_backup_window"></a> [backup\_window](#input\_backup\_window) | The daily time range (in UTC) during which automated backups are created if they are enabled, eg: `09:46-10:16` | `string` | n/a | yes |
+| <a name="input_database_insights_mode"></a> [database\_insights\_mode](#input\_database\_insights\_mode) | The mode of Database Insights that is enabled for the instance. Valid values: standard, advanced. | `string` | `"standard"` | no |
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Whether to protect the database from deletion. Defaults to `true`. | `bool` | `true` | no |
 | <a name="input_engine"></a> [engine](#input\_engine) | Database engine to use. | `string` | n/a | yes |
 | <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | Version of the database engine to use. | `string` | n/a | yes |
@@ -53,6 +54,7 @@ No modules.
 | <a name="input_max_allocated_storage"></a> [max\_allocated\_storage](#input\_max\_allocated\_storage) | Maximum allocated storage for the instance. Defaults to `null` (no autoscaling). | `number` | `1` | no |
 | <a name="input_multi_az"></a> [multi\_az](#input\_multi\_az) | If the RDS instance is multi-AZ. | `bool` | `false` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the database. | `string` | n/a | yes |
+| <a name="input_performance_insights_enabled"></a> [performance\_insights\_enabled](#input\_performance\_insights\_enabled) | Whether to enable Performance Insights. Defaults to `true`. | `bool` | `false` | no |
 | <a name="input_performance_insights_retention_period"></a> [performance\_insights\_retention\_period](#input\_performance\_insights\_retention\_period) | Amount of time, in days, (minimum 7, maximum 731, or any multiple of 31) to retain performance insights data. | `number` | `31` | no |
 | <a name="input_private_subnet_ids"></a> [private\_subnet\_ids](#input\_private\_subnet\_ids) | A list of private subnet IDs | `list(string)` | n/a | yes |
 | <a name="input_secret_kms_key_arn"></a> [secret\_kms\_key\_arn](#input\_secret\_kms\_key\_arn) | ARN of the KMS Key to use to encrypt the connection string secret. | `string` | n/a | yes |

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -27,7 +27,7 @@ resource "aws_db_instance" "this" {
   iam_database_authentication_enabled = true
 
   performance_insights_enabled          = var.performance_insights_enabled
-  performance_insights_retention_period = var.performance_insights_retention_period
+  performance_insights_retention_period = var.performance_insights_enabled ? var.performance_insights_retention_period : null
   performance_insights_kms_key_id       = aws_kms_key.this.arn
   database_insights_mode                = var.database_insights_mode
 

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -26,10 +26,12 @@ resource "aws_db_instance" "this" {
   password                            = local.master_password
   iam_database_authentication_enabled = true
 
-  performance_insights_enabled          = true
+  performance_insights_enabled          = var.performance_insights_enabled
   performance_insights_retention_period = var.performance_insights_retention_period
   performance_insights_kms_key_id       = aws_kms_key.this.arn
-  parameter_group_name                  = aws_db_parameter_group.postgres[0].name
+  database_insights_mode                = var.database_insights_mode
+
+  parameter_group_name = aws_db_parameter_group.postgres[0].name
 
   vpc_security_group_ids = var.security_group_ids
 

--- a/modules/rds/variables.tf
+++ b/modules/rds/variables.tf
@@ -26,10 +26,22 @@ variable "backup_retention_period" {
   default     = 30
 }
 
+variable "performance_insights_enabled" {
+  description = "Whether to enable Performance Insights. Defaults to `true`."
+  type        = bool
+  default     = false
+}
+
 variable "performance_insights_retention_period" {
   description = "Amount of time, in days, (minimum 7, maximum 731, or any multiple of 31) to retain performance insights data."
   type        = number
   default     = 31
+}
+
+variable "database_insights_mode" {
+  description = "The mode of Database Insights that is enabled for the instance. Valid values: standard, advanced."
+  type        = string
+  default     = "standard"
 }
 
 variable "security_group_ids" {

--- a/modules/rds_cluster/README.md
+++ b/modules/rds_cluster/README.md
@@ -39,6 +39,7 @@ No modules.
 | <a name="input_cluster_instances"></a> [cluster\_instances](#input\_cluster\_instances) | n/a | `number` | `0` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | n/a | `string` | n/a | yes |
 | <a name="input_create_subnet_group"></a> [create\_subnet\_group](#input\_create\_subnet\_group) | Whether to create a DB subnet group. | `bool` | `true` | no |
+| <a name="input_database_insights_mode"></a> [database\_insights\_mode](#input\_database\_insights\_mode) | The mode of Database Insights that is enabled for the instance. Valid values: standard, advanced. | `string` | `"standard"` | no |
 | <a name="input_database_name"></a> [database\_name](#input\_database\_name) | Name of the database. | `string` | n/a | yes |
 | <a name="input_db_cluster_parameter_group_name"></a> [db\_cluster\_parameter\_group\_name](#input\_db\_cluster\_parameter\_group\_name) | The name of the DB cluster parameter group to associate with this cluster. | `string` | n/a | yes |
 | <a name="input_db_subnet_group_name"></a> [db\_subnet\_group\_name](#input\_db\_subnet\_group\_name) | Existing DB subnet group name to use | `string` | `null` | no |

--- a/modules/rds_cluster/main.tf
+++ b/modules/rds_cluster/main.tf
@@ -39,6 +39,7 @@ resource "aws_rds_cluster" "this" {
   performance_insights_enabled          = var.performance_insights_enabled
   performance_insights_retention_period = var.performance_insights_enabled ? var.performance_insights_retention_period : null
   performance_insights_kms_key_id       = var.performance_insights_enabled ? try(aws_kms_key.this[0].arn, var.kms_key_id) : null
+  database_insights_mode                = var.database_insights_mode
 
   tags = var.tags
 }

--- a/modules/rds_cluster/variables.tf
+++ b/modules/rds_cluster/variables.tf
@@ -122,6 +122,12 @@ variable "performance_insights_retention_period" {
   default     = 31
 }
 
+variable "database_insights_mode" {
+  description = "The mode of Database Insights that is enabled for the instance. Valid values: standard, advanced."
+  type        = string
+  default     = "standard"
+}
+
 variable "instance_identifiers" {
   type        = list(string)
   description = "To avoid renames after a snapshot restore, we manually pass the cluster identifiers to have these identifiers reflected in terraform state and avoid alterations to the writer/reader instances."


### PR DESCRIPTION
# Jira link
[HMRC-2158](https://transformuk.atlassian.net/browse/HMRC-2158)
## What?

I have:

- Enabled Performance Insights for commodi-tea (prod) and Admin (prod)
- Disabled Performance Insights for staging and development (commodi-tea, dev-hub)
- Enabled CloudWatch Database Insights (standard mode, 7-day retention)
- Set database_insights_mode to advanced for Aurora PostgreSQL (prod)


## Why?

I am doing this because:

- To improve observability and query performance monitoring in production while reducing unnecessary cost and noise in non-production environments.
