### PR TITLE
BAU: Set a default root object for the Reporting CDN

### DIFF
--- a/environments/development/common/cloudfront.tf
+++ b/environments/development/common/cloudfront.tf
@@ -400,6 +400,8 @@ module "reporting_cdn" {
   route53_zone_id = data.aws_route53_zone.this.id
   comment         = "${title(var.environment)} Reporting CDN"
 
+  default_root_object = "index.html"
+
   enabled         = true
   is_ipv6_enabled = true
   price_class     = "PriceClass_100"

--- a/environments/production/common/cloudfront.tf
+++ b/environments/production/common/cloudfront.tf
@@ -352,6 +352,8 @@ module "reporting_cdn" {
   route53_zone_id = data.aws_route53_zone.this.id
   comment         = "${title(var.environment)} Reporting CDN"
 
+  default_root_object = "index.html"
+
   enabled         = true
   is_ipv6_enabled = true
   price_class     = "PriceClass_100"

--- a/environments/staging/common/cloudfront.tf
+++ b/environments/staging/common/cloudfront.tf
@@ -398,6 +398,8 @@ module "reporting_cdn" {
   route53_zone_id = data.aws_route53_zone.this.id
   comment         = "${title(var.environment)} Reporting CDN"
 
+  default_root_object = "index.html"
+
   enabled         = true
   is_ipv6_enabled = true
   price_class     = "PriceClass_100"


### PR DESCRIPTION
## What?

I have:

- Added a default root object of `index.html` in the reporting CDN.

## Why?

I am doing this because:

- Currently, navigating to the root of the reporting CDN gives you the unstyled S3 objects XML. This change will return the default index for all visits to the CDN root, simplifying reporting navigation.