### PR TITLE
BAU: Remove old Valkey clusters from Production

### DIFF
--- a/environments/production/common/redis.tf
+++ b/environments/production/common/redis.tf
@@ -1,70 +1,16 @@
 locals {
-  redis = {
-    "frontend"   = "cache.r4.large",
-    "backend-uk" = "cache.m7g.large",
-    "backend-xi" = "cache.t3.medium",
-  }
-
   valkey = {
     "frontend"   = "cache.r4.large",
     "backend-uk" = "cache.t3.medium",
     "backend-xi" = "cache.t3.medium",
+    "sidekiq-uk" = "cache.t3.medium",
+    "sidekiq-xi" = "cache.t3.medium",
   }
 }
 
 resource "aws_elasticache_subnet_group" "this" {
   name       = "redis-subnet-group"
   subnet_ids = data.terraform_remote_state.base.outputs.private_subnet_ids
-}
-
-module "redis" {
-  source   = "../../../modules/elasticache/"
-  for_each = local.redis
-
-  engine         = "valkey"
-  engine_version = "8.2"
-
-  replication_group_id        = "redis-${each.key}-${var.environment}"
-  description                 = "redis-${each.key}-${var.environment}"
-  parameter_group_name        = "default.valkey8"
-  num_node_groups             = 1
-  replicas_per_node_group     = 2
-  node_type                   = each.value
-  security_group_ids          = [module.alb-security-group.redis_security_group_id]
-  subnet_group_name           = aws_elasticache_subnet_group.this.name
-  multi_az_enabled            = true
-  automatic_failover_enabled  = true
-  preferred_cache_cluster_azs = ["eu-west-2a", "eu-west-2b", "eu-west-2c"]
-  auto_minor_version_upgrade  = true
-  maintenance_window          = "sun:04:00-sun:05:00"
-  snapshot_window             = "02:00-04:00"
-  snapshot_retention_limit    = 7
-  apply_immediately           = true
-  log_retention_days          = 30
-}
-
-resource "aws_secretsmanager_secret" "redis_connection_string" {
-  for_each   = local.redis
-  name       = "redis-${each.key}-connection-string"
-  kms_key_id = aws_kms_key.secretsmanager_kms_key.arn
-}
-
-resource "aws_secretsmanager_secret_version" "redis_connection_string_value" {
-  for_each      = local.redis
-  secret_id     = aws_secretsmanager_secret.redis_connection_string[each.key].id
-  secret_string = "redis://${module.redis[each.key].primary_endpoint}:6379"
-}
-
-resource "aws_secretsmanager_secret" "redis_reader_connection_string" {
-  for_each   = local.redis
-  name       = "redis-${each.key}-reader-connection-string"
-  kms_key_id = aws_kms_key.secretsmanager_kms_key.arn
-}
-
-resource "aws_secretsmanager_secret_version" "redis_reader_connection_string_value" {
-  for_each      = local.redis
-  secret_id     = aws_secretsmanager_secret.redis_reader_connection_string[each.key].id
-  secret_string = "redis://${module.redis[each.key].reader_endpoint}:6379"
 }
 
 resource "aws_elasticache_parameter_group" "sidekiq" {
@@ -77,55 +23,10 @@ resource "aws_elasticache_parameter_group" "sidekiq" {
   }
 }
 
-locals {
-  redis_sidekiq = {
-    "sidekiq-uk" = "cache.t3.medium",
-    "sidekiq-xi" = "cache.t3.medium",
-  }
-}
-
-module "redis_sidekiq" {
-  source   = "../../../modules/elasticache/"
-  for_each = local.redis_sidekiq
-
-  engine         = "valkey"
-  engine_version = "8.2"
-
-  replication_group_id        = "redis-${each.key}-${var.environment}"
-  description                 = "redis-${each.key}-${var.environment}"
-  parameter_group_name        = aws_elasticache_parameter_group.sidekiq.name
-  num_node_groups             = 1
-  replicas_per_node_group     = 2
-  node_type                   = each.value
-  security_group_ids          = [module.alb-security-group.redis_security_group_id]
-  subnet_group_name           = aws_elasticache_subnet_group.this.name
-  multi_az_enabled            = true
-  automatic_failover_enabled  = true
-  preferred_cache_cluster_azs = ["eu-west-2a", "eu-west-2b", "eu-west-2c"]
-  auto_minor_version_upgrade  = true
-  maintenance_window          = "sun:04:00-sun:05:00"
-  snapshot_window             = "02:00-04:00"
-  snapshot_retention_limit    = 7
-  apply_immediately           = true
-  log_retention_days          = 30
-}
-
-resource "aws_secretsmanager_secret" "redis_sidekiq_connection_string" {
-  for_each   = local.redis_sidekiq
-  name       = "redis-${each.key}-connection-string"
-  kms_key_id = aws_kms_key.secretsmanager_kms_key.arn
-}
-
-resource "aws_secretsmanager_secret_version" "redis_sidekiq_connection_string_value" {
-  for_each      = local.redis_sidekiq
-  secret_id     = aws_secretsmanager_secret.redis_sidekiq_connection_string[each.key].id
-  secret_string = "redis://${module.redis_sidekiq[each.key].primary_endpoint}:6379"
-}
-
 # Authenticated, encrypted clusters
 module "valkey" {
   source   = "../../../modules/elasticache/"
-  for_each = merge(local.valkey, local.redis_sidekiq)
+  for_each = local.valkey
 
   engine         = "valkey"
   engine_version = "8.2"
@@ -157,19 +58,19 @@ module "valkey" {
 
 # Generate a password for each cluster, to avoid credential sharing
 resource "random_password" "valkey_auth" {
-  for_each = merge(local.valkey, local.redis_sidekiq)
+  for_each = local.valkey
   length   = 16
   special  = false
 }
 
 resource "aws_secretsmanager_secret" "valkey_connection_string" {
-  for_each   = merge(local.valkey, local.redis_sidekiq)
+  for_each   = local.valkey
   name       = "valkey-${each.key}-connection-string"
   kms_key_id = aws_kms_key.secretsmanager_kms_key.arn
 }
 
 resource "aws_secretsmanager_secret_version" "valkey_connection_string_value" {
-  for_each      = merge(local.valkey, local.redis_sidekiq)
+  for_each      = local.valkey
   secret_id     = aws_secretsmanager_secret.valkey_connection_string[each.key].id
   secret_string = "rediss://:${random_password.valkey_auth[each.key].result}@${module.valkey[each.key].primary_endpoint}:6379"
 }


### PR DESCRIPTION
## What?

I have:

- Removed unauthenticated Valkey clusters from production

## Why?

I am doing this because:

- After the switchover, they are no longer in use and must be destroyed
