### PR TITLE
BAU: Edit GithubActions-Serverless-Lambda-Role

### DIFF
--- a/environments/development/common/iam-roles.tf
+++ b/environments/development/common/iam-roles.tf
@@ -52,6 +52,7 @@ resource "aws_iam_role" "serverless_lambda_ci_role" {
               "repo:trade-tariff/trade-tariff-lambdas-electronic-tariff-file-rotations:*",
               "repo:trade-tariff/trade-tariff-lambdas-fpo-model-garbage-collection:*",
               "repo:trade-tariff/trade-tariff-lambdas-fpo-search:*",
+              "repo:trade-tariff/trade-tariff-lambdas-uptime-monitor:*",
             ]
           }
         }

--- a/environments/production/common/iam-roles.tf
+++ b/environments/production/common/iam-roles.tf
@@ -52,6 +52,7 @@ resource "aws_iam_role" "serverless_lambda_ci_role" {
               "repo:trade-tariff/trade-tariff-lambdas-electronic-tariff-file-rotations:*",
               "repo:trade-tariff/trade-tariff-lambdas-fpo-model-garbage-collection:*",
               "repo:trade-tariff/trade-tariff-lambdas-fpo-search:*",
+              "repo:trade-tariff/trade-tariff-lambdas-uptime-monitor:*",
             ]
           }
         }

--- a/environments/staging/common/iam-roles.tf
+++ b/environments/staging/common/iam-roles.tf
@@ -52,6 +52,7 @@ resource "aws_iam_role" "serverless_lambda_ci_role" {
               "repo:trade-tariff/trade-tariff-lambdas-electronic-tariff-file-rotations:*",
               "repo:trade-tariff/trade-tariff-lambdas-fpo-model-garbage-collection:*",
               "repo:trade-tariff/trade-tariff-lambdas-fpo-search:*",
+              "repo:trade-tariff/trade-tariff-lambdas-uptime-monitor:*",
             ]
           }
         }


### PR DESCRIPTION
# Jira link
BAU
## What?

I have:

- Added repo:trade-tariff/trade-tariff-lambdas-uptime-monitor:* to the list of repositories allowed to consume GithubActions-Serverless-Lambda-Role.

## Why?

I am doing this because:

- This allows the trade-tariff-lambdas-uptime-monitor repository to assume and use the role in GitHub Actions.
