### PR TITLE
HMRC-2165: Add deletion protection to Elasticache, OpenSearch and DynamoDB

### DIFF
--- a/environments/development/common/dynamodb.tf
+++ b/environments/development/common/dynamodb.tf
@@ -8,4 +8,6 @@ resource "aws_dynamodb_table" "client_rate_limits" {
     name = "clientId"
     type = "S"
   }
+
+  deletion_protection_enabled = true
 }

--- a/environments/production/common/dynamodb.tf
+++ b/environments/production/common/dynamodb.tf
@@ -8,4 +8,6 @@ resource "aws_dynamodb_table" "client_rate_limits" {
     name = "clientId"
     type = "S"
   }
+
+  deletion_protection_enabled = true
 }

--- a/environments/staging/common/dynamodb.tf
+++ b/environments/staging/common/dynamodb.tf
@@ -8,4 +8,6 @@ resource "aws_dynamodb_table" "client_rate_limits" {
     name = "clientId"
     type = "S"
   }
+
+  deletion_protection_enabled = true
 }

--- a/modules/elasticache/main.tf
+++ b/modules/elasticache/main.tf
@@ -1,4 +1,8 @@
 resource "aws_elasticache_replication_group" "this" {
+  lifecycle {
+    prevent_destroy = true
+  }
+
   engine                      = var.engine
   engine_version              = var.engine_version
   port                        = var.port

--- a/modules/opensearch/main.tf
+++ b/modules/opensearch/main.tf
@@ -16,6 +16,10 @@ resource "aws_iam_service_linked_role" "opensearch" {
 }
 
 resource "aws_opensearch_domain" "opensearch" {
+  lifecycle {
+    prevent_destroy = true
+  }
+
   domain_name     = var.cluster_name
   engine_version  = "OpenSearch_${var.cluster_version}"
   access_policies = data.aws_iam_policy_document.access_policy.json


### PR DESCRIPTION
# Jira link
[HMRC-2165](https://transformuk.atlassian.net/browse/HMRC-2165)

## What?

I have:

- Added `lifecycle { prevent_destroy = true } `to:
  - Elasticache replication groups
  - OpenSearch domains
- Added `deletion_protection_enabled` to DynamoDB tables

## Why?

I am doing this because:

- These resources hold persistent, business‑critical data. 
- Adding deletion protection ensures safer Terraform workflows.
