### PR TITLE
HMRC-2110: Add DescribeLogStreams IAM action

### DIFF
--- a/environments/development/common/iam-policies.tf
+++ b/environments/development/common/iam-policies.tf
@@ -158,6 +158,7 @@ resource "aws_iam_policy" "ci_ecs_deployment_policy" {
           "logs:CreateLogGroup",
           "logs:DeleteLogGroup",
           "logs:DescribeLogGroups",
+          "logs:DescribeLogStreams",
           "logs:GetLogEvents",
           "logs:ListTagsForResource",
           "logs:PutRetentionPolicy",

--- a/environments/production/common/iam-policies.tf
+++ b/environments/production/common/iam-policies.tf
@@ -159,6 +159,7 @@ resource "aws_iam_policy" "ci_ecs_deployment_policy" {
           "logs:CreateLogGroup",
           "logs:DeleteLogGroup",
           "logs:DescribeLogGroups",
+          "logs:DescribeLogStreams",
           "logs:GetLogEvents",
           "logs:ListTagsForResource",
           "logs:PutRetentionPolicy",

--- a/environments/staging/common/iam-policies.tf
+++ b/environments/staging/common/iam-policies.tf
@@ -159,6 +159,7 @@ resource "aws_iam_policy" "ci_ecs_deployment_policy" {
           "logs:CreateLogGroup",
           "logs:DeleteLogGroup",
           "logs:DescribeLogGroups",
+          "logs:DescribeLogStreams",
           "logs:GetLogEvents",
           "logs:ListTagsForResource",
           "logs:PutRetentionPolicy",


### PR DESCRIPTION
## What?

I have:

- Added `logs:DescribeLogStreams` IAM action to GithubActions deployment role policies

## Why?

I am doing this because:

- In order to run `run-task` scripts in CI workflows, the role performing the action requires this action to be able to run `aws logs describe-log-streams`