### PR TITLE
Revert terragrunt version upgrade

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -11,7 +11,7 @@ env:
   AWS_REGION: eu-west-2
   PYTHON_VERSION: 3
   TERRAFORM_VERSION: 1.13.4
-  TERRAGRUNT_VERSION: 1.0.1
+  TERRAGRUNT_VERSION: 0.78.1
   # TODO: Remove this when autero1/action-terragrunt@v3 is updated to use node 24
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -14,7 +14,7 @@ env:
   AWS_REGION: eu-west-2
   PYTHON_VERSION: 3
   TERRAFORM_VERSION: 1.13.4
-  TERRAGRUNT_VERSION: 1.0.1
+  TERRAGRUNT_VERSION: 0.78.1
   # TODO: Remove this when autero1/action-terragrunt@v3 is updated to use node 24
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 


### PR DESCRIPTION
# Jira link

BAU

## What?

I have:

- Reverted the terragrunt version upgrade made in PR #577

## Why?

I am doing this because:

- Upgrade cased `Unreadable module directory` error and needs to be tested and applied in a separate PR
