### PR TITLE
Add uptime monitor with PagerDuty alerting (all environments)

### DIFF
--- a/.github/workflows/deploy-to-development.yml
+++ b/.github/workflows/deploy-to-development.yml
@@ -142,6 +142,12 @@ jobs:
       - run: bundle config set path 'vendor/bundle' && bundle install
         working-directory: common/lambda/trade-tariff-identity-create-auth-challenge
 
+      - run: bundle config set path 'vendor/bundle' && bundle install
+        working-directory: common/lambda/trade-tariff-uptime-checker
+
+      - run: bundle config set path 'vendor/bundle' && bundle install
+        working-directory: common/lambda/trade-tariff-uptime-pagerduty
+
       - uses: autero1/action-terragrunt@v3
         with:
           terragrunt-version: ${{ env.TERRAGRUNT_VERSION }}

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -40,6 +40,12 @@ jobs:
       - run: bundle config set path 'vendor/bundle' && bundle install
         working-directory: common/lambda/trade-tariff-identity-create-auth-challenge
 
+      - run: bundle config set path 'vendor/bundle' && bundle install
+        working-directory: common/lambda/trade-tariff-uptime-checker
+
+      - run: bundle config set path 'vendor/bundle' && bundle install
+        working-directory: common/lambda/trade-tariff-uptime-pagerduty
+
       - uses: autero1/action-terragrunt@v3
         with:
           terragrunt-version: ${{ env.TERRAGRUNT_VERSION }}

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -43,6 +43,12 @@ jobs:
       - run: bundle config set path 'vendor/bundle' && bundle install
         working-directory: common/lambda/trade-tariff-identity-create-auth-challenge
 
+      - run: bundle config set path 'vendor/bundle' && bundle install
+        working-directory: common/lambda/trade-tariff-uptime-checker
+
+      - run: bundle config set path 'vendor/bundle' && bundle install
+        working-directory: common/lambda/trade-tariff-uptime-pagerduty
+
       - uses: autero1/action-terragrunt@v3
         with:
           terragrunt-version: ${{ env.TERRAGRUNT_VERSION }}

--- a/common/lambda/trade-tariff-uptime-checker/Gemfile
+++ b/common/lambda/trade-tariff-uptime-checker/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'aws-sdk-cloudwatch', '~> 1'

--- a/common/lambda/trade-tariff-uptime-checker/lambda_function.rb
+++ b/common/lambda/trade-tariff-uptime-checker/lambda_function.rb
@@ -1,0 +1,57 @@
+require 'json'
+require 'net/http'
+require 'uri'
+require 'aws-sdk-cloudwatch'
+
+CLOUDWATCH_NAMESPACE = 'TradeTariff/Uptime'
+
+def lambda_handler(event:, context:)
+  endpoints = JSON.parse(ENV.fetch('MONITORED_URLS'))
+  cloudwatch = Aws::CloudWatch::Client.new
+
+  endpoints.each do |endpoint|
+    name = endpoint.fetch('name')
+    url  = endpoint.fetch('url')
+
+    available, response_time_ms = probe(url)
+
+    cloudwatch.put_metric_data(
+      namespace: CLOUDWATCH_NAMESPACE,
+      metric_data: [
+        {
+          metric_name: 'Availability',
+          dimensions: [{ name: 'Endpoint', value: name }],
+          value: available ? 1.0 : 0.0,
+          unit: 'Count'
+        },
+        {
+          metric_name: 'ResponseTime',
+          dimensions: [{ name: 'Endpoint', value: name }],
+          value: response_time_ms.to_f,
+          unit: 'Milliseconds'
+        }
+      ]
+    )
+
+    puts "#{name}: available=#{available} response_time=#{response_time_ms}ms"
+  end
+end
+
+def probe(url)
+  uri = URI.parse(url)
+  http = Net::HTTP.new(uri.host, uri.port)
+  http.use_ssl     = uri.scheme == 'https'
+  http.open_timeout = 10
+  http.read_timeout = 15
+
+  started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  response   = http.get(uri.request_uri)
+  elapsed_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at) * 1000).round
+
+  available = response.code.to_i < 500
+  [available, elapsed_ms]
+rescue => e
+  elapsed_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at) * 1000).round
+  puts "Probe failed for #{url}: #{e.class} #{e.message}"
+  [false, elapsed_ms]
+end

--- a/common/lambda/trade-tariff-uptime-pagerduty/Gemfile
+++ b/common/lambda/trade-tariff-uptime-pagerduty/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'aws-sdk-secretsmanager', '~> 1'

--- a/common/lambda/trade-tariff-uptime-pagerduty/Gemfile
+++ b/common/lambda/trade-tariff-uptime-pagerduty/Gemfile
@@ -1,5 +1,3 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
-
-gem 'aws-sdk-secretsmanager', '~> 1'

--- a/common/lambda/trade-tariff-uptime-pagerduty/lambda_function.rb
+++ b/common/lambda/trade-tariff-uptime-pagerduty/lambda_function.rb
@@ -1,0 +1,59 @@
+require 'json'
+require 'net/http'
+require 'uri'
+require 'aws-sdk-secretsmanager'
+
+PAGERDUTY_EVENTS_URL = 'https://events.pagerduty.com/v2/enqueue'
+
+def lambda_handler(event:, context:)
+  routing_key = fetch_routing_key
+
+  event['Records'].each do |record|
+    message    = JSON.parse(record.dig('Sns', 'Message'))
+    alarm_name = message['AlarmName']
+    new_state  = message['NewStateValue']  # "ALARM" or "OK"
+
+    event_action = new_state == 'ALARM' ? 'trigger' : 'resolve'
+
+    payload = {
+      routing_key:  routing_key,
+      event_action: event_action,
+      dedup_key:    alarm_name,
+      payload: {
+        summary:  message['AlarmDescription'] || alarm_name,
+        source:   alarm_name,
+        severity: 'critical',
+        custom_details: {
+          alarm_name: alarm_name,
+          state:      new_state,
+          reason:     message['NewStateReason']
+        }
+      }
+    }
+
+    post_to_pagerduty(payload)
+  end
+end
+
+def fetch_routing_key
+  secret_arn = ENV.fetch('PAGERDUTY_SECRET_ARN')
+  client     = Aws::SecretsManager::Client.new
+  secret     = client.get_secret_value(secret_id: secret_arn)
+  JSON.parse(secret.secret_string).fetch('routing_key')
+end
+
+def post_to_pagerduty(payload)
+  uri      = URI.parse(PAGERDUTY_EVENTS_URL)
+  http     = Net::HTTP.new(uri.host, uri.port)
+  http.use_ssl      = true
+  http.open_timeout = 10
+  http.read_timeout = 10
+
+  request      = Net::HTTP::Post.new(uri.path, 'Content-Type' => 'application/json')
+  request.body = payload.to_json
+
+  response = http.request(request)
+  puts "PagerDuty response: #{response.code} #{response.body}"
+
+  raise "PagerDuty API error: #{response.code}" unless response.code.to_i < 300
+end

--- a/common/lambda/trade-tariff-uptime-pagerduty/lambda_function.rb
+++ b/common/lambda/trade-tariff-uptime-pagerduty/lambda_function.rb
@@ -1,14 +1,13 @@
 require 'json'
 require 'net/http'
 require 'uri'
-require 'aws-sdk-secretsmanager'
 
 PAGERDUTY_EVENTS_URL = 'https://events.pagerduty.com/v2/enqueue'
 
 def lambda_handler(event:, context:)
-  routing_key = fetch_routing_key
+  routing_key = ENV.fetch('PAGERDUTY_ROUTING_KEY', '')
 
-  unless routing_key
+  if routing_key.empty?
     puts 'PagerDuty routing key not configured — skipping alert'
     return
   end
@@ -38,18 +37,6 @@ def lambda_handler(event:, context:)
 
     post_to_pagerduty(payload)
   end
-end
-
-def fetch_routing_key
-  secret_arn = ENV.fetch('PAGERDUTY_SECRET_ARN')
-  client     = Aws::SecretsManager::Client.new
-  secret     = client.get_secret_value(secret_id: secret_arn)
-  JSON.parse(secret.secret_string)['routing_key']
-rescue Aws::SecretsManager::Errors::ResourceNotFoundException,
-       Aws::SecretsManager::Errors::InvalidRequestException,
-       JSON::ParserError => e
-  puts "Could not read PagerDuty routing key: #{e.message}"
-  nil
 end
 
 def post_to_pagerduty(payload)

--- a/common/lambda/trade-tariff-uptime-pagerduty/lambda_function.rb
+++ b/common/lambda/trade-tariff-uptime-pagerduty/lambda_function.rb
@@ -8,6 +8,11 @@ PAGERDUTY_EVENTS_URL = 'https://events.pagerduty.com/v2/enqueue'
 def lambda_handler(event:, context:)
   routing_key = fetch_routing_key
 
+  unless routing_key
+    puts 'PagerDuty routing key not configured — skipping alert'
+    return
+  end
+
   event['Records'].each do |record|
     message    = JSON.parse(record.dig('Sns', 'Message'))
     alarm_name = message['AlarmName']
@@ -39,7 +44,12 @@ def fetch_routing_key
   secret_arn = ENV.fetch('PAGERDUTY_SECRET_ARN')
   client     = Aws::SecretsManager::Client.new
   secret     = client.get_secret_value(secret_id: secret_arn)
-  JSON.parse(secret.secret_string).fetch('routing_key')
+  JSON.parse(secret.secret_string)['routing_key']
+rescue Aws::SecretsManager::Errors::ResourceNotFoundException,
+       Aws::SecretsManager::Errors::InvalidRequestException,
+       JSON::ParserError => e
+  puts "Could not read PagerDuty routing key: #{e.message}"
+  nil
 end
 
 def post_to_pagerduty(payload)

--- a/environments/development/common/uptime-monitor.tf
+++ b/environments/development/common/uptime-monitor.tf
@@ -217,6 +217,7 @@ resource "aws_cloudwatch_dashboard" "uptime" {
           height = 6
           properties = {
             title   = "${name} — Availability"
+            region  = var.region
             metrics = [["TradeTariff/Uptime", "Availability", "Endpoint", name]]
             period  = 60
             stat    = "Minimum"
@@ -233,6 +234,7 @@ resource "aws_cloudwatch_dashboard" "uptime" {
           height = 6
           properties = {
             title   = "${name} — Response Time (ms)"
+            region  = var.region
             metrics = [["TradeTariff/Uptime", "ResponseTime", "Endpoint", name]]
             period  = 60
             stat    = "Average"

--- a/environments/development/common/uptime-monitor.tf
+++ b/environments/development/common/uptime-monitor.tf
@@ -1,0 +1,246 @@
+locals {
+  # Add URLs to monitor here. The key becomes the Endpoint dimension in CloudWatch
+  # and must be unique. Example:
+  #   "search-suggestions" = "https://www.trade-tariff.service.gov.uk/api/v2/search_suggestions"
+  uptime_endpoints = {
+    "find-commodity" = "https://dev.trade-tariff.service.gov.uk/find_commodity"
+  }
+
+  # Number of consecutive 1-minute failures before PagerDuty is alerted
+  uptime_failure_threshold = 3
+}
+
+# ---------------------------------------------------------------------------
+# Lambda: URL checker
+# Runs every minute via EventBridge, probes each URL, emits custom metrics.
+# ---------------------------------------------------------------------------
+
+data "archive_file" "uptime_checker" {
+  type        = "zip"
+  source_dir  = "../../../common/lambda/trade-tariff-uptime-checker"
+  output_path = "lambda_uptime_checker.zip"
+}
+
+module "uptime_checker" {
+  source = "../../../modules/lambda"
+
+  function_name    = "trade-tariff-uptime-checker-${var.environment}"
+  filename         = data.archive_file.uptime_checker.output_path
+  handler          = "lambda_function.lambda_handler"
+  runtime          = "ruby3.4"
+  source_code_hash = data.archive_file.uptime_checker.output_base64sha256
+  memory_size      = 256
+  timeout          = 60
+
+  additional_policy_arns = [aws_iam_policy.uptime_checker_cloudwatch.arn]
+
+  environment_variables = {
+    MONITORED_URLS = jsonencode([
+      for name, url in local.uptime_endpoints : { name = name, url = url }
+    ])
+  }
+}
+
+resource "aws_iam_policy" "uptime_checker_cloudwatch" {
+  name = "trade-tariff-uptime-checker-cloudwatch-${var.environment}"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["cloudwatch:PutMetricData"]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "cloudwatch:namespace" = "TradeTariff/Uptime"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_cloudwatch_event_rule" "uptime_checker" {
+  name                = "trade-tariff-uptime-checker-${var.environment}"
+  description         = "Triggers uptime checker Lambda every minute"
+  schedule_expression = "rate(1 minute)"
+}
+
+resource "aws_cloudwatch_event_target" "uptime_checker" {
+  rule = aws_cloudwatch_event_rule.uptime_checker.name
+  arn  = module.uptime_checker.lambda_arn
+}
+
+resource "aws_lambda_permission" "uptime_checker_eventbridge" {
+  statement_id  = "AllowEventBridgeInvokeUptimeChecker"
+  action        = "lambda:InvokeFunction"
+  function_name = module.uptime_checker.lambda_arn
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.uptime_checker.arn
+}
+
+# ---------------------------------------------------------------------------
+# CloudWatch alarms — one per endpoint
+# Fires after uptime_failure_threshold consecutive 1-minute failures.
+# ---------------------------------------------------------------------------
+
+resource "aws_cloudwatch_metric_alarm" "uptime" {
+  for_each = local.uptime_endpoints
+
+  alarm_name          = "uptime-${each.key}-${var.environment}"
+  alarm_description   = "Uptime check failed for ${each.value}"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = local.uptime_failure_threshold
+  datapoints_to_alarm = local.uptime_failure_threshold
+  metric_name         = "Availability"
+  namespace           = "TradeTariff/Uptime"
+  period              = 60
+  statistic           = "Minimum"
+  threshold           = 1
+  treat_missing_data  = "breaching"
+
+  dimensions = {
+    Endpoint = each.key
+  }
+
+  alarm_actions = [aws_sns_topic.uptime_alerts.arn]
+  ok_actions    = [aws_sns_topic.uptime_alerts.arn]
+}
+
+# ---------------------------------------------------------------------------
+# SNS topic — fan-out point between alarms and the PagerDuty Lambda
+# ---------------------------------------------------------------------------
+
+resource "aws_sns_topic" "uptime_alerts" {
+  name = "trade-tariff-uptime-alerts-${var.environment}"
+}
+
+resource "aws_sns_topic_subscription" "uptime_pagerduty" {
+  topic_arn = aws_sns_topic.uptime_alerts.arn
+  protocol  = "lambda"
+  endpoint  = module.uptime_pagerduty.lambda_arn
+}
+
+# ---------------------------------------------------------------------------
+# Lambda: PagerDuty forwarder
+# Translates CloudWatch Alarm SNS payloads into PagerDuty Events API v2 calls.
+# ---------------------------------------------------------------------------
+
+data "archive_file" "uptime_pagerduty" {
+  type        = "zip"
+  source_dir  = "../../../common/lambda/trade-tariff-uptime-pagerduty"
+  output_path = "lambda_uptime_pagerduty.zip"
+}
+
+module "uptime_pagerduty" {
+  source = "../../../modules/lambda"
+
+  function_name    = "trade-tariff-uptime-pagerduty-${var.environment}"
+  filename         = data.archive_file.uptime_pagerduty.output_path
+  handler          = "lambda_function.lambda_handler"
+  runtime          = "ruby3.4"
+  source_code_hash = data.archive_file.uptime_pagerduty.output_base64sha256
+  memory_size      = 128
+  timeout          = 30
+
+  additional_policy_arns = [aws_iam_policy.uptime_pagerduty_secrets.arn]
+
+  environment_variables = {
+    PAGERDUTY_SECRET_ARN = module.uptime_pagerduty_secret.secret_arn
+  }
+}
+
+resource "aws_iam_policy" "uptime_pagerduty_secrets" {
+  name = "trade-tariff-uptime-pagerduty-secrets-${var.environment}"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["secretsmanager:GetSecretValue"]
+        Resource = module.uptime_pagerduty_secret.secret_arn
+      }
+    ]
+  })
+}
+
+resource "aws_lambda_permission" "uptime_pagerduty_sns" {
+  statement_id  = "AllowSNSInvokeUptimePagerduty"
+  action        = "lambda:InvokeFunction"
+  function_name = module.uptime_pagerduty.lambda_arn
+  principal     = "sns.amazonaws.com"
+  source_arn    = aws_sns_topic.uptime_alerts.arn
+}
+
+# ---------------------------------------------------------------------------
+# Secret: PagerDuty routing key
+# Populate manually after apply:
+#   aws secretsmanager put-secret-value \
+#     --secret-id trade-tariff-uptime-pagerduty-development \
+#     --secret-string '{"routing_key":"<your-integration-key>"}'
+# ---------------------------------------------------------------------------
+
+resource "aws_kms_key" "uptime_monitor" {
+  description             = "KMS key for uptime monitor secrets"
+  deletion_window_in_days = 10
+  enable_key_rotation     = true
+}
+
+resource "aws_kms_alias" "uptime_monitor" {
+  name          = "alias/uptime-monitor-${var.environment}"
+  target_key_id = aws_kms_key.uptime_monitor.key_id
+}
+
+module "uptime_pagerduty_secret" {
+  source = "../../../modules/secret"
+
+  name            = "trade-tariff-uptime-pagerduty-${var.environment}"
+  kms_key_arn     = aws_kms_key.uptime_monitor.arn
+  recovery_window = "7"
+}
+
+# ---------------------------------------------------------------------------
+# CloudWatch dashboard — availability and response time per endpoint
+# ---------------------------------------------------------------------------
+
+resource "aws_cloudwatch_dashboard" "uptime" {
+  dashboard_name = "trade-tariff-uptime-${var.environment}"
+
+  dashboard_body = jsonencode({
+    widgets = flatten([
+      for name, url in local.uptime_endpoints : [
+        {
+          type   = "metric"
+          width  = 12
+          height = 6
+          properties = {
+            title   = "${name} — Availability"
+            metrics = [["TradeTariff/Uptime", "Availability", "Endpoint", name]]
+            period  = 60
+            stat    = "Minimum"
+            view    = "timeSeries"
+            yAxis   = { left = { min = 0, max = 1 } }
+            annotations = {
+              horizontal = [{ value = 1, color = "#2ca02c", label = "Up" }]
+            }
+          }
+        },
+        {
+          type   = "metric"
+          width  = 12
+          height = 6
+          properties = {
+            title   = "${name} — Response Time (ms)"
+            metrics = [["TradeTariff/Uptime", "ResponseTime", "Endpoint", name]]
+            period  = 60
+            stat    = "Average"
+            view    = "timeSeries"
+            yAxis   = { left = { min = 0 } }
+          }
+        }
+      ]
+    ])
+  })
+}

--- a/environments/development/common/uptime-monitor.tf
+++ b/environments/development/common/uptime-monitor.tf
@@ -8,6 +8,13 @@ locals {
 
   # Number of consecutive 1-minute failures before PagerDuty is alerted
   uptime_failure_threshold = 3
+
+  pagerduty_secret_value = try(data.aws_secretsmanager_secret_version.uptime_pagerduty.secret_string, "{}")
+  pagerduty_secret_map   = jsondecode(local.pagerduty_secret_value)
+}
+
+data "aws_secretsmanager_secret_version" "uptime_pagerduty" {
+  secret_id = module.uptime_pagerduty_secret.secret_arn
 }
 
 # ---------------------------------------------------------------------------
@@ -144,26 +151,9 @@ module "uptime_pagerduty" {
   memory_size      = 128
   timeout          = 30
 
-  additional_policy_arns = [aws_iam_policy.uptime_pagerduty_secrets.arn]
-
   environment_variables = {
-    PAGERDUTY_SECRET_ARN = module.uptime_pagerduty_secret.secret_arn
+    PAGERDUTY_ROUTING_KEY = lookup(local.pagerduty_secret_map, "routing_key", "")
   }
-}
-
-resource "aws_iam_policy" "uptime_pagerduty_secrets" {
-  name = "trade-tariff-uptime-pagerduty-secrets-${var.environment}"
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect   = "Allow"
-        Action   = ["secretsmanager:GetSecretValue"]
-        Resource = module.uptime_pagerduty_secret.secret_arn
-      }
-    ]
-  })
 }
 
 resource "aws_lambda_permission" "uptime_pagerduty_sns" {

--- a/environments/production/common/uptime-monitor.tf
+++ b/environments/production/common/uptime-monitor.tf
@@ -217,6 +217,7 @@ resource "aws_cloudwatch_dashboard" "uptime" {
           height = 6
           properties = {
             title   = "${name} — Availability"
+            region  = var.region
             metrics = [["TradeTariff/Uptime", "Availability", "Endpoint", name]]
             period  = 60
             stat    = "Minimum"
@@ -233,6 +234,7 @@ resource "aws_cloudwatch_dashboard" "uptime" {
           height = 6
           properties = {
             title   = "${name} — Response Time (ms)"
+            region  = var.region
             metrics = [["TradeTariff/Uptime", "ResponseTime", "Endpoint", name]]
             period  = 60
             stat    = "Average"

--- a/environments/production/common/uptime-monitor.tf
+++ b/environments/production/common/uptime-monitor.tf
@@ -1,0 +1,246 @@
+locals {
+  # Add URLs to monitor here. The key becomes the Endpoint dimension in CloudWatch
+  # and must be unique. Example:
+  #   "search-suggestions" = "https://www.trade-tariff.service.gov.uk/api/v2/search_suggestions"
+  uptime_endpoints = {
+    "find-commodity" = "https://www.trade-tariff.service.gov.uk/find_commodity"
+  }
+
+  # Number of consecutive 1-minute failures before PagerDuty is alerted
+  uptime_failure_threshold = 3
+}
+
+# ---------------------------------------------------------------------------
+# Lambda: URL checker
+# Runs every minute via EventBridge, probes each URL, emits custom metrics.
+# ---------------------------------------------------------------------------
+
+data "archive_file" "uptime_checker" {
+  type        = "zip"
+  source_dir  = "../../../common/lambda/trade-tariff-uptime-checker"
+  output_path = "lambda_uptime_checker.zip"
+}
+
+module "uptime_checker" {
+  source = "../../../modules/lambda"
+
+  function_name    = "trade-tariff-uptime-checker-${var.environment}"
+  filename         = data.archive_file.uptime_checker.output_path
+  handler          = "lambda_function.lambda_handler"
+  runtime          = "ruby3.4"
+  source_code_hash = data.archive_file.uptime_checker.output_base64sha256
+  memory_size      = 256
+  timeout          = 60
+
+  additional_policy_arns = [aws_iam_policy.uptime_checker_cloudwatch.arn]
+
+  environment_variables = {
+    MONITORED_URLS = jsonencode([
+      for name, url in local.uptime_endpoints : { name = name, url = url }
+    ])
+  }
+}
+
+resource "aws_iam_policy" "uptime_checker_cloudwatch" {
+  name = "trade-tariff-uptime-checker-cloudwatch-${var.environment}"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["cloudwatch:PutMetricData"]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "cloudwatch:namespace" = "TradeTariff/Uptime"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_cloudwatch_event_rule" "uptime_checker" {
+  name                = "trade-tariff-uptime-checker-${var.environment}"
+  description         = "Triggers uptime checker Lambda every minute"
+  schedule_expression = "rate(1 minute)"
+}
+
+resource "aws_cloudwatch_event_target" "uptime_checker" {
+  rule = aws_cloudwatch_event_rule.uptime_checker.name
+  arn  = module.uptime_checker.lambda_arn
+}
+
+resource "aws_lambda_permission" "uptime_checker_eventbridge" {
+  statement_id  = "AllowEventBridgeInvokeUptimeChecker"
+  action        = "lambda:InvokeFunction"
+  function_name = module.uptime_checker.lambda_arn
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.uptime_checker.arn
+}
+
+# ---------------------------------------------------------------------------
+# CloudWatch alarms — one per endpoint
+# Fires after uptime_failure_threshold consecutive 1-minute failures.
+# ---------------------------------------------------------------------------
+
+resource "aws_cloudwatch_metric_alarm" "uptime" {
+  for_each = local.uptime_endpoints
+
+  alarm_name          = "uptime-${each.key}-${var.environment}"
+  alarm_description   = "Uptime check failed for ${each.value}"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = local.uptime_failure_threshold
+  datapoints_to_alarm = local.uptime_failure_threshold
+  metric_name         = "Availability"
+  namespace           = "TradeTariff/Uptime"
+  period              = 60
+  statistic           = "Minimum"
+  threshold           = 1
+  treat_missing_data  = "breaching"
+
+  dimensions = {
+    Endpoint = each.key
+  }
+
+  alarm_actions = [aws_sns_topic.uptime_alerts.arn]
+  ok_actions    = [aws_sns_topic.uptime_alerts.arn]
+}
+
+# ---------------------------------------------------------------------------
+# SNS topic — fan-out point between alarms and the PagerDuty Lambda
+# ---------------------------------------------------------------------------
+
+resource "aws_sns_topic" "uptime_alerts" {
+  name = "trade-tariff-uptime-alerts-${var.environment}"
+}
+
+resource "aws_sns_topic_subscription" "uptime_pagerduty" {
+  topic_arn = aws_sns_topic.uptime_alerts.arn
+  protocol  = "lambda"
+  endpoint  = module.uptime_pagerduty.lambda_arn
+}
+
+# ---------------------------------------------------------------------------
+# Lambda: PagerDuty forwarder
+# Translates CloudWatch Alarm SNS payloads into PagerDuty Events API v2 calls.
+# ---------------------------------------------------------------------------
+
+data "archive_file" "uptime_pagerduty" {
+  type        = "zip"
+  source_dir  = "../../../common/lambda/trade-tariff-uptime-pagerduty"
+  output_path = "lambda_uptime_pagerduty.zip"
+}
+
+module "uptime_pagerduty" {
+  source = "../../../modules/lambda"
+
+  function_name    = "trade-tariff-uptime-pagerduty-${var.environment}"
+  filename         = data.archive_file.uptime_pagerduty.output_path
+  handler          = "lambda_function.lambda_handler"
+  runtime          = "ruby3.4"
+  source_code_hash = data.archive_file.uptime_pagerduty.output_base64sha256
+  memory_size      = 128
+  timeout          = 30
+
+  additional_policy_arns = [aws_iam_policy.uptime_pagerduty_secrets.arn]
+
+  environment_variables = {
+    PAGERDUTY_SECRET_ARN = module.uptime_pagerduty_secret.secret_arn
+  }
+}
+
+resource "aws_iam_policy" "uptime_pagerduty_secrets" {
+  name = "trade-tariff-uptime-pagerduty-secrets-${var.environment}"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["secretsmanager:GetSecretValue"]
+        Resource = module.uptime_pagerduty_secret.secret_arn
+      }
+    ]
+  })
+}
+
+resource "aws_lambda_permission" "uptime_pagerduty_sns" {
+  statement_id  = "AllowSNSInvokeUptimePagerduty"
+  action        = "lambda:InvokeFunction"
+  function_name = module.uptime_pagerduty.lambda_arn
+  principal     = "sns.amazonaws.com"
+  source_arn    = aws_sns_topic.uptime_alerts.arn
+}
+
+# ---------------------------------------------------------------------------
+# Secret: PagerDuty routing key
+# Populate manually after apply:
+#   aws secretsmanager put-secret-value \
+#     --secret-id trade-tariff-uptime-pagerduty-production \
+#     --secret-string '{"routing_key":"<your-integration-key>"}'
+# ---------------------------------------------------------------------------
+
+resource "aws_kms_key" "uptime_monitor" {
+  description             = "KMS key for uptime monitor secrets"
+  deletion_window_in_days = 10
+  enable_key_rotation     = true
+}
+
+resource "aws_kms_alias" "uptime_monitor" {
+  name          = "alias/uptime-monitor-${var.environment}"
+  target_key_id = aws_kms_key.uptime_monitor.key_id
+}
+
+module "uptime_pagerduty_secret" {
+  source = "../../../modules/secret"
+
+  name            = "trade-tariff-uptime-pagerduty-${var.environment}"
+  kms_key_arn     = aws_kms_key.uptime_monitor.arn
+  recovery_window = "7"
+}
+
+# ---------------------------------------------------------------------------
+# CloudWatch dashboard — availability and response time per endpoint
+# ---------------------------------------------------------------------------
+
+resource "aws_cloudwatch_dashboard" "uptime" {
+  dashboard_name = "trade-tariff-uptime-${var.environment}"
+
+  dashboard_body = jsonencode({
+    widgets = flatten([
+      for name, url in local.uptime_endpoints : [
+        {
+          type   = "metric"
+          width  = 12
+          height = 6
+          properties = {
+            title   = "${name} — Availability"
+            metrics = [["TradeTariff/Uptime", "Availability", "Endpoint", name]]
+            period  = 60
+            stat    = "Minimum"
+            view    = "timeSeries"
+            yAxis   = { left = { min = 0, max = 1 } }
+            annotations = {
+              horizontal = [{ value = 1, color = "#2ca02c", label = "Up" }]
+            }
+          }
+        },
+        {
+          type   = "metric"
+          width  = 12
+          height = 6
+          properties = {
+            title   = "${name} — Response Time (ms)"
+            metrics = [["TradeTariff/Uptime", "ResponseTime", "Endpoint", name]]
+            period  = 60
+            stat    = "Average"
+            view    = "timeSeries"
+            yAxis   = { left = { min = 0 } }
+          }
+        }
+      ]
+    ])
+  })
+}

--- a/environments/production/common/uptime-monitor.tf
+++ b/environments/production/common/uptime-monitor.tf
@@ -8,6 +8,13 @@ locals {
 
   # Number of consecutive 1-minute failures before PagerDuty is alerted
   uptime_failure_threshold = 3
+
+  pagerduty_secret_value = try(data.aws_secretsmanager_secret_version.uptime_pagerduty.secret_string, "{}")
+  pagerduty_secret_map   = jsondecode(local.pagerduty_secret_value)
+}
+
+data "aws_secretsmanager_secret_version" "uptime_pagerduty" {
+  secret_id = module.uptime_pagerduty_secret.secret_arn
 }
 
 # ---------------------------------------------------------------------------
@@ -144,26 +151,9 @@ module "uptime_pagerduty" {
   memory_size      = 128
   timeout          = 30
 
-  additional_policy_arns = [aws_iam_policy.uptime_pagerduty_secrets.arn]
-
   environment_variables = {
-    PAGERDUTY_SECRET_ARN = module.uptime_pagerduty_secret.secret_arn
+    PAGERDUTY_ROUTING_KEY = lookup(local.pagerduty_secret_map, "routing_key", "")
   }
-}
-
-resource "aws_iam_policy" "uptime_pagerduty_secrets" {
-  name = "trade-tariff-uptime-pagerduty-secrets-${var.environment}"
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect   = "Allow"
-        Action   = ["secretsmanager:GetSecretValue"]
-        Resource = module.uptime_pagerduty_secret.secret_arn
-      }
-    ]
-  })
 }
 
 resource "aws_lambda_permission" "uptime_pagerduty_sns" {

--- a/environments/staging/common/uptime-monitor.tf
+++ b/environments/staging/common/uptime-monitor.tf
@@ -217,6 +217,7 @@ resource "aws_cloudwatch_dashboard" "uptime" {
           height = 6
           properties = {
             title   = "${name} — Availability"
+            region  = var.region
             metrics = [["TradeTariff/Uptime", "Availability", "Endpoint", name]]
             period  = 60
             stat    = "Minimum"
@@ -233,6 +234,7 @@ resource "aws_cloudwatch_dashboard" "uptime" {
           height = 6
           properties = {
             title   = "${name} — Response Time (ms)"
+            region  = var.region
             metrics = [["TradeTariff/Uptime", "ResponseTime", "Endpoint", name]]
             period  = 60
             stat    = "Average"

--- a/environments/staging/common/uptime-monitor.tf
+++ b/environments/staging/common/uptime-monitor.tf
@@ -1,0 +1,246 @@
+locals {
+  # Add URLs to monitor here. The key becomes the Endpoint dimension in CloudWatch
+  # and must be unique. Example:
+  #   "search-suggestions" = "https://www.trade-tariff.service.gov.uk/api/v2/search_suggestions"
+  uptime_endpoints = {
+    "find-commodity" = "https://staging.trade-tariff.service.gov.uk/find_commodity"
+  }
+
+  # Number of consecutive 1-minute failures before PagerDuty is alerted
+  uptime_failure_threshold = 3
+}
+
+# ---------------------------------------------------------------------------
+# Lambda: URL checker
+# Runs every minute via EventBridge, probes each URL, emits custom metrics.
+# ---------------------------------------------------------------------------
+
+data "archive_file" "uptime_checker" {
+  type        = "zip"
+  source_dir  = "../../../common/lambda/trade-tariff-uptime-checker"
+  output_path = "lambda_uptime_checker.zip"
+}
+
+module "uptime_checker" {
+  source = "../../../modules/lambda"
+
+  function_name    = "trade-tariff-uptime-checker-${var.environment}"
+  filename         = data.archive_file.uptime_checker.output_path
+  handler          = "lambda_function.lambda_handler"
+  runtime          = "ruby3.4"
+  source_code_hash = data.archive_file.uptime_checker.output_base64sha256
+  memory_size      = 256
+  timeout          = 60
+
+  additional_policy_arns = [aws_iam_policy.uptime_checker_cloudwatch.arn]
+
+  environment_variables = {
+    MONITORED_URLS = jsonencode([
+      for name, url in local.uptime_endpoints : { name = name, url = url }
+    ])
+  }
+}
+
+resource "aws_iam_policy" "uptime_checker_cloudwatch" {
+  name = "trade-tariff-uptime-checker-cloudwatch-${var.environment}"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["cloudwatch:PutMetricData"]
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "cloudwatch:namespace" = "TradeTariff/Uptime"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_cloudwatch_event_rule" "uptime_checker" {
+  name                = "trade-tariff-uptime-checker-${var.environment}"
+  description         = "Triggers uptime checker Lambda every minute"
+  schedule_expression = "rate(1 minute)"
+}
+
+resource "aws_cloudwatch_event_target" "uptime_checker" {
+  rule = aws_cloudwatch_event_rule.uptime_checker.name
+  arn  = module.uptime_checker.lambda_arn
+}
+
+resource "aws_lambda_permission" "uptime_checker_eventbridge" {
+  statement_id  = "AllowEventBridgeInvokeUptimeChecker"
+  action        = "lambda:InvokeFunction"
+  function_name = module.uptime_checker.lambda_arn
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.uptime_checker.arn
+}
+
+# ---------------------------------------------------------------------------
+# CloudWatch alarms — one per endpoint
+# Fires after uptime_failure_threshold consecutive 1-minute failures.
+# ---------------------------------------------------------------------------
+
+resource "aws_cloudwatch_metric_alarm" "uptime" {
+  for_each = local.uptime_endpoints
+
+  alarm_name          = "uptime-${each.key}-${var.environment}"
+  alarm_description   = "Uptime check failed for ${each.value}"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = local.uptime_failure_threshold
+  datapoints_to_alarm = local.uptime_failure_threshold
+  metric_name         = "Availability"
+  namespace           = "TradeTariff/Uptime"
+  period              = 60
+  statistic           = "Minimum"
+  threshold           = 1
+  treat_missing_data  = "breaching"
+
+  dimensions = {
+    Endpoint = each.key
+  }
+
+  alarm_actions = [aws_sns_topic.uptime_alerts.arn]
+  ok_actions    = [aws_sns_topic.uptime_alerts.arn]
+}
+
+# ---------------------------------------------------------------------------
+# SNS topic — fan-out point between alarms and the PagerDuty Lambda
+# ---------------------------------------------------------------------------
+
+resource "aws_sns_topic" "uptime_alerts" {
+  name = "trade-tariff-uptime-alerts-${var.environment}"
+}
+
+resource "aws_sns_topic_subscription" "uptime_pagerduty" {
+  topic_arn = aws_sns_topic.uptime_alerts.arn
+  protocol  = "lambda"
+  endpoint  = module.uptime_pagerduty.lambda_arn
+}
+
+# ---------------------------------------------------------------------------
+# Lambda: PagerDuty forwarder
+# Translates CloudWatch Alarm SNS payloads into PagerDuty Events API v2 calls.
+# ---------------------------------------------------------------------------
+
+data "archive_file" "uptime_pagerduty" {
+  type        = "zip"
+  source_dir  = "../../../common/lambda/trade-tariff-uptime-pagerduty"
+  output_path = "lambda_uptime_pagerduty.zip"
+}
+
+module "uptime_pagerduty" {
+  source = "../../../modules/lambda"
+
+  function_name    = "trade-tariff-uptime-pagerduty-${var.environment}"
+  filename         = data.archive_file.uptime_pagerduty.output_path
+  handler          = "lambda_function.lambda_handler"
+  runtime          = "ruby3.4"
+  source_code_hash = data.archive_file.uptime_pagerduty.output_base64sha256
+  memory_size      = 128
+  timeout          = 30
+
+  additional_policy_arns = [aws_iam_policy.uptime_pagerduty_secrets.arn]
+
+  environment_variables = {
+    PAGERDUTY_SECRET_ARN = module.uptime_pagerduty_secret.secret_arn
+  }
+}
+
+resource "aws_iam_policy" "uptime_pagerduty_secrets" {
+  name = "trade-tariff-uptime-pagerduty-secrets-${var.environment}"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["secretsmanager:GetSecretValue"]
+        Resource = module.uptime_pagerduty_secret.secret_arn
+      }
+    ]
+  })
+}
+
+resource "aws_lambda_permission" "uptime_pagerduty_sns" {
+  statement_id  = "AllowSNSInvokeUptimePagerduty"
+  action        = "lambda:InvokeFunction"
+  function_name = module.uptime_pagerduty.lambda_arn
+  principal     = "sns.amazonaws.com"
+  source_arn    = aws_sns_topic.uptime_alerts.arn
+}
+
+# ---------------------------------------------------------------------------
+# Secret: PagerDuty routing key
+# Populate manually after apply:
+#   aws secretsmanager put-secret-value \
+#     --secret-id trade-tariff-uptime-pagerduty-staging \
+#     --secret-string '{"routing_key":"<your-integration-key>"}'
+# ---------------------------------------------------------------------------
+
+resource "aws_kms_key" "uptime_monitor" {
+  description             = "KMS key for uptime monitor secrets"
+  deletion_window_in_days = 10
+  enable_key_rotation     = true
+}
+
+resource "aws_kms_alias" "uptime_monitor" {
+  name          = "alias/uptime-monitor-${var.environment}"
+  target_key_id = aws_kms_key.uptime_monitor.key_id
+}
+
+module "uptime_pagerduty_secret" {
+  source = "../../../modules/secret"
+
+  name            = "trade-tariff-uptime-pagerduty-${var.environment}"
+  kms_key_arn     = aws_kms_key.uptime_monitor.arn
+  recovery_window = "7"
+}
+
+# ---------------------------------------------------------------------------
+# CloudWatch dashboard — availability and response time per endpoint
+# ---------------------------------------------------------------------------
+
+resource "aws_cloudwatch_dashboard" "uptime" {
+  dashboard_name = "trade-tariff-uptime-${var.environment}"
+
+  dashboard_body = jsonencode({
+    widgets = flatten([
+      for name, url in local.uptime_endpoints : [
+        {
+          type   = "metric"
+          width  = 12
+          height = 6
+          properties = {
+            title   = "${name} — Availability"
+            metrics = [["TradeTariff/Uptime", "Availability", "Endpoint", name]]
+            period  = 60
+            stat    = "Minimum"
+            view    = "timeSeries"
+            yAxis   = { left = { min = 0, max = 1 } }
+            annotations = {
+              horizontal = [{ value = 1, color = "#2ca02c", label = "Up" }]
+            }
+          }
+        },
+        {
+          type   = "metric"
+          width  = 12
+          height = 6
+          properties = {
+            title   = "${name} — Response Time (ms)"
+            metrics = [["TradeTariff/Uptime", "ResponseTime", "Endpoint", name]]
+            period  = 60
+            stat    = "Average"
+            view    = "timeSeries"
+            yAxis   = { left = { min = 0 } }
+          }
+        }
+      ]
+    ])
+  })
+}

--- a/environments/staging/common/uptime-monitor.tf
+++ b/environments/staging/common/uptime-monitor.tf
@@ -8,6 +8,13 @@ locals {
 
   # Number of consecutive 1-minute failures before PagerDuty is alerted
   uptime_failure_threshold = 3
+
+  pagerduty_secret_value = try(data.aws_secretsmanager_secret_version.uptime_pagerduty.secret_string, "{}")
+  pagerduty_secret_map   = jsondecode(local.pagerduty_secret_value)
+}
+
+data "aws_secretsmanager_secret_version" "uptime_pagerduty" {
+  secret_id = module.uptime_pagerduty_secret.secret_arn
 }
 
 # ---------------------------------------------------------------------------
@@ -144,26 +151,9 @@ module "uptime_pagerduty" {
   memory_size      = 128
   timeout          = 30
 
-  additional_policy_arns = [aws_iam_policy.uptime_pagerduty_secrets.arn]
-
   environment_variables = {
-    PAGERDUTY_SECRET_ARN = module.uptime_pagerduty_secret.secret_arn
+    PAGERDUTY_ROUTING_KEY = lookup(local.pagerduty_secret_map, "routing_key", "")
   }
-}
-
-resource "aws_iam_policy" "uptime_pagerduty_secrets" {
-  name = "trade-tariff-uptime-pagerduty-secrets-${var.environment}"
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect   = "Allow"
-        Action   = ["secretsmanager:GetSecretValue"]
-        Resource = module.uptime_pagerduty_secret.secret_arn
-      }
-    ]
-  })
 }
 
 resource "aws_lambda_permission" "uptime_pagerduty_sns" {

--- a/modules/lambda/README.md
+++ b/modules/lambda/README.md
@@ -46,6 +46,7 @@ No modules.
 | <a name="input_memory_size"></a> [memory\_size](#input\_memory\_size) | Memory limit in MB | `number` | `128` | no |
 | <a name="input_runtime"></a> [runtime](#input\_runtime) | Function runtime identifier | `string` | n/a | yes |
 | <a name="input_source_code_hash"></a> [source\_code\_hash](#input\_source\_code\_hash) | base64 encoded SHA256 hash of the payload file | `string` | n/a | yes |
+| <a name="input_timeout"></a> [timeout](#input\_timeout) | Timeout in seconds | `number` | `30` | no |
 
 ## Outputs
 

--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -8,6 +8,7 @@ resource "aws_lambda_function" "this" {
   runtime          = var.runtime
 
   memory_size = var.memory_size
+  timeout     = var.timeout
 
   environment {
     variables = var.environment_variables

--- a/modules/lambda/variables.tf
+++ b/modules/lambda/variables.tf
@@ -41,6 +41,12 @@ variable "environment_variables" {
   default     = {}
 }
 
+variable "timeout" {
+  description = "Timeout in seconds"
+  type        = number
+  default     = 30
+}
+
 variable "log_retention_days" {
   description = "Number of days to retain CloudWatch logs"
   type        = number


### PR DESCRIPTION
## Summary

- Adds a Lambda-based uptime monitor that probes configured URLs every minute and publishes `Availability` and `ResponseTime` metrics to CloudWatch (`TradeTariff/Uptime` namespace)
- CloudWatch alarms fire after 3 consecutive 1-minute failures and auto-resolve when the endpoint recovers
- Alarms trigger a PagerDuty forwarder Lambda via SNS, which calls the PagerDuty Events API v2 (deduplication key per alarm ensures clean trigger/resolve pairs)
- A CloudWatch dashboard provides a live view of availability and response-time history per endpoint
- Deployed across all three environments (development, staging, production) with environment-appropriate URLs

## Architecture

```
EventBridge (rate 1 min)
  └─> Checker Lambda (probes URLs, emits CloudWatch metrics)
        └─> CloudWatch Alarm (fires after 3 consecutive failures)
              └─> SNS Topic
                    └─> PagerDuty Lambda (Events API v2 trigger/resolve)
```

## Adding more URLs

Edit `uptime_endpoints` in the relevant `environments/{env}/common/uptime-monitor.tf` and re-apply. Each new entry automatically gets an alarm, dashboard widget, and metric.

## Post-deploy step (per environment)

After first apply, populate the PagerDuty routing key from the Integrations page (Events API v2):

```sh
aws secretsmanager put-secret-value \
  --region eu-west-2 \
  --secret-id trade-tariff-uptime-pagerduty-{environment} \
  --secret-string '{"routing_key":"<your-integration-key>"}'
```

## Test plan

- [ ] `terraform plan` shows expected resources in each environment before applying
- [ ] After apply, verify the checker Lambda invokes on schedule (CloudWatch Logs: `/aws/lambda/trade-tariff-uptime-checker-{env}`)
- [ ] Confirm `Availability` and `ResponseTime` metrics appear in CloudWatch under `TradeTariff/Uptime`
- [ ] Populate PagerDuty secret and manually invoke PagerDuty Lambda with a test ALARM payload to confirm alert fires
- [ ] Verify CloudWatch dashboard renders correctly