### PR TITLE
Add Aurora reader connection string secret to all environments

### DIFF
--- a/environments/development/common/rds.tf
+++ b/environments/development/common/rds.tf
@@ -155,6 +155,14 @@ module "rw_aurora_connection_string" {
   secret_string   = module.postgres_aurora.rw_connection_string
 }
 
+module "ro_aurora_connection_string" {
+  source          = "../../../modules/secret/"
+  name            = "aurora-postgres-ro-connection-string"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = module.postgres_aurora.ro_connection_string
+}
+
 module "postgres_admin_aurora" {
   source = "../../../modules/rds_cluster"
 

--- a/environments/production/common/rds.tf
+++ b/environments/production/common/rds.tf
@@ -148,6 +148,14 @@ module "postgres_database_url" {
   secret_string   = module.postgres_aurora.rw_connection_string
 }
 
+module "ro_aurora_connection_string" {
+  source          = "../../../modules/secret/"
+  name            = "aurora-postgres-ro-connection-string"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = module.postgres_aurora.ro_connection_string
+}
+
 module "postgres_admin_aurora" {
   source = "../../../modules/rds_cluster"
 

--- a/environments/staging/common/rds.tf
+++ b/environments/staging/common/rds.tf
@@ -155,6 +155,14 @@ module "rw_aurora_connection_string" {
   secret_string   = module.postgres_aurora.rw_connection_string
 }
 
+module "ro_aurora_connection_string" {
+  source          = "../../../modules/secret/"
+  name            = "aurora-postgres-ro-connection-string"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+  secret_string   = module.postgres_aurora.ro_connection_string
+}
+
 module "postgres_admin_aurora" {
   source = "../../../modules/rds_cluster"
 


### PR DESCRIPTION
## Summary

- Stores the Aurora cluster reader endpoint URL as `aurora-postgres-ro-connection-string` in Secrets Manager for all three environments (development, staging, production)
- The Terraform module already outputs `ro_connection_string` (the Aurora reader endpoint) but it was never persisted as a secret
- Uses the same `modules/secret/` pattern and KMS key as the existing `rw_aurora_connection_string` / `postgres_database_url` secrets

## Why

The backend app needs a `READER_DATABASE_URL` env var to route read queries to the Aurora reader instance rather than the writer. The backend Terraform module will fetch this secret and inject it into UK and XI ECS web task definitions (tracked in a separate PR in trade-tariff-backend).

Sidekiq worker task definitions are intentionally excluded — workers use the writer only, since they frequently read data immediately after writing it.
