### PR TITLE
BAU: Allow cloudwatch:TagResource action for ci_ecs_deployment_policy

### DIFF
--- a/environments/development/common/iam-policies.tf
+++ b/environments/development/common/iam-policies.tf
@@ -94,6 +94,7 @@ resource "aws_iam_policy" "ci_ecs_deployment_policy" {
           "cloudwatch:ListTagsForResource",
           "cloudwatch:PutDashboard",
           "cloudwatch:PutMetricAlarm",
+          "cloudwatch:TagResource",
           # Cognito - identity service reads user pool config
           "cognito-idp:DescribeUserPool",
           # EC2 - read-only data sources for VPC, subnets, security groups

--- a/environments/production/common/iam-policies.tf
+++ b/environments/production/common/iam-policies.tf
@@ -175,6 +175,7 @@ resource "aws_iam_policy" "ci_ecs_deployment_policy" {
           "cloudwatch:ListTagsForResource",
           "cloudwatch:PutDashboard",
           "cloudwatch:PutMetricAlarm",
+          "cloudwatch:TagResource",
           # Cognito - identity service reads user pool config
           "cognito-idp:DescribeUserPool",
           # EC2 - read-only data sources for VPC, subnets, security groups

--- a/environments/staging/common/iam-policies.tf
+++ b/environments/staging/common/iam-policies.tf
@@ -175,6 +175,7 @@ resource "aws_iam_policy" "ci_ecs_deployment_policy" {
           "cloudwatch:ListTagsForResource",
           "cloudwatch:PutDashboard",
           "cloudwatch:PutMetricAlarm",
+          "cloudwatch:TagResource",
           # Cognito - identity service reads user pool config
           "cognito-idp:DescribeUserPool",
           # EC2 - read-only data sources for VPC, subnets, security groups


### PR DESCRIPTION
# Jira link
BAU

## What?

I have:

- Added `CloudWatch:TagResource `action to the `ci_ecs_deployment_policy`

## Why?

I am doing this because:

- I am doing this because ECS deployments require permission to tag resources in CloudWatch, and the deployment process was failing due to [missing `CloudWatch:TagResource` permissions.](https://github.com/trade-tariff/trade-tariff-frontend/actions/runs/25170431187/job/73788530129)
