### PR TITLE
Add cloud watch alarm for when cognito hits 800 clients for the dev-hub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ backend.tf
 environments/production/common/builds/
 /.terraform.lock.hcl
 modules/**/.terraform.lock.hcl
+# Track lockfile so pre-commit `terraform init -lockfile=readonly` succeeds for this module.
+!modules/cognito_app_client_count_monitor/.terraform.lock.hcl
 
 # vim
 [._]*.s[a-v][a-z]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,14 +9,18 @@ repos:
     rev: v1.105.0
     hooks:
       - id: terraform_fmt
+      # -backend=false: install modules/providers without remote state (S3 backend often
+      # unavailable locally); otherwise init aborts and validate reports "Module not installed".
       - id: terraform_validate
         args:
           - --hook-config=--parallelism-limit=1
           - --tf-init-args=-lockfile=readonly
+          - --tf-init-args=-backend=false
       - id: terraform_tflint
         args:
           - --hook-config=--parallelism-limit=1
           - --tf-init-args=-lockfile=readonly
+          - --tf-init-args=-backend=false
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/environments/production/common/cognito-app-client-count.tf
+++ b/environments/production/common/cognito-app-client-count.tf
@@ -1,0 +1,8 @@
+module "identity_cognito_app_client_count_monitor" {
+  source = "../../../modules/cognito_app_client_count_monitor"
+
+  environment   = var.environment
+  user_pool_id  = module.identity_cognito.user_pool_id
+  user_pool_arn = module.identity_cognito.user_pool_arn
+  alarm_actions = local.alert_actions
+}

--- a/environments/staging/common/.terraform.lock.hcl
+++ b/environments/staging/common/.terraform.lock.hcl
@@ -1,9 +1,14 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/archive" {
   version     = "2.7.1"
-  constraints = ">= 2.0.0"
+  constraints = ">= 2.0.0, 2.7.1"
   hashes = [
     "h1:62VrkalDPMKB9zerCBS4iKTbvxejwnAWn/XXYZZQWD4=",
+    "h1:A7EnRBVm4h9ryO9LwxYnKr4fy7ExPMwD5a1DsY7m1Y0=",
+    "h1:MwZ8uhTOmj3W8wiMeitCnzuf+897qka4/NBIAWFrm+k=",
+    "h1:Tr6LvLbm30zX4BRNPHhXo8SnOP0vg5UKAeunRNfnas8=",
     "zh:19881bb356a4a656a865f48aee70c0b8a03c35951b7799b6113883f67f196e8e",
     "zh:2fcfbf6318dd514863268b09bbe19bfc958339c636bcbcc3664b45f2b8bf5cc6",
     "zh:3323ab9a504ce0a115c28e64d0739369fe85151291a2ce480d51ccbb0c381ac5",
@@ -21,9 +26,12 @@ provider "registry.terraform.io/hashicorp/archive" {
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "6.38.0"
-  constraints = ">= 6.0.0"
+  constraints = ">= 4.9.0, >= 6.0.0"
   hashes = [
     "h1:7F3W4qGLTbr4aploSI8eIqE4AueoNe/Tq5Osuo0IgJ4=",
+    "h1:GOlIkFIhuKpVeBG+m77rXhiT7/r1AKFfhokm9WdZj1o=",
+    "h1:RDoKIzXmt7H1mNFcNIyRT+nA/gTJyO3+iW9QGN5I2eQ=",
+    "h1:fJlpWm8M4RGM5TZGeblUiP3WqhUI0zV0hM+NAJ9lVlY=",
     "zh:143f118ae71059a7a7026c6b950da23fef04a06e2362ffa688bef75e43e869ed",
     "zh:29ee220a017306effd877e1280f8b2934dc957e16e0e72ca0222e5514d0db522",
     "zh:3a31baabf7aea7aa7669f5a3d76f3445e0e6cce5e9aea0279992765c0df12aee",
@@ -44,8 +52,11 @@ provider "registry.terraform.io/hashicorp/aws" {
 
 provider "registry.terraform.io/hashicorp/external" {
   version     = "2.3.5"
-  constraints = ">= 2.3.5"
+  constraints = ">= 1.0.0, >= 2.3.5"
   hashes = [
+    "h1:1JSWWSmVSxzHGbD4RmaNUsdGsr2hPo+WwYaluyWv7vY=",
+    "h1:FnUk98MI5nOh3VJ16cHf8mchQLewLfN1qZG/MqNgPrI=",
+    "h1:IE3n531K7Agq3/pourJdsKV7l5EifBb09TXsb8shTXM=",
     "h1:smKSos4zs57pJjQrNuvGBpSWth2el9SgePPbPHo0aps=",
     "zh:6e89509d056091266532fa64de8c06950010498adf9070bf6ff85bc485a82562",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
@@ -64,9 +75,12 @@ provider "registry.terraform.io/hashicorp/external" {
 
 provider "registry.terraform.io/hashicorp/local" {
   version     = "2.7.0"
-  constraints = "2.7.0"
+  constraints = ">= 1.0.0"
   hashes = [
     "h1:2RYa3j7m/0WmET2fqotY4CHxE1Hpk0fgn47/126l+Og=",
+    "h1:SY06ZmR7rY7QMGoVEkeFrERVitBp2GKl/ATz9tbjXlk=",
+    "h1:ZM8+dCHsSogRknZkPUeUMzHyY1UAZ0GWFJ24YP8v+AQ=",
+    "h1:sSwlfp2etjCaE9hIF7bJBDjRIhDCVFglEOVyiCI7vgs=",
     "zh:261fec71bca13e0a7812dc0d8ae9af2b4326b24d9b2e9beab3d2400fab5c5f9a",
     "zh:308da3b5376a9ede815042deec5af1050ec96a5a5410a2206ae847d82070a23e",
     "zh:3d056924c420464dc8aba10e1915956b2e5c4d55b11ffff79aa8be563fbfe298",
@@ -84,9 +98,12 @@ provider "registry.terraform.io/hashicorp/local" {
 
 provider "registry.terraform.io/hashicorp/null" {
   version     = "3.2.4"
-  constraints = "3.2.4"
+  constraints = ">= 2.0.0, >= 3.0.0"
   hashes = [
+    "h1:127ts0CG8hFk1bHIfrBsKxcnt9bAYQCq3udWM+AACH8=",
+    "h1:L5V05xwp/Gto1leRryuesxjMfgZwjb7oool4WS1UEFQ=",
     "h1:hkf5w5B6q8e2A42ND2CjAvgvSN3puAosDmOJb3zCVQM=",
+    "h1:wTNrZnwQdOOT/TW9pa+7GgJeFK2OvTvDmx78VmUmZXM=",
     "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
     "zh:795c897119ff082133150121d39ff26cb5f89a730a2c8c26f3a9c1abf81a9c43",
@@ -107,6 +124,9 @@ provider "registry.terraform.io/hashicorp/random" {
   constraints = ">= 3.0.0"
   hashes = [
     "h1:Eexl06+6J+s75uD46+WnZtpJZYRVUMB0AiuPBifK6Jc=",
+    "h1:fdfOl1HabDT42XLH8qjmfTbVZpgQZ5lyOyOa+GQhm0w=",
+    "h1:m2y2fw9SBQ6+e7pNhi3+qsh8bYNmqkL89BulzH7uK3U=",
+    "h1:u8AKlWVDTH5r9YLSeswoVEjiY72Rt4/ch7U+61ZDkiQ=",
     "zh:08dd03b918c7b55713026037c5400c48af5b9f468f483463321bd18e17b907b4",
     "zh:0eee654a5542dc1d41920bbf2419032d6f0d5625b03bd81339e5b33394a3e0ae",
     "zh:229665ddf060aa0ed315597908483eee5b818a17d09b6417a0f52fd9405c4f57",
@@ -126,7 +146,10 @@ provider "registry.terraform.io/hashicorp/tls" {
   version     = "4.2.1"
   constraints = ">= 4.0.0"
   hashes = [
+    "h1:8ChZhIRVwAgZS31pAlOJ/yMeujsOATFNv2eRp3R9sBE=",
     "h1:F5d6bQY8UlBo0D71Sv7CsV+3aZOFz0yeNF+vufog7h4=",
+    "h1:akFNuHwvrtnYMBofieoeXhPJDhYZzJVu/Q/BgZK2fgg=",
+    "h1:wTIzrwUB7NINYwLFYLdWkJQwg1r9XT6rVOGrZ1+lMmI=",
     "zh:0d1e7d07ac973b97fa228f46596c800de830820506ee145626f079dd6bbf8d8a",
     "zh:5c7e3d4348cb4861ab812973ef493814a4b224bdd3e9d534a7c8a7c992382b86",
     "zh:7c6d4a86cd7a4e9c1025c6b3a3a6a45dea202af85d870cddbab455fb1bd568ad",
@@ -147,6 +170,9 @@ provider "registry.terraform.io/newrelic/newrelic" {
   constraints = ">= 3.78.0"
   hashes = [
     "h1:BacBfo4iCzWThRgNX/f26M0vt81ud1CG1kTYsCKVfZY=",
+    "h1:In6ESu7ojzE/gklJbqIRIQmTDJjoJP41Js29I8c9b2M=",
+    "h1:JnOuc3JAIr2nNIKtg1EVZTfmNCInrZTAdCFJqMyO9zQ=",
+    "h1:rVZUwPAgKDcGmTlKD9GwNRAinQZPwO2ZEMRwCRDGH80=",
     "zh:0a15f8e4103e7744e5292607f6e161bbf0fef753e699a1e2c27e6d42d8960a26",
     "zh:105b1e03306a33ef92a942b7974100092bb907aed5e3c715f99ccd1a3d0afb8e",
     "zh:16557e02b4dc2b7b96383323bc153b892142ff95b0be19de1d6a62537a6f854c",

--- a/environments/staging/common/cognito-app-client-count.tf
+++ b/environments/staging/common/cognito-app-client-count.tf
@@ -1,0 +1,8 @@
+module "identity_cognito_app_client_count_monitor" {
+  source = "../../../modules/cognito_app_client_count_monitor"
+
+  environment   = var.environment
+  user_pool_id  = module.identity_cognito.user_pool_id
+  user_pool_arn = module.identity_cognito.user_pool_arn
+  alarm_actions = local.alert_actions
+}

--- a/modules/cognito_app_client_count_monitor/.terraform.lock.hcl
+++ b/modules/cognito_app_client_count_monitor/.terraform.lock.hcl
@@ -1,0 +1,51 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version     = "2.7.1"
+  constraints = ">= 2.0.0"
+  hashes = [
+    "h1:62VrkalDPMKB9zerCBS4iKTbvxejwnAWn/XXYZZQWD4=",
+    "h1:A7EnRBVm4h9ryO9LwxYnKr4fy7ExPMwD5a1DsY7m1Y0=",
+    "h1:MwZ8uhTOmj3W8wiMeitCnzuf+897qka4/NBIAWFrm+k=",
+    "h1:Tr6LvLbm30zX4BRNPHhXo8SnOP0vg5UKAeunRNfnas8=",
+    "zh:19881bb356a4a656a865f48aee70c0b8a03c35951b7799b6113883f67f196e8e",
+    "zh:2fcfbf6318dd514863268b09bbe19bfc958339c636bcbcc3664b45f2b8bf5cc6",
+    "zh:3323ab9a504ce0a115c28e64d0739369fe85151291a2ce480d51ccbb0c381ac5",
+    "zh:362674746fb3da3ab9bd4e70c75a3cdd9801a6cf258991102e2c46669cf68e19",
+    "zh:7140a46d748fdd12212161445c46bbbf30a3f4586c6ac97dd497f0c2565fe949",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:875e6ce78b10f73b1efc849bfcc7af3a28c83a52f878f503bb22776f71d79521",
+    "zh:b872c6ed24e38428d817ebfb214da69ea7eefc2c38e5a774db2ccd58e54d3a22",
+    "zh:cd6a44f731c1633ae5d37662af86e7b01ae4c96eb8b04144255824c3f350392d",
+    "zh:e0600f5e8da12710b0c52d6df0ba147a5486427c1a2cc78f31eea37a47ee1b07",
+    "zh:f21b2e2563bbb1e44e73557bcd6cdbc1ceb369d471049c40eb56cb84b6317a60",
+    "zh:f752829eba1cc04a479cf7ae7271526b402e206d5bcf1fcce9f535de5ff9e4e6",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.43.0"
+  constraints = ">= 6.0.0"
+  hashes = [
+    "h1:/A3VpeGOhvutRSlGACfUKeBMFZa3CTSLIqvT+XH0364=",
+    "h1:TuLqfrTx7PrnCuYIqNJHLJ4UtCq8xsiuhDBoRA71Bxw=",
+    "h1:wnmFvwQyif+Z0D+fZP8i8hmqvrZqsxwYdyaI7X05jTk=",
+    "h1:yvdZqdEHHDk0WWL8oiK8dLaouJMSVZRkxGLEhDZyFCo=",
+    "zh:0fe91026ce8c5178781de6773531dcfcf5280ee139059dc5a0c046f1532cf389",
+    "zh:114001f94c38db8702210eda643ec627fa1929a88f774e17db30bc172df6759e",
+    "zh:1fc668d57c7edd81c06f5705b03517393444fe4988a68a3fd90b5b21fed64a55",
+    "zh:2bc0b4d5b706c3bbe7824bcf410942ee631d3423c23f935a51129832d81e1e17",
+    "zh:3f27e2befae3393df2ba423abba7f64c774d8aa6e0de20d00b35d7cca6f47d65",
+    "zh:410bfc19e1f38b7caabc5e1b9cd2de196bdcaa02c840372be26734775ee0214c",
+    "zh:417181a86499386ffbf4d023b9c5219a0d322751513806e977f146f170f0aebc",
+    "zh:6764d31dbae9656b698a3b9d4a44e4267210375ff9bec3e8716bac4450a06f0d",
+    "zh:86401475746c94b12e90b065b76a77c635a84d9cbfc57eace65131c780bd34c6",
+    "zh:98388ac853abbcb18fdf578c18203f485479610d28329c21deefc573976e4b1d",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:afb84c77c569e9979b8287cde33543cff992ca17e62ebe3f2b4a8e69884dbdc5",
+    "zh:c54c64dba350e6856fb8f2813b81d20286a532b02bad5f67da35135c02594407",
+    "zh:d1a46adf1c8f5bf42a1886b06fd25d86981236c933165f0fbc07e4330b77d8d1",
+    "zh:e719e227a676588cdaa5a3e7e3e6b10da26830a566730e8bce2127eec1780f40",
+  ]
+}

--- a/modules/cognito_app_client_count_monitor/README.md
+++ b/modules/cognito_app_client_count_monitor/README.md
@@ -1,0 +1,56 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.0 |
+| <a name="requirement_archive"></a> [archive](#requirement\_archive) | >= 2.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_archive"></a> [archive](#provider\_archive) | 2.7.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.43.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_event_rule.schedule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
+| [aws_cloudwatch_event_target.schedule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
+| [aws_cloudwatch_log_group.lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_cloudwatch_metric_alarm.app_client_count](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_lambda_function.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
+| [aws_lambda_permission.events](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
+| [archive_file.lambda_zip](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.lambda_execution](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_alarm_actions"></a> [alarm\_actions](#input\_alarm\_actions) | SNS topic ARNs for alarm notifications (e.g. Slack notify topics). | `list(string)` | n/a | yes |
+| <a name="input_alarm_threshold"></a> [alarm\_threshold](#input\_alarm\_threshold) | Alarm when app client count is at or above this value. | `number` | `800` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment label (e.g. staging, production) — used in metric dimensions and resource names. | `string` | n/a | yes |
+| <a name="input_lambda_timeout_seconds"></a> [lambda\_timeout\_seconds](#input\_lambda\_timeout\_seconds) | Lambda timeout — pagination must finish within this window. | `number` | `60` | no |
+| <a name="input_log_retention_days"></a> [log\_retention\_days](#input\_log\_retention\_days) | Retention for the Lambda log group. | `number` | `14` | no |
+| <a name="input_metric_name"></a> [metric\_name](#input\_metric\_name) | CloudWatch metric name for app client count. | `string` | `"AppClientCount"` | no |
+| <a name="input_metric_namespace"></a> [metric\_namespace](#input\_metric\_namespace) | CloudWatch namespace for the custom metric. | `string` | `"TradeTariff/Identity"` | no |
+| <a name="input_schedule_expression"></a> [schedule\_expression](#input\_schedule\_expression) | EventBridge schedule for publishing the metric. | `string` | `"rate(1 hour)"` | no |
+| <a name="input_user_pool_arn"></a> [user\_pool\_arn](#input\_user\_pool\_arn) | ARN of the Cognito user pool — scopes ListUserPoolClients. | `string` | n/a | yes |
+| <a name="input_user_pool_id"></a> [user\_pool\_id](#input\_user\_pool\_id) | Cognito user pool ID whose app clients are counted. | `string` | n/a | yes |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/modules/cognito_app_client_count_monitor/lambda/app_client_count.py
+++ b/modules/cognito_app_client_count_monitor/lambda/app_client_count.py
@@ -1,0 +1,37 @@
+"""Publish Cognito user pool app client count as a custom CloudWatch metric."""
+
+import os
+
+import boto3
+
+METRIC_NAMESPACE = os.environ["METRIC_NAMESPACE"]
+METRIC_NAME = os.environ.get("METRIC_NAME", "AppClientCount")
+USER_POOL_ID = os.environ["USER_POOL_ID"]
+ENVIRONMENT = os.environ.get("ENVIRONMENT", "unknown")
+
+
+def lambda_handler(event, context):
+    cognito = boto3.client("cognito-idp")
+    paginator = cognito.get_paginator("list_user_pool_clients")
+
+    total = 0
+    for page in paginator.paginate(UserPoolId=USER_POOL_ID, PaginationConfig={"PageSize": 60}):
+        total += len(page["UserPoolClients"])
+
+    cloudwatch = boto3.client("cloudwatch")
+    cloudwatch.put_metric_data(
+        Namespace=METRIC_NAMESPACE,
+        MetricData=[
+            {
+                "MetricName": METRIC_NAME,
+                "Dimensions": [
+                    {"Name": "UserPoolId", "Value": USER_POOL_ID},
+                    {"Name": "Environment", "Value": ENVIRONMENT},
+                ],
+                "Value": float(total),
+                "Unit": "Count",
+            }
+        ],
+    )
+
+    return {"statusCode": 200, "client_count": total}

--- a/modules/cognito_app_client_count_monitor/main.tf
+++ b/modules/cognito_app_client_count_monitor/main.tf
@@ -1,0 +1,140 @@
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
+
+locals {
+  account_id = data.aws_caller_identity.current.account_id
+  region     = data.aws_region.current.region
+}
+
+data "archive_file" "lambda_zip" {
+  type        = "zip"
+  source_file = "${path.module}/lambda/app_client_count.py"
+  output_path = "${path.module}/lambda/tmp/app_client_count.zip"
+}
+
+resource "aws_iam_role" "this" {
+  name = "trade-tariff-identity-app-client-count-${var.environment}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Service = "lambda.amazonaws.com"
+      }
+      Action = "sts:AssumeRole"
+    }]
+  })
+}
+
+data "aws_iam_policy_document" "lambda_execution" {
+  statement {
+    sid = "Logging"
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+    resources = ["arn:aws:logs:${local.region}:${local.account_id}:*"]
+  }
+
+  statement {
+    sid       = "ListUserPoolClients"
+    actions   = ["cognito-idp:ListUserPoolClients"]
+    resources = [var.user_pool_arn]
+  }
+
+  statement {
+    sid    = "PutMetricData"
+    effect = "Allow"
+    actions = [
+      "cloudwatch:PutMetricData",
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      variable = "cloudwatch:namespace"
+      values   = [var.metric_namespace]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "this" {
+  name   = "trade-tariff-identity-app-client-count-${var.environment}"
+  role   = aws_iam_role.this.id
+  policy = data.aws_iam_policy_document.lambda_execution.json
+}
+
+resource "aws_lambda_function" "this" {
+  function_name = "trade-tariff-identity-cognito-app-client-count-${var.environment}"
+  role          = aws_iam_role.this.arn
+  handler       = "app_client_count.lambda_handler"
+  runtime       = "python3.11"
+  timeout       = var.lambda_timeout_seconds
+
+  filename         = data.archive_file.lambda_zip.output_path
+  source_code_hash = data.archive_file.lambda_zip.output_base64sha256
+
+  environment {
+    variables = {
+      USER_POOL_ID     = var.user_pool_id
+      ENVIRONMENT      = var.environment
+      METRIC_NAMESPACE = var.metric_namespace
+      METRIC_NAME      = var.metric_name
+    }
+  }
+
+  logging_config {
+    log_format = "Text"
+    log_group  = aws_cloudwatch_log_group.lambda.name
+  }
+
+  depends_on = [aws_cloudwatch_log_group.lambda]
+}
+
+resource "aws_cloudwatch_log_group" "lambda" {
+  name              = "/aws/lambda/trade-tariff-identity-cognito-app-client-count-${var.environment}"
+  retention_in_days = var.log_retention_days
+}
+
+resource "aws_cloudwatch_event_rule" "schedule" {
+  name                = "trade-tariff-identity-app-client-count-${var.environment}"
+  description         = "Publish Cognito identity pool app client count custom metric"
+  schedule_expression = var.schedule_expression
+}
+
+resource "aws_cloudwatch_event_target" "schedule" {
+  rule      = aws_cloudwatch_event_rule.schedule.name
+  target_id = "trade-tariff-identity-app-client-count-${var.environment}"
+  arn       = aws_lambda_function.this.arn
+}
+
+resource "aws_lambda_permission" "events" {
+  statement_id  = "AllowExecutionFromEventBridge"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.this.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.schedule.arn
+}
+
+resource "aws_cloudwatch_metric_alarm" "app_client_count" {
+  alarm_name          = "trade-tariff-identity-cognito-app-client-count-${var.environment}"
+  alarm_description   = "Identity Cognito user pool app clients >= ${var.alarm_threshold}. Mitigate via Service Quota increase and/or cleanup of stale credentials clients."
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  metric_name         = var.metric_name
+  namespace           = var.metric_namespace
+  period              = 3600
+  statistic           = "Maximum"
+  threshold           = var.alarm_threshold
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    UserPoolId  = var.user_pool_id
+    Environment = var.environment
+  }
+
+  alarm_actions = var.alarm_actions
+  ok_actions    = var.alarm_actions
+}

--- a/modules/cognito_app_client_count_monitor/variables.tf
+++ b/modules/cognito_app_client_count_monitor/variables.tf
@@ -1,0 +1,55 @@
+variable "environment" {
+  description = "Environment label (e.g. staging, production) — used in metric dimensions and resource names."
+  type        = string
+}
+
+variable "user_pool_id" {
+  description = "Cognito user pool ID whose app clients are counted."
+  type        = string
+}
+
+variable "user_pool_arn" {
+  description = "ARN of the Cognito user pool — scopes ListUserPoolClients."
+  type        = string
+}
+
+variable "alarm_actions" {
+  description = "SNS topic ARNs for alarm notifications (e.g. Slack notify topics)."
+  type        = list(string)
+}
+
+variable "alarm_threshold" {
+  description = "Alarm when app client count is at or above this value."
+  type        = number
+  default     = 800
+}
+
+variable "schedule_expression" {
+  description = "EventBridge schedule for publishing the metric."
+  type        = string
+  default     = "rate(1 hour)"
+}
+
+variable "metric_namespace" {
+  description = "CloudWatch namespace for the custom metric."
+  type        = string
+  default     = "TradeTariff/Identity"
+}
+
+variable "metric_name" {
+  description = "CloudWatch metric name for app client count."
+  type        = string
+  default     = "AppClientCount"
+}
+
+variable "lambda_timeout_seconds" {
+  description = "Lambda timeout — pagination must finish within this window."
+  type        = number
+  default     = 60
+}
+
+variable "log_retention_days" {
+  description = "Retention for the Lambda log group."
+  type        = number
+  default     = 14
+}

--- a/modules/cognito_app_client_count_monitor/versions.tf
+++ b/modules/cognito_app_client_count_monitor/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.12.0"
+
+  required_providers {
+    archive = {
+      source  = "hashicorp/archive"
+      version = ">= 2.0.0"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.0.0"
+    }
+  }
+}


### PR DESCRIPTION
# Jira link

https://transformuk.atlassian.net/browse/OTTIMP-536

## What?

This PR introduces a reusable Terraform module that tracks Cognito user pool app client count and raises a CloudWatch alarm when it reaches a warning threshold (default 800).
The module deploys a scheduled Lambda that counts app clients hourly, publishes a custom CloudWatch metric, and triggers alert actions (SNS/Slack topics) when the threshold is breached.

It is wired into both staging and production common environments for the identity Cognito user pool.
The PR also includes supporting Terraform/pre-commit updates (lockfile handling and terraform init -backend=false for local validation reliability), plus provider lockfile updates required for the new module.

- Gives early warning before Cognito app client exhaustion affects Dev Hub onboarding/auth flows.
