### PR TITLE
Enable Cognito refresh token rotation in production

### DIFF
--- a/environments/production/common/cognito-identity.tf
+++ b/environments/production/common/cognito-identity.tf
@@ -29,12 +29,12 @@ module "identity_cognito" {
 
   client_name = "identity-client"
   client_auth_flows = [
-    "ALLOW_CUSTOM_AUTH",
-    "ALLOW_REFRESH_TOKEN_AUTH"
+    "ALLOW_CUSTOM_AUTH"
   ]
 
-  client_auth_session_validity   = 15
-  client_enable_token_revocation = false
+  client_auth_session_validity         = 15
+  client_enable_token_revocation       = false
+  client_enable_refresh_token_rotation = true
 
   client_token_validity = {
     access_token = {


### PR DESCRIPTION
# Jira link
[OTTIMP-542](https://transformuk.atlassian.net/browse/OTTIMP-542)

## What?
Enabled refresh token rotation in production.
This is not compatible with the old ALLOW_REFRESH_TOKEN_AUTH auth flow so it has been removed.

## Why?
This enables users to stay logged in for longer the current 30 day duration of the refresh token. Every time the user is re-authenticated a new 30 day refresh token is issued.

Previously this had been enabled in staging
