### PR TITLE
HMRC-2188: Update the ALB target group health check configuration

### DIFF
--- a/modules/application-load-balancer/main.tf
+++ b/modules/application-load-balancer/main.tf
@@ -34,10 +34,10 @@ resource "aws_lb_target_group" "trade_tariff_https_target_groups" {
 
   health_check {
     enabled             = true
-    interval            = 60
+    interval            = 30
     path                = each.value.healthcheck_path
     port                = "traffic-port"
-    healthy_threshold   = 3
+    healthy_threshold   = 2
     unhealthy_threshold = 3
     timeout             = 6
     protocol            = "HTTPS"


### PR DESCRIPTION
# Jira link
[HMRC-2188](https://transformuk.atlassian.net/browse/HMRC-2188)
## What?

I have:

- Changed health check interval from 60 seconds to 30 seconds
- Changed healthy threshold from 3 to 2

## Why?

I am doing this because:

- This will reduce time-to-healthy during ECS deployments and improve autoscaling responsiveness.
- The current health check interval and thresholds cause new ECS tasks to take several minutes before becoming healthy, which delays effective scale‑out during traffic increases.

**Impact (timing breakdown)**

Previous configuration
Interval: 60 seconds
Healthy threshold: 3
```
Registered → healthy = 60s × 3 = 180 seconds
Additional startup/registration overhead ≈ 25 seconds
Total worst case ≈ 205 seconds (~3.5 minutes)
```

New configuration
Interval: 30 seconds
Healthy threshold: 2
```
Registered → healthy = 30s × 2 = 60 seconds
Additional startup/registration overhead ≈ 25 seconds
Total worst case ≈ 85 seconds (~1.5 minutes)
```