### PR TITLE
OTTIMP-542 Enable refresh token rotation in staging/development

### DIFF
--- a/environments/development/common/cognito-identity.tf
+++ b/environments/development/common/cognito-identity.tf
@@ -29,12 +29,12 @@ module "identity_cognito" {
 
   client_name = "identity-client"
   client_auth_flows = [
-    "ALLOW_CUSTOM_AUTH",
-    "ALLOW_REFRESH_TOKEN_AUTH"
+    "ALLOW_CUSTOM_AUTH"
   ]
 
   client_auth_session_validity   = 15
   client_enable_token_revocation = false
+  client_enable_refresh_token_rotation = true
 
   client_token_validity = {
     access_token = {

--- a/environments/development/common/cognito-identity.tf
+++ b/environments/development/common/cognito-identity.tf
@@ -32,8 +32,8 @@ module "identity_cognito" {
     "ALLOW_CUSTOM_AUTH"
   ]
 
-  client_auth_session_validity   = 15
-  client_enable_token_revocation = false
+  client_auth_session_validity         = 15
+  client_enable_token_revocation       = false
   client_enable_refresh_token_rotation = true
 
   client_token_validity = {

--- a/environments/staging/common/cognito-identity.tf
+++ b/environments/staging/common/cognito-identity.tf
@@ -29,12 +29,12 @@ module "identity_cognito" {
 
   client_name = "identity-client"
   client_auth_flows = [
-    "ALLOW_CUSTOM_AUTH",
-    "ALLOW_REFRESH_TOKEN_AUTH"
+    "ALLOW_CUSTOM_AUTH"
   ]
 
   client_auth_session_validity   = 15
   client_enable_token_revocation = false
+  client_enable_refresh_token_rotation = true
 
   client_token_validity = {
     access_token = {

--- a/environments/staging/common/cognito-identity.tf
+++ b/environments/staging/common/cognito-identity.tf
@@ -32,8 +32,8 @@ module "identity_cognito" {
     "ALLOW_CUSTOM_AUTH"
   ]
 
-  client_auth_session_validity   = 15
-  client_enable_token_revocation = false
+  client_auth_session_validity         = 15
+  client_enable_token_revocation       = false
   client_enable_refresh_token_rotation = true
 
   client_token_validity = {

--- a/modules/cognito/README.md
+++ b/modules/cognito/README.md
@@ -78,6 +78,7 @@ No modules.
 | <a name="input_client_auth_flows"></a> [client\_auth\_flows](#input\_client\_auth\_flows) | Authentication flows the client supports. | `list(string)` | `null` | no |
 | <a name="input_client_auth_session_validity"></a> [client\_auth\_session\_validity](#input\_client\_auth\_session\_validity) | Time (in minutes) for session to be valid in authentication flow. Defaults to `3` (minimum). Maximum value is `15`. | `number` | `3` | no |
 | <a name="input_client_callback_urls"></a> [client\_callback\_urls](#input\_client\_callback\_urls) | A list of callback URLs for the client identity providers. | `list(string)` | `null` | no |
+| <a name="input_client_enable_refresh_token_rotation"></a> [client\_enable\_refresh\_token\_rotation](#input\_client\_enable\_refresh\_token\_rotation) | Whether refresh token rotation is enabled for the app client. Defaults to `false`. | `bool` | `false` | no |
 | <a name="input_client_enable_token_revocation"></a> [client\_enable\_token\_revocation](#input\_client\_enable\_token\_revocation) | Whether tokens can be revoked. Defaults to `true`. | `bool` | `true` | no |
 | <a name="input_client_generate_secret"></a> [client\_generate\_secret](#input\_client\_generate\_secret) | Whether to generate a client secret for this application client. | `bool` | `null` | no |
 | <a name="input_client_identity_providers"></a> [client\_identity\_providers](#input\_client\_identity\_providers) | List of `provider_name`s from Cognito Identity Providers. | `list(string)` | `null` | no |

--- a/modules/cognito/main.tf
+++ b/modules/cognito/main.tf
@@ -227,7 +227,8 @@ resource "aws_cognito_user_pool_client" "this" {
   dynamic "refresh_token_rotation" {
     for_each = var.client_enable_refresh_token_rotation ? [true] : []
     content {
-      feature = "ENABLED"
+      feature                    = "ENABLED"
+      retry_grace_period_seconds = 0
     }
   }
 }

--- a/modules/cognito/main.tf
+++ b/modules/cognito/main.tf
@@ -223,6 +223,13 @@ resource "aws_cognito_user_pool_client" "this" {
     id_token      = var.client_token_validity["id_token"]["units"]
     refresh_token = var.client_token_validity["refresh_token"]["units"]
   }
+
+  dynamic "refresh_token_rotation" {
+    for_each = var.client_enable_refresh_token_rotation ? [true] : []
+    content {
+      feature = "ENABLED"
+    }
+  }
 }
 
 resource "aws_cognito_resource_server" "this" {

--- a/modules/cognito/variables.tf
+++ b/modules/cognito/variables.tf
@@ -292,6 +292,12 @@ variable "client_enable_token_revocation" {
   default     = true
 }
 
+variable "client_enable_refresh_token_rotation" {
+  description = "Whether refresh token rotation is enabled for the app client. Defaults to `false`."
+  type        = bool
+  default     = false
+}
+
 variable "client_prevent_user_existence_errors" {
   description = "Whether the API returns a generic authentication error (default), or indicates whether the user was not found."
   type        = bool


### PR DESCRIPTION
# Jira link
OTTIMP-542

## What?

I have enabled refresh token rotation in staging and development.
This is not compatible with the old ALLOW_REFRESH_TOKEN_AUTH auth flow so it has been removed.

## Why?

This enables users to stay logged in for longer the current 30 day duration of the refresh token. Every time the user is re-authenticated a new 30 day refresh token is issued.
