### PR TITLE
BAU: Add more actions required for Trade Tariff Uptime Monitor

### DIFF
--- a/environments/development/common/iam-policies.tf
+++ b/environments/development/common/iam-policies.tf
@@ -456,6 +456,31 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
           module.fpo_search_configuration.secret_arn,
         ]
       },
+      {
+        Sid    = "TradeTariffUptimeMonitorInfra",
+        Effect = "Allow",
+        Action = [
+          "cloudwatch:DeleteDashboards",
+          "cloudwatch:GetDashboard",
+          "cloudwatch:ListDashboards",
+          "cloudwatch:PutDashboard",
+          "sns:CreateTopic",
+          "sns:DeleteTopic",
+          "sns:GetTopicAttributes",
+          "sns:SetTopicAttributes",
+          "sns:Subscribe",
+          "sns:Unsubscribe",
+          "sns:ListSubscriptionsByTopic",
+          "sns:ListTopics",
+          "sns:TagResource",
+          "sns:UntagResource",
+          "lambda:InvokeFunction",
+          "lambda:ListEventSourceMappings",
+          "events:TagResource",
+          "events:UntagResource"
+        ],
+        Resource = "*"
+      }
     ]
   })
 }

--- a/environments/production/common/iam-policies.tf
+++ b/environments/production/common/iam-policies.tf
@@ -573,6 +573,31 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
           module.fpo_search_configuration.secret_arn,
         ]
       },
+      {
+        Sid    = "TradeTariffUptimeMonitorInfra",
+        Effect = "Allow",
+        Action = [
+          "cloudwatch:DeleteDashboards",
+          "cloudwatch:GetDashboard",
+          "cloudwatch:ListDashboards",
+          "cloudwatch:PutDashboard",
+          "sns:CreateTopic",
+          "sns:DeleteTopic",
+          "sns:GetTopicAttributes",
+          "sns:SetTopicAttributes",
+          "sns:Subscribe",
+          "sns:Unsubscribe",
+          "sns:ListSubscriptionsByTopic",
+          "sns:ListTopics",
+          "sns:TagResource",
+          "sns:UntagResource",
+          "lambda:InvokeFunction",
+          "lambda:ListEventSourceMappings",
+          "events:TagResource",
+          "events:UntagResource"
+        ],
+        Resource = "*"
+      }
     ]
   })
 }

--- a/environments/staging/common/iam-policies.tf
+++ b/environments/staging/common/iam-policies.tf
@@ -537,6 +537,31 @@ resource "aws_iam_policy" "ci_lambda_deployment_policy" {
           module.fpo_search_configuration.secret_arn,
         ]
       },
+      {
+        Sid    = "TradeTariffUptimeMonitorInfra",
+        Effect = "Allow",
+        Action = [
+          "cloudwatch:DeleteDashboards",
+          "cloudwatch:GetDashboard",
+          "cloudwatch:ListDashboards",
+          "cloudwatch:PutDashboard",
+          "sns:CreateTopic",
+          "sns:DeleteTopic",
+          "sns:GetTopicAttributes",
+          "sns:SetTopicAttributes",
+          "sns:Subscribe",
+          "sns:Unsubscribe",
+          "sns:ListSubscriptionsByTopic",
+          "sns:ListTopics",
+          "sns:TagResource",
+          "sns:UntagResource",
+          "lambda:InvokeFunction",
+          "lambda:ListEventSourceMappings",
+          "events:TagResource",
+          "events:UntagResource"
+        ],
+        Resource = "*"
+      }
     ]
   })
 }


### PR DESCRIPTION
# Jira link
BAU

## What?

I have:

- Expanded the `ci_lambda_deployment_policy` with additional IAM actions.

## Why?

I am doing this because:

- The new serverless uptime monitoring service (trade-tariff-lambdas-uptime-monitor) introduces additional AWS resources (SNS topics, CloudWatch dashboards/alarms, EventBridge rules).
- CloudFormation and Serverless require extra permissions (e.g. resource creation, tagging, and deletion) to successfully deploy, update, and roll back this infrastructure.
- Without these permissions, deployments can fail or stacks can become stuck in CREATE_FAILED / ROLLBACK_FAILED states.
