### PR TITLE
Fix notify-slack lambda replacement on every plan

### DIFF
--- a/modules/aws-notify-slack/README.md
+++ b/modules/aws-notify-slack/README.md
@@ -17,7 +17,7 @@ This module is derived from official terraform module https://github.com/terrafo
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_lambda"></a> [lambda](#module\_lambda) | terraform-aws-modules/lambda/aws | 3.2.0 |
+| <a name="module_lambda"></a> [lambda](#module\_lambda) | terraform-aws-modules/lambda/aws | 8.8.0 |
 
 ## Resources
 
@@ -39,7 +39,6 @@ This module is derived from official terraform module https://github.com/terrafo
 | <a name="input_create"></a> [create](#input\_create) | Whether to create all resources | `bool` | `true` | no |
 | <a name="input_create_sns_topic"></a> [create\_sns\_topic](#input\_create\_sns\_topic) | Whether to create new SNS topic | `bool` | `true` | no |
 | <a name="input_enable_sns_topic_delivery_status_logs"></a> [enable\_sns\_topic\_delivery\_status\_logs](#input\_enable\_sns\_topic\_delivery\_status\_logs) | Whether to enable SNS topic delivery status logs | `bool` | `false` | no |
-| <a name="input_iam_policy_path"></a> [iam\_policy\_path](#input\_iam\_policy\_path) | Path of policies to that should be added to IAM role for Lambda Function | `string` | `null` | no |
 | <a name="input_iam_role_boundary_policy_arn"></a> [iam\_role\_boundary\_policy\_arn](#input\_iam\_role\_boundary\_policy\_arn) | The ARN of the policy that is used to set the permissions boundary for the role | `string` | `null` | no |
 | <a name="input_iam_role_name_prefix"></a> [iam\_role\_name\_prefix](#input\_iam\_role\_name\_prefix) | A unique role name beginning with the specified prefix | `string` | `"lambda"` | no |
 | <a name="input_iam_role_path"></a> [iam\_role\_path](#input\_iam\_role\_path) | Path of IAM role to use for Lambda Function | `string` | `null` | no |

--- a/modules/aws-notify-slack/main.tf
+++ b/modules/aws-notify-slack/main.tf
@@ -72,7 +72,7 @@ resource "aws_sns_topic_subscription" "sns_notify_slack" {
 
 module "lambda" {
   source  = "terraform-aws-modules/lambda/aws"
-  version = "3.2.0"
+  version = "8.8.0"
 
   create = var.create
 
@@ -82,11 +82,15 @@ module "lambda" {
   handler                        = "${local.lambda_handler}.lambda_handler"
   source_path                    = var.lambda_source_path != null ? "${path.root}/${var.lambda_source_path}" : "${path.module}/functions/notify_slack.py"
   recreate_missing_package       = var.recreate_missing_package
-  runtime                        = "python3.8"
+  runtime                        = "python3.12"
   timeout                        = 30
   kms_key_arn                    = var.kms_key_arn
   reserved_concurrent_executions = var.reserved_concurrent_executions
   ephemeral_storage_size         = var.lambda_function_ephemeral_storage_size
+
+  # Disable timestamp-based triggers so CI runners (which reset file mtimes on
+  # checkout) don't force a replacement on every plan.
+  trigger_on_package_timestamp = false
 
   # If publish is disabled, there will be "Error adding new Lambda Permission for notify_slack:
   # InvalidParameterValueException: We currently do not support adding policies for $LATEST."
@@ -106,7 +110,6 @@ module "lambda" {
   role_permissions_boundary = var.iam_role_boundary_policy_arn
   role_tags                 = var.iam_role_tags
   role_path                 = var.iam_role_path
-  policy_path               = var.iam_policy_path
 
   # Do not use Lambda's policy for cloudwatch logs, because we have to add a policy
   # for KMS conditionally. This way attach_policy_json is always true independenty of

--- a/modules/aws-notify-slack/variables.tf
+++ b/modules/aws-notify-slack/variables.tf
@@ -198,12 +198,6 @@ variable "iam_role_path" {
   default     = null
 }
 
-variable "iam_policy_path" {
-  description = "Path of policies to that should be added to IAM role for Lambda Function"
-  type        = string
-  default     = null
-}
-
 variable "lambda_function_tags" {
   description = "Additional tags for the Lambda function"
   type        = map(string)


### PR DESCRIPTION
## Problem

Every Terraform plan was showing a spurious replacement for `module.notify_slack.module.lambda.null_resource.archive[0]`, triggering the production downtime warning.

**Root cause:** `terraform-aws-modules/lambda` v3.2.0 uses `null_resource.archive` with a trigger keyed on the source file's `mtime`. CI runners do a fresh `git checkout` on every run, which resets all file timestamps to the current time. The stored timestamp in state never matches the freshly-checked-out mtime, so Terraform always plans a replacement.

## Changes

- Upgrade `terraform-aws-modules/lambda/aws` from `3.2.0` → `8.8.0`
- Set `trigger_on_package_timestamp = false` (new in v4+) so the package is only rebuilt when file content actually changes, not when mtimes differ
- Bump Lambda runtime from EOL `python3.8` → `python3.12`
- Remove `policy_path` argument and `iam_policy_path` variable — removed from the module in v4+ and was always `null` in our usage

## Test plan

- [ ] Confirm dev plan no longer shows `null_resource.archive` replacement
- [ ] Confirm staging plan is clean
- [ ] Review any Lambda-related changes in the plan output to ensure no unexpected replacements