### PR TITLE
HMRC-2014: Add Valkey cluster alerting and CloudWatch dashboard

### DIFF
--- a/environments/development/common/.terraform.lock.hcl
+++ b/environments/development/common/.terraform.lock.hcl
@@ -1,9 +1,12 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/archive" {
   version     = "2.7.1"
-  constraints = ">= 2.0.0"
+  constraints = ">= 2.0.0, 2.7.1"
   hashes = [
     "h1:62VrkalDPMKB9zerCBS4iKTbvxejwnAWn/XXYZZQWD4=",
+    "h1:Tr6LvLbm30zX4BRNPHhXo8SnOP0vg5UKAeunRNfnas8=",
     "zh:19881bb356a4a656a865f48aee70c0b8a03c35951b7799b6113883f67f196e8e",
     "zh:2fcfbf6318dd514863268b09bbe19bfc958339c636bcbcc3664b45f2b8bf5cc6",
     "zh:3323ab9a504ce0a115c28e64d0739369fe85151291a2ce480d51ccbb0c381ac5",
@@ -21,9 +24,10 @@ provider "registry.terraform.io/hashicorp/archive" {
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "6.38.0"
-  constraints = ">= 6.0.0"
+  constraints = ">= 4.9.0, >= 6.0.0"
   hashes = [
     "h1:7F3W4qGLTbr4aploSI8eIqE4AueoNe/Tq5Osuo0IgJ4=",
+    "h1:fJlpWm8M4RGM5TZGeblUiP3WqhUI0zV0hM+NAJ9lVlY=",
     "zh:143f118ae71059a7a7026c6b950da23fef04a06e2362ffa688bef75e43e869ed",
     "zh:29ee220a017306effd877e1280f8b2934dc957e16e0e72ca0222e5514d0db522",
     "zh:3a31baabf7aea7aa7669f5a3d76f3445e0e6cce5e9aea0279992765c0df12aee",
@@ -44,8 +48,9 @@ provider "registry.terraform.io/hashicorp/aws" {
 
 provider "registry.terraform.io/hashicorp/external" {
   version     = "2.3.5"
-  constraints = ">= 2.3.5"
+  constraints = ">= 1.0.0, >= 2.3.5"
   hashes = [
+    "h1:1JSWWSmVSxzHGbD4RmaNUsdGsr2hPo+WwYaluyWv7vY=",
     "h1:smKSos4zs57pJjQrNuvGBpSWth2el9SgePPbPHo0aps=",
     "zh:6e89509d056091266532fa64de8c06950010498adf9070bf6ff85bc485a82562",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
@@ -64,9 +69,10 @@ provider "registry.terraform.io/hashicorp/external" {
 
 provider "registry.terraform.io/hashicorp/local" {
   version     = "2.7.0"
-  constraints = "2.7.0"
+  constraints = ">= 1.0.0"
   hashes = [
     "h1:2RYa3j7m/0WmET2fqotY4CHxE1Hpk0fgn47/126l+Og=",
+    "h1:SY06ZmR7rY7QMGoVEkeFrERVitBp2GKl/ATz9tbjXlk=",
     "zh:261fec71bca13e0a7812dc0d8ae9af2b4326b24d9b2e9beab3d2400fab5c5f9a",
     "zh:308da3b5376a9ede815042deec5af1050ec96a5a5410a2206ae847d82070a23e",
     "zh:3d056924c420464dc8aba10e1915956b2e5c4d55b11ffff79aa8be563fbfe298",
@@ -84,8 +90,9 @@ provider "registry.terraform.io/hashicorp/local" {
 
 provider "registry.terraform.io/hashicorp/null" {
   version     = "3.2.4"
-  constraints = "3.2.4"
+  constraints = ">= 2.0.0, >= 3.0.0"
   hashes = [
+    "h1:127ts0CG8hFk1bHIfrBsKxcnt9bAYQCq3udWM+AACH8=",
     "h1:hkf5w5B6q8e2A42ND2CjAvgvSN3puAosDmOJb3zCVQM=",
     "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
@@ -107,6 +114,7 @@ provider "registry.terraform.io/hashicorp/random" {
   constraints = ">= 3.0.0"
   hashes = [
     "h1:Eexl06+6J+s75uD46+WnZtpJZYRVUMB0AiuPBifK6Jc=",
+    "h1:fdfOl1HabDT42XLH8qjmfTbVZpgQZ5lyOyOa+GQhm0w=",
     "zh:08dd03b918c7b55713026037c5400c48af5b9f468f483463321bd18e17b907b4",
     "zh:0eee654a5542dc1d41920bbf2419032d6f0d5625b03bd81339e5b33394a3e0ae",
     "zh:229665ddf060aa0ed315597908483eee5b818a17d09b6417a0f52fd9405c4f57",
@@ -127,6 +135,7 @@ provider "registry.terraform.io/hashicorp/tls" {
   constraints = ">= 4.0.0"
   hashes = [
     "h1:F5d6bQY8UlBo0D71Sv7CsV+3aZOFz0yeNF+vufog7h4=",
+    "h1:wTIzrwUB7NINYwLFYLdWkJQwg1r9XT6rVOGrZ1+lMmI=",
     "zh:0d1e7d07ac973b97fa228f46596c800de830820506ee145626f079dd6bbf8d8a",
     "zh:5c7e3d4348cb4861ab812973ef493814a4b224bdd3e9d534a7c8a7c992382b86",
     "zh:7c6d4a86cd7a4e9c1025c6b3a3a6a45dea202af85d870cddbab455fb1bd568ad",

--- a/environments/development/common/redis.tf
+++ b/environments/development/common/redis.tf
@@ -74,3 +74,101 @@ resource "aws_secretsmanager_secret_version" "valkey_connection_string_value" {
   secret_id     = aws_secretsmanager_secret.valkey_connection_string[each.key].id
   secret_string = "rediss://:${random_password.valkey_auth[each.key].result}@${module.valkey[each.key].primary_endpoint}:6379"
 }
+
+locals {
+  memory_use_widgets = [
+    for k, v in local.redis : {
+      type   = "metric"
+      width  = 12
+      height = 6
+      properties = {
+        metrics = [
+          "AWS/Elasticache",
+          "DatabaseMemoryUsagePercentage",
+          "ReplicationGroupId",
+          "valkey-${k}-${var.environment}"
+        ]
+        period = 3600
+        stat   = "Average"
+        region = var.region
+        title  = "Valkey ${title(split("-", k)[0])}${length(split("-", k)) > 1 ? " ${upper(split("-", k)[1])}" : ""} Memory Usage"
+      }
+    }
+  ]
+  key_count = [
+    for k, v in local.redis : {
+      type   = "metric"
+      width  = 12
+      height = 6
+      properties = {
+        metrics = [
+          "AWS/Elasticache",
+          "CurrItems",
+          "ReplicationGroupId"
+        ]
+      }
+    }
+  ]
+  key_eviction_widgets = [
+    for k, v in local.redis : {
+      type   = "metric"
+      width  = 12
+      height = 6
+      properties = {
+        metrics = [
+          "AWS/Elasticache",
+          "Evictions",
+          "ReplicationGroupId",
+          "valkey-${k}-${var.environment}"
+        ]
+        period = 3600
+        stat   = "Sum"
+        region = var.region
+        title  = "Valkey ${title(split("-", k)[0])}${length(split("-", k)) > 1 ? " ${upper(split("-", k)[1])}" : ""} Key Evictions"
+      }
+    }
+  ]
+  latency_widgets = [
+    for k, v in local.redis : {
+      type   = "metric"
+      width  = 12
+      height = 6
+      properties = {
+        metrics = [
+          "AWS/Elasticache",
+          "KeyBasedCmdsLatency",
+          "ReplicationGroupId",
+          "valkey-${k}-${var.environment}"
+        ]
+        period = 3600
+        stat   = "Average"
+        region = var.region
+        title  = "Valkey ${title(split("-", k)[0])}${length(split("-", k)) > 1 ? " ${upper(split("-", k)[1])}" : ""} Latency (ms)"
+      }
+    }
+  ]
+}
+
+resource "aws_cloudwatch_dashboard" "valkey" {
+  dashboard_name = "Valkey-Stats-${title(var.environment)}"
+  dashboard_body = jsonencode({
+    widgets = [
+      {
+        type   = "text"
+        x      = 0
+        y      = 0
+        width  = 24
+        height = 4
+        properties = {
+          markdown = join("\n", [
+            "## Valkey Cluster Stats",
+            "Surfaces Valkey memory usage, key count, eviction rates, and RTTs (Round-Trip Time)"
+          ])
+        }
+      },
+      local.memory_use_widgets,
+      local.key_eviction_widgets,
+      local.latency_widgets,
+    ]
+  })
+}

--- a/environments/development/common/redis.tf
+++ b/environments/development/common/redis.tf
@@ -1,5 +1,5 @@
 locals {
-  redis = {
+  valkey = {
     "frontend"   = "cache.t3.micro",
     "backend-uk" = "cache.t3.micro",
     "backend-xi" = "cache.t3.micro",
@@ -26,7 +26,7 @@ resource "aws_elasticache_parameter_group" "sidekiq" {
 # Authenticated, encrypted clusters
 module "valkey" {
   source   = "../../../modules/elasticache/"
-  for_each = local.redis
+  for_each = local.valkey
 
   engine         = "valkey"
   engine_version = "8.2"
@@ -53,40 +53,46 @@ module "valkey" {
   transit_encryption_enabled = true
   transit_encryption_mode    = "required"
   auth_token                 = random_password.valkey_auth[each.key].result
-  auth_token_update_strategy = "SET"
+  auth_token_update_strategy = "ROTATE"
 }
 
 # Generate a password for each cluster, to avoid credential sharing
 resource "random_password" "valkey_auth" {
-  for_each = local.redis
+  for_each = local.valkey
   length   = 16
   special  = false
 }
 
 resource "aws_secretsmanager_secret" "valkey_connection_string" {
-  for_each   = local.redis
+  for_each   = local.valkey
   name       = "valkey-${each.key}-connection-string"
   kms_key_id = aws_kms_key.secretsmanager_kms_key.arn
 }
 
 resource "aws_secretsmanager_secret_version" "valkey_connection_string_value" {
-  for_each      = local.redis
+  for_each      = local.valkey
   secret_id     = aws_secretsmanager_secret.valkey_connection_string[each.key].id
   secret_string = "rediss://:${random_password.valkey_auth[each.key].result}@${module.valkey[each.key].primary_endpoint}:6379"
 }
 
 locals {
+  # There are three nodes in each cluster; therefore we want three metrics for
+  # each graph, to group the nodes
+  cluster_nodes = range(1, 4)
+
   memory_use_widgets = [
-    for k, v in local.redis : {
+    for k, v in local.valkey : {
       type   = "metric"
-      width  = 12
-      height = 6
+      width  = 8
+      height = 4
       properties = {
         metrics = [
-          "AWS/Elasticache",
-          "DatabaseMemoryUsagePercentage",
-          "ReplicationGroupId",
-          "valkey-${k}-${var.environment}"
+          [
+            "AWS/ElastiCache",
+            "DatabaseMemoryUsageCountedForEvictPercentage",
+            "ReplicationGroupId",
+            "valkey-${k}-${var.environment}"
+          ]
         ]
         period = 3600
         stat   = "Average"
@@ -95,55 +101,68 @@ locals {
       }
     }
   ]
-  key_count = [
-    for k, v in local.redis : {
+
+  key_count_widgets = [
+    for k, v in local.valkey : {
       type   = "metric"
-      width  = 12
-      height = 6
+      width  = 8
+      height = 4
       properties = {
         metrics = [
-          "AWS/Elasticache",
-          "CurrItems",
-          "ReplicationGroupId"
+          for i in local.cluster_nodes : [
+            "AWS/ElastiCache",
+            "CurrVolatileItems", # Cache items with a TTL set
+            "CacheClusterId",
+            "valkey-${k}-${var.environment}-00${i}"
+          ]
         ]
+        period = 3600
+        stat   = "Average"
+        region = var.region
+        title  = "Valkey ${title(split("-", k)[0])}${length(split("-", k)) > 1 ? " ${upper(split("-", k)[1])}" : ""} Key Count"
       }
     }
   ]
+
   key_eviction_widgets = [
-    for k, v in local.redis : {
+    for k, v in local.valkey : {
       type   = "metric"
-      width  = 12
-      height = 6
+      width  = 8
+      height = 4
       properties = {
         metrics = [
-          "AWS/Elasticache",
-          "Evictions",
-          "ReplicationGroupId",
-          "valkey-${k}-${var.environment}"
+          for i in local.cluster_nodes : [
+            "AWS/ElastiCache",
+            "Evictions",
+            "CacheClusterId",
+            "valkey-${k}-${var.environment}-00${i}"
+          ]
         ]
         period = 3600
-        stat   = "Sum"
         region = var.region
         title  = "Valkey ${title(split("-", k)[0])}${length(split("-", k)) > 1 ? " ${upper(split("-", k)[1])}" : ""} Key Evictions"
       }
     }
   ]
+
   latency_widgets = [
-    for k, v in local.redis : {
+    for k, v in local.valkey : {
       type   = "metric"
-      width  = 12
-      height = 6
+      width  = 8
+      height = 4
       properties = {
         metrics = [
-          "AWS/Elasticache",
-          "KeyBasedCmdsLatency",
-          "ReplicationGroupId",
-          "valkey-${k}-${var.environment}"
+          for i in local.cluster_nodes : [
+            "AWS/ElastiCache",
+            "SuccessfulReadRequestLatency",
+            "CacheClusterId",
+            "valkey-${k}-${var.environment}-00${i}"
+          ]
         ]
         period = 3600
-        stat   = "Average"
+        stat   = "p99"
         region = var.region
-        title  = "Valkey ${title(split("-", k)[0])}${length(split("-", k)) > 1 ? " ${upper(split("-", k)[1])}" : ""} Latency (ms)"
+        title  = "Valkey ${title(split("-", k)[0])}${length(split("-", k)) > 1 ? " ${upper(split("-", k)[1])}" : ""} p99 Read Latency"
       }
     }
   ]
@@ -152,23 +171,54 @@ locals {
 resource "aws_cloudwatch_dashboard" "valkey" {
   dashboard_name = "Valkey-Stats-${title(var.environment)}"
   dashboard_body = jsonencode({
-    widgets = flatten([
-      {
+    widgets = concat(
+      [{
         type   = "text"
-        x      = 0
-        y      = 0
         width  = 24
-        height = 4
+        height = 2
         properties = {
           markdown = join("\n", [
             "## Valkey Cluster Stats",
-            "Surfaces Valkey memory usage, key count, eviction rates, and RTTs (Round-Trip Time)"
+            "Surfaces Valkey memory usage, key count, eviction rates, and latency"
           ])
         }
-      },
+        },
+        {
+          type   = "text"
+          width  = 24
+          height = 1
+          properties = {
+            markdown = "### Memory Usage Percentage"
+          }
+      }],
       local.memory_use_widgets,
+      [{
+        type   = "text"
+        width  = 24
+        height = 1
+        properties = {
+          markdown = "### Key Count (Cache keys with explicit TTL set)"
+        }
+      }],
+      local.key_count_widgets,
+      [{
+        type   = "text"
+        width  = 24
+        height = 1
+        properties = {
+          markdown = "### Key Evictions Count"
+        }
+      }],
       local.key_eviction_widgets,
+      [{
+        type   = "text"
+        width  = 24
+        height = 1
+        properties = {
+          markdown = "### p99 Read Latency"
+        }
+      }],
       local.latency_widgets,
-    ])
+    )
   })
 }

--- a/environments/development/common/redis.tf
+++ b/environments/development/common/redis.tf
@@ -152,7 +152,7 @@ locals {
 resource "aws_cloudwatch_dashboard" "valkey" {
   dashboard_name = "Valkey-Stats-${title(var.environment)}"
   dashboard_body = jsonencode({
-    widgets = [
+    widgets = flatten([
       {
         type   = "text"
         x      = 0
@@ -169,6 +169,6 @@ resource "aws_cloudwatch_dashboard" "valkey" {
       local.memory_use_widgets,
       local.key_eviction_widgets,
       local.latency_widgets,
-    ]
+    ])
   })
 }

--- a/environments/development/common/slack-notify.tf
+++ b/environments/development/common/slack-notify.tf
@@ -264,7 +264,7 @@ resource "aws_cloudwatch_metric_alarm" "valkey_memory_usage" {
   alarm_description   = "High memory usage (>80%) on ${each.key} Valkey cluster"
   comparison_operator = "GreaterThanThreshold"
   threshold           = 80
-  evaluation_periods  = 1
+  evaluation_periods  = 5
   datapoints_to_alarm = 5
   treat_missing_data  = "notBreaching"
   alarm_actions       = local.alert_actions
@@ -272,7 +272,7 @@ resource "aws_cloudwatch_metric_alarm" "valkey_memory_usage" {
 
   metric_name = "DatabaseMemoryUsagePercentage"
   namespace   = "AWS/Elasticache"
-  period      = 300
+  period      = 120
   statistic   = "Average"
   unit        = "Percent"
 

--- a/environments/development/common/slack-notify.tf
+++ b/environments/development/common/slack-notify.tf
@@ -258,7 +258,7 @@ resource "aws_cloudwatch_metric_alarm" "apigw_cache_hit_ratio" {
 
 # Alarms for Valkey clusters
 resource "aws_cloudwatch_metric_alarm" "valkey_memory_usage" {
-  for_each = local.redis
+  for_each = local.valkey
 
   alarm_name          = "valkey-${each.key}-high-memory-usage"
   alarm_description   = "High memory usage (>80%) on ${each.key} Valkey cluster"

--- a/environments/development/common/slack-notify.tf
+++ b/environments/development/common/slack-notify.tf
@@ -255,3 +255,28 @@ resource "aws_cloudwatch_metric_alarm" "apigw_cache_hit_ratio" {
     return_data = true
   }
 }
+
+# Alarms for Valkey clusters
+resource "aws_cloudwatch_metric_alarm" "valkey_memory_usage" {
+  for_each = local.redis
+
+  alarm_name          = "valkey-${each.key}-high-memory-usage"
+  alarm_description   = "High memory usage (>80%) on ${each.key} Valkey cluster"
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = 80
+  evaluation_periods  = 1
+  datapoints_to_alarm = 5
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = local.alert_actions
+  ok_actions          = local.alert_actions
+
+  metric_name = "DatabaseMemoryUsagePercentage"
+  namespace   = "AWS/Elasticache"
+  period      = 300
+  statistic   = "Average"
+  unit        = "Percent"
+
+  dimensions = {
+    ReplicationGroupId = "valkey-${each.key}-${var.environment}"
+  }
+}

--- a/environments/production/common/.terraform.lock.hcl
+++ b/environments/production/common/.terraform.lock.hcl
@@ -7,6 +7,7 @@ provider "registry.terraform.io/hashicorp/archive" {
   hashes = [
     "h1:62VrkalDPMKB9zerCBS4iKTbvxejwnAWn/XXYZZQWD4=",
     "h1:A7EnRBVm4h9ryO9LwxYnKr4fy7ExPMwD5a1DsY7m1Y0=",
+    "h1:Tr6LvLbm30zX4BRNPHhXo8SnOP0vg5UKAeunRNfnas8=",
     "zh:19881bb356a4a656a865f48aee70c0b8a03c35951b7799b6113883f67f196e8e",
     "zh:2fcfbf6318dd514863268b09bbe19bfc958339c636bcbcc3664b45f2b8bf5cc6",
     "zh:3323ab9a504ce0a115c28e64d0739369fe85151291a2ce480d51ccbb0c381ac5",
@@ -28,6 +29,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   hashes = [
     "h1:7F3W4qGLTbr4aploSI8eIqE4AueoNe/Tq5Osuo0IgJ4=",
     "h1:RDoKIzXmt7H1mNFcNIyRT+nA/gTJyO3+iW9QGN5I2eQ=",
+    "h1:fJlpWm8M4RGM5TZGeblUiP3WqhUI0zV0hM+NAJ9lVlY=",
     "zh:143f118ae71059a7a7026c6b950da23fef04a06e2362ffa688bef75e43e869ed",
     "zh:29ee220a017306effd877e1280f8b2934dc957e16e0e72ca0222e5514d0db522",
     "zh:3a31baabf7aea7aa7669f5a3d76f3445e0e6cce5e9aea0279992765c0df12aee",
@@ -50,6 +52,7 @@ provider "registry.terraform.io/hashicorp/external" {
   version     = "2.3.5"
   constraints = ">= 1.0.0, >= 2.3.5"
   hashes = [
+    "h1:1JSWWSmVSxzHGbD4RmaNUsdGsr2hPo+WwYaluyWv7vY=",
     "h1:FnUk98MI5nOh3VJ16cHf8mchQLewLfN1qZG/MqNgPrI=",
     "h1:smKSos4zs57pJjQrNuvGBpSWth2el9SgePPbPHo0aps=",
     "zh:6e89509d056091266532fa64de8c06950010498adf9070bf6ff85bc485a82562",
@@ -72,6 +75,7 @@ provider "registry.terraform.io/hashicorp/local" {
   constraints = ">= 1.0.0"
   hashes = [
     "h1:2RYa3j7m/0WmET2fqotY4CHxE1Hpk0fgn47/126l+Og=",
+    "h1:SY06ZmR7rY7QMGoVEkeFrERVitBp2GKl/ATz9tbjXlk=",
     "h1:sSwlfp2etjCaE9hIF7bJBDjRIhDCVFglEOVyiCI7vgs=",
     "zh:261fec71bca13e0a7812dc0d8ae9af2b4326b24d9b2e9beab3d2400fab5c5f9a",
     "zh:308da3b5376a9ede815042deec5af1050ec96a5a5410a2206ae847d82070a23e",
@@ -92,6 +96,7 @@ provider "registry.terraform.io/hashicorp/null" {
   version     = "3.2.4"
   constraints = ">= 2.0.0, >= 3.0.0"
   hashes = [
+    "h1:127ts0CG8hFk1bHIfrBsKxcnt9bAYQCq3udWM+AACH8=",
     "h1:L5V05xwp/Gto1leRryuesxjMfgZwjb7oool4WS1UEFQ=",
     "h1:hkf5w5B6q8e2A42ND2CjAvgvSN3puAosDmOJb3zCVQM=",
     "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
@@ -114,6 +119,7 @@ provider "registry.terraform.io/hashicorp/random" {
   constraints = ">= 3.0.0"
   hashes = [
     "h1:Eexl06+6J+s75uD46+WnZtpJZYRVUMB0AiuPBifK6Jc=",
+    "h1:fdfOl1HabDT42XLH8qjmfTbVZpgQZ5lyOyOa+GQhm0w=",
     "h1:u8AKlWVDTH5r9YLSeswoVEjiY72Rt4/ch7U+61ZDkiQ=",
     "zh:08dd03b918c7b55713026037c5400c48af5b9f468f483463321bd18e17b907b4",
     "zh:0eee654a5542dc1d41920bbf2419032d6f0d5625b03bd81339e5b33394a3e0ae",
@@ -136,6 +142,7 @@ provider "registry.terraform.io/hashicorp/tls" {
   hashes = [
     "h1:F5d6bQY8UlBo0D71Sv7CsV+3aZOFz0yeNF+vufog7h4=",
     "h1:akFNuHwvrtnYMBofieoeXhPJDhYZzJVu/Q/BgZK2fgg=",
+    "h1:wTIzrwUB7NINYwLFYLdWkJQwg1r9XT6rVOGrZ1+lMmI=",
     "zh:0d1e7d07ac973b97fa228f46596c800de830820506ee145626f079dd6bbf8d8a",
     "zh:5c7e3d4348cb4861ab812973ef493814a4b224bdd3e9d534a7c8a7c992382b86",
     "zh:7c6d4a86cd7a4e9c1025c6b3a3a6a45dea202af85d870cddbab455fb1bd568ad",
@@ -156,6 +163,7 @@ provider "registry.terraform.io/newrelic/newrelic" {
   constraints = ">= 3.78.0"
   hashes = [
     "h1:BacBfo4iCzWThRgNX/f26M0vt81ud1CG1kTYsCKVfZY=",
+    "h1:In6ESu7ojzE/gklJbqIRIQmTDJjoJP41Js29I8c9b2M=",
     "h1:JnOuc3JAIr2nNIKtg1EVZTfmNCInrZTAdCFJqMyO9zQ=",
     "zh:0a15f8e4103e7744e5292607f6e161bbf0fef753e699a1e2c27e6d42d8960a26",
     "zh:105b1e03306a33ef92a942b7974100092bb907aed5e3c715f99ccd1a3d0afb8e",

--- a/environments/production/common/redis.tf
+++ b/environments/production/common/redis.tf
@@ -76,17 +76,23 @@ resource "aws_secretsmanager_secret_version" "valkey_connection_string_value" {
 }
 
 locals {
+  # There are three nodes in each cluster; therefore we want three metrics for
+  # each graph, to group the nodes
+  cluster_nodes = range(1, 4)
+
   memory_use_widgets = [
     for k, v in local.valkey : {
       type   = "metric"
-      width  = 12
-      height = 6
+      width  = 8
+      height = 4
       properties = {
         metrics = [
-          "AWS/Elasticache",
-          "DatabaseMemoryUsagePercentage",
-          "ReplicationGroupId",
-          "valkey-${k}-${var.environment}"
+          [
+            "AWS/ElastiCache",
+            "DatabaseMemoryUsageCountedForEvictPercentage",
+            "ReplicationGroupId",
+            "valkey-${k}-${var.environment}"
+          ]
         ]
         period = 3600
         stat   = "Average"
@@ -95,55 +101,68 @@ locals {
       }
     }
   ]
-  key_count = [
+
+  key_count_widgets = [
     for k, v in local.valkey : {
       type   = "metric"
-      width  = 12
-      height = 6
+      width  = 8
+      height = 4
       properties = {
         metrics = [
-          "AWS/Elasticache",
-          "CurrItems",
-          "ReplicationGroupId"
+          for i in local.cluster_nodes : [
+            "AWS/ElastiCache",
+            "CurrVolatileItems", # Cache items with a TTL set
+            "CacheClusterId",
+            "valkey-${k}-${var.environment}-00${i}"
+          ]
         ]
+        period = 3600
+        stat   = "Average"
+        region = var.region
+        title  = "Valkey ${title(split("-", k)[0])}${length(split("-", k)) > 1 ? " ${upper(split("-", k)[1])}" : ""} Key Count"
       }
     }
   ]
+
   key_eviction_widgets = [
     for k, v in local.valkey : {
       type   = "metric"
-      width  = 12
-      height = 6
+      width  = 8
+      height = 4
       properties = {
         metrics = [
-          "AWS/Elasticache",
-          "Evictions",
-          "ReplicationGroupId",
-          "valkey-${k}-${var.environment}"
+          for i in local.cluster_nodes : [
+            "AWS/ElastiCache",
+            "Evictions",
+            "CacheClusterId",
+            "valkey-${k}-${var.environment}-00${i}"
+          ]
         ]
         period = 3600
-        stat   = "Sum"
         region = var.region
         title  = "Valkey ${title(split("-", k)[0])}${length(split("-", k)) > 1 ? " ${upper(split("-", k)[1])}" : ""} Key Evictions"
       }
     }
   ]
+
   latency_widgets = [
     for k, v in local.valkey : {
       type   = "metric"
-      width  = 12
-      height = 6
+      width  = 8
+      height = 4
       properties = {
         metrics = [
-          "AWS/Elasticache",
-          "KeyBasedCmdsLatency",
-          "ReplicationGroupId",
-          "valkey-${k}-${var.environment}"
+          for i in local.cluster_nodes : [
+            "AWS/ElastiCache",
+            "SuccessfulReadRequestLatency",
+            "CacheClusterId",
+            "valkey-${k}-${var.environment}-00${i}"
+          ]
         ]
         period = 3600
-        stat   = "Average"
+        stat   = "p99"
         region = var.region
-        title  = "Valkey ${title(split("-", k)[0])}${length(split("-", k)) > 1 ? " ${upper(split("-", k)[1])}" : ""} Latency (ms)"
+        title  = "Valkey ${title(split("-", k)[0])}${length(split("-", k)) > 1 ? " ${upper(split("-", k)[1])}" : ""} p99 Read Latency"
       }
     }
   ]
@@ -152,23 +171,54 @@ locals {
 resource "aws_cloudwatch_dashboard" "valkey" {
   dashboard_name = "Valkey-Stats-${title(var.environment)}"
   dashboard_body = jsonencode({
-    widgets = flatten([
-      {
+    widgets = concat(
+      [{
         type   = "text"
-        x      = 0
-        y      = 0
         width  = 24
-        height = 4
+        height = 2
         properties = {
           markdown = join("\n", [
             "## Valkey Cluster Stats",
-            "Surfaces Valkey memory usage, key count, eviction rates, and RTTs (Round-Trip Time)"
+            "Surfaces Valkey memory usage, key count, eviction rates, and latency"
           ])
         }
-      },
+        },
+        {
+          type   = "text"
+          width  = 24
+          height = 1
+          properties = {
+            markdown = "### Memory Usage Percentage"
+          }
+      }],
       local.memory_use_widgets,
+      [{
+        type   = "text"
+        width  = 24
+        height = 1
+        properties = {
+          markdown = "### Key Count (Cache keys with explicit TTL set)"
+        }
+      }],
+      local.key_count_widgets,
+      [{
+        type   = "text"
+        width  = 24
+        height = 1
+        properties = {
+          markdown = "### Key Evictions Count"
+        }
+      }],
       local.key_eviction_widgets,
+      [{
+        type   = "text"
+        width  = 24
+        height = 1
+        properties = {
+          markdown = "### p99 Read Latency"
+        }
+      }],
       local.latency_widgets,
-    ])
+    )
   })
 }

--- a/environments/production/common/redis.tf
+++ b/environments/production/common/redis.tf
@@ -74,3 +74,101 @@ resource "aws_secretsmanager_secret_version" "valkey_connection_string_value" {
   secret_id     = aws_secretsmanager_secret.valkey_connection_string[each.key].id
   secret_string = "rediss://:${random_password.valkey_auth[each.key].result}@${module.valkey[each.key].primary_endpoint}:6379"
 }
+
+locals {
+  memory_use_widgets = [
+    for k, v in local.valkey : {
+      type   = "metric"
+      width  = 12
+      height = 6
+      properties = {
+        metrics = [
+          "AWS/Elasticache",
+          "DatabaseMemoryUsagePercentage",
+          "ReplicationGroupId",
+          "valkey-${k}-${var.environment}"
+        ]
+        period = 3600
+        stat   = "Average"
+        region = var.region
+        title  = "Valkey ${title(split("-", k)[0])}${length(split("-", k)) > 1 ? " ${upper(split("-", k)[1])}" : ""} Memory Usage"
+      }
+    }
+  ]
+  key_count = [
+    for k, v in local.valkey : {
+      type   = "metric"
+      width  = 12
+      height = 6
+      properties = {
+        metrics = [
+          "AWS/Elasticache",
+          "CurrItems",
+          "ReplicationGroupId"
+        ]
+      }
+    }
+  ]
+  key_eviction_widgets = [
+    for k, v in local.valkey : {
+      type   = "metric"
+      width  = 12
+      height = 6
+      properties = {
+        metrics = [
+          "AWS/Elasticache",
+          "Evictions",
+          "ReplicationGroupId",
+          "valkey-${k}-${var.environment}"
+        ]
+        period = 3600
+        stat   = "Sum"
+        region = var.region
+        title  = "Valkey ${title(split("-", k)[0])}${length(split("-", k)) > 1 ? " ${upper(split("-", k)[1])}" : ""} Key Evictions"
+      }
+    }
+  ]
+  latency_widgets = [
+    for k, v in local.valkey : {
+      type   = "metric"
+      width  = 12
+      height = 6
+      properties = {
+        metrics = [
+          "AWS/Elasticache",
+          "KeyBasedCmdsLatency",
+          "ReplicationGroupId",
+          "valkey-${k}-${var.environment}"
+        ]
+        period = 3600
+        stat   = "Average"
+        region = var.region
+        title  = "Valkey ${title(split("-", k)[0])}${length(split("-", k)) > 1 ? " ${upper(split("-", k)[1])}" : ""} Latency (ms)"
+      }
+    }
+  ]
+}
+
+resource "aws_cloudwatch_dashboard" "valkey" {
+  dashboard_name = "Valkey-Stats-${title(var.environment)}"
+  dashboard_body = jsonencode({
+    widgets = [
+      {
+        type   = "text"
+        x      = 0
+        y      = 0
+        width  = 24
+        height = 4
+        properties = {
+          markdown = join("\n", [
+            "## Valkey Cluster Stats",
+            "Surfaces Valkey memory usage, key count, eviction rates, and RTTs (Round-Trip Time)"
+          ])
+        }
+      },
+      local.memory_use_widgets,
+      local.key_eviction_widgets,
+      local.latency_widgets,
+    ]
+  })
+}

--- a/environments/production/common/redis.tf
+++ b/environments/production/common/redis.tf
@@ -152,7 +152,7 @@ locals {
 resource "aws_cloudwatch_dashboard" "valkey" {
   dashboard_name = "Valkey-Stats-${title(var.environment)}"
   dashboard_body = jsonencode({
-    widgets = [
+    widgets = flatten([
       {
         type   = "text"
         x      = 0
@@ -169,6 +169,6 @@ resource "aws_cloudwatch_dashboard" "valkey" {
       local.memory_use_widgets,
       local.key_eviction_widgets,
       local.latency_widgets,
-    ]
+    ])
   })
 }

--- a/environments/production/common/slack-notify.tf
+++ b/environments/production/common/slack-notify.tf
@@ -126,7 +126,7 @@ resource "aws_cloudwatch_metric_alarm" "slack_notify_self_monitor" {
 
 # Alarms for Valkey clusters
 resource "aws_cloudwatch_metric_alarm" "valkey_memory_usage" {
-  for_each = local.redis
+  for_each = local.valkey
 
   alarm_name          = "valkey-${each.key}-high-memory-usage"
   alarm_description   = "High memory usage (>80%) on ${each.key} Valkey cluster"

--- a/environments/production/common/slack-notify.tf
+++ b/environments/production/common/slack-notify.tf
@@ -123,3 +123,28 @@ resource "aws_cloudwatch_metric_alarm" "slack_notify_self_monitor" {
   alarm_actions = var.enable_sns_alerts ? [aws_sns_topic.critical_email_alerts.arn] : []
   ok_actions    = var.enable_sns_alerts ? [aws_sns_topic.critical_email_alerts.arn] : []
 }
+
+# Alarms for Valkey clusters
+resource "aws_cloudwatch_metric_alarm" "valkey_memory_usage" {
+  for_each = local.valkey
+
+  alarm_name          = "valkey-${each.key}-high-memory-usage"
+  alarm_description   = "High memory usage (>80%) on ${each.key} Valkey cluster"
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = 80
+  evaluation_periods  = 1
+  datapoints_to_alarm = 5
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = local.alert_actions
+  ok_actions          = local.alert_actions
+
+  metric_name = "DatabaseMemoryUsagePercentage"
+  namespace   = "AWS/Elasticache"
+  period      = 300
+  statistic   = "Average"
+  unit        = "Percent"
+
+  dimensions = {
+    ReplicationGroupId = "valkey-${each.key}-${var.environment}"
+  }
+}

--- a/environments/production/common/slack-notify.tf
+++ b/environments/production/common/slack-notify.tf
@@ -126,13 +126,13 @@ resource "aws_cloudwatch_metric_alarm" "slack_notify_self_monitor" {
 
 # Alarms for Valkey clusters
 resource "aws_cloudwatch_metric_alarm" "valkey_memory_usage" {
-  for_each = local.valkey
+  for_each = local.redis
 
   alarm_name          = "valkey-${each.key}-high-memory-usage"
   alarm_description   = "High memory usage (>80%) on ${each.key} Valkey cluster"
   comparison_operator = "GreaterThanThreshold"
   threshold           = 80
-  evaluation_periods  = 1
+  evaluation_periods  = 5
   datapoints_to_alarm = 5
   treat_missing_data  = "notBreaching"
   alarm_actions       = local.alert_actions
@@ -140,7 +140,7 @@ resource "aws_cloudwatch_metric_alarm" "valkey_memory_usage" {
 
   metric_name = "DatabaseMemoryUsagePercentage"
   namespace   = "AWS/Elasticache"
-  period      = 300
+  period      = 120
   statistic   = "Average"
   unit        = "Percent"
 

--- a/environments/staging/common/.terraform.lock.hcl
+++ b/environments/staging/common/.terraform.lock.hcl
@@ -1,9 +1,12 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/archive" {
   version     = "2.7.1"
-  constraints = ">= 2.0.0"
+  constraints = ">= 2.0.0, 2.7.1"
   hashes = [
     "h1:62VrkalDPMKB9zerCBS4iKTbvxejwnAWn/XXYZZQWD4=",
+    "h1:Tr6LvLbm30zX4BRNPHhXo8SnOP0vg5UKAeunRNfnas8=",
     "zh:19881bb356a4a656a865f48aee70c0b8a03c35951b7799b6113883f67f196e8e",
     "zh:2fcfbf6318dd514863268b09bbe19bfc958339c636bcbcc3664b45f2b8bf5cc6",
     "zh:3323ab9a504ce0a115c28e64d0739369fe85151291a2ce480d51ccbb0c381ac5",
@@ -21,9 +24,10 @@ provider "registry.terraform.io/hashicorp/archive" {
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "6.38.0"
-  constraints = ">= 6.0.0"
+  constraints = ">= 4.9.0, >= 6.0.0"
   hashes = [
     "h1:7F3W4qGLTbr4aploSI8eIqE4AueoNe/Tq5Osuo0IgJ4=",
+    "h1:fJlpWm8M4RGM5TZGeblUiP3WqhUI0zV0hM+NAJ9lVlY=",
     "zh:143f118ae71059a7a7026c6b950da23fef04a06e2362ffa688bef75e43e869ed",
     "zh:29ee220a017306effd877e1280f8b2934dc957e16e0e72ca0222e5514d0db522",
     "zh:3a31baabf7aea7aa7669f5a3d76f3445e0e6cce5e9aea0279992765c0df12aee",
@@ -44,8 +48,9 @@ provider "registry.terraform.io/hashicorp/aws" {
 
 provider "registry.terraform.io/hashicorp/external" {
   version     = "2.3.5"
-  constraints = ">= 2.3.5"
+  constraints = ">= 1.0.0, >= 2.3.5"
   hashes = [
+    "h1:1JSWWSmVSxzHGbD4RmaNUsdGsr2hPo+WwYaluyWv7vY=",
     "h1:smKSos4zs57pJjQrNuvGBpSWth2el9SgePPbPHo0aps=",
     "zh:6e89509d056091266532fa64de8c06950010498adf9070bf6ff85bc485a82562",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
@@ -64,9 +69,10 @@ provider "registry.terraform.io/hashicorp/external" {
 
 provider "registry.terraform.io/hashicorp/local" {
   version     = "2.7.0"
-  constraints = "2.7.0"
+  constraints = ">= 1.0.0"
   hashes = [
     "h1:2RYa3j7m/0WmET2fqotY4CHxE1Hpk0fgn47/126l+Og=",
+    "h1:SY06ZmR7rY7QMGoVEkeFrERVitBp2GKl/ATz9tbjXlk=",
     "zh:261fec71bca13e0a7812dc0d8ae9af2b4326b24d9b2e9beab3d2400fab5c5f9a",
     "zh:308da3b5376a9ede815042deec5af1050ec96a5a5410a2206ae847d82070a23e",
     "zh:3d056924c420464dc8aba10e1915956b2e5c4d55b11ffff79aa8be563fbfe298",
@@ -84,8 +90,9 @@ provider "registry.terraform.io/hashicorp/local" {
 
 provider "registry.terraform.io/hashicorp/null" {
   version     = "3.2.4"
-  constraints = "3.2.4"
+  constraints = ">= 2.0.0, >= 3.0.0"
   hashes = [
+    "h1:127ts0CG8hFk1bHIfrBsKxcnt9bAYQCq3udWM+AACH8=",
     "h1:hkf5w5B6q8e2A42ND2CjAvgvSN3puAosDmOJb3zCVQM=",
     "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
@@ -107,6 +114,7 @@ provider "registry.terraform.io/hashicorp/random" {
   constraints = ">= 3.0.0"
   hashes = [
     "h1:Eexl06+6J+s75uD46+WnZtpJZYRVUMB0AiuPBifK6Jc=",
+    "h1:fdfOl1HabDT42XLH8qjmfTbVZpgQZ5lyOyOa+GQhm0w=",
     "zh:08dd03b918c7b55713026037c5400c48af5b9f468f483463321bd18e17b907b4",
     "zh:0eee654a5542dc1d41920bbf2419032d6f0d5625b03bd81339e5b33394a3e0ae",
     "zh:229665ddf060aa0ed315597908483eee5b818a17d09b6417a0f52fd9405c4f57",
@@ -127,6 +135,7 @@ provider "registry.terraform.io/hashicorp/tls" {
   constraints = ">= 4.0.0"
   hashes = [
     "h1:F5d6bQY8UlBo0D71Sv7CsV+3aZOFz0yeNF+vufog7h4=",
+    "h1:wTIzrwUB7NINYwLFYLdWkJQwg1r9XT6rVOGrZ1+lMmI=",
     "zh:0d1e7d07ac973b97fa228f46596c800de830820506ee145626f079dd6bbf8d8a",
     "zh:5c7e3d4348cb4861ab812973ef493814a4b224bdd3e9d534a7c8a7c992382b86",
     "zh:7c6d4a86cd7a4e9c1025c6b3a3a6a45dea202af85d870cddbab455fb1bd568ad",
@@ -147,6 +156,7 @@ provider "registry.terraform.io/newrelic/newrelic" {
   constraints = ">= 3.78.0"
   hashes = [
     "h1:BacBfo4iCzWThRgNX/f26M0vt81ud1CG1kTYsCKVfZY=",
+    "h1:In6ESu7ojzE/gklJbqIRIQmTDJjoJP41Js29I8c9b2M=",
     "zh:0a15f8e4103e7744e5292607f6e161bbf0fef753e699a1e2c27e6d42d8960a26",
     "zh:105b1e03306a33ef92a942b7974100092bb907aed5e3c715f99ccd1a3d0afb8e",
     "zh:16557e02b4dc2b7b96383323bc153b892142ff95b0be19de1d6a62537a6f854c",

--- a/environments/staging/common/redis.tf
+++ b/environments/staging/common/redis.tf
@@ -74,3 +74,101 @@ resource "aws_secretsmanager_secret_version" "valkey_connection_string_value" {
   secret_id     = aws_secretsmanager_secret.valkey_connection_string[each.key].id
   secret_string = "rediss://:${random_password.valkey_auth[each.key].result}@${module.valkey[each.key].primary_endpoint}:6379"
 }
+
+locals {
+  memory_use_widgets = [
+    for k, v in local.redis : {
+      type   = "metric"
+      width  = 12
+      height = 6
+      properties = {
+        metrics = [
+          "AWS/Elasticache",
+          "DatabaseMemoryUsagePercentage",
+          "ReplicationGroupId",
+          "valkey-${k}-${var.environment}"
+        ]
+        period = 3600
+        stat   = "Average"
+        region = var.region
+        title  = "Valkey ${title(split("-", k)[0])}${length(split("-", k)) > 1 ? " ${upper(split("-", k)[1])}" : ""} Memory Usage"
+      }
+    }
+  ]
+  key_count = [
+    for k, v in local.redis : {
+      type   = "metric"
+      width  = 12
+      height = 6
+      properties = {
+        metrics = [
+          "AWS/Elasticache",
+          "CurrItems",
+          "ReplicationGroupId"
+        ]
+      }
+    }
+  ]
+  key_eviction_widgets = [
+    for k, v in local.redis : {
+      type   = "metric"
+      width  = 12
+      height = 6
+      properties = {
+        metrics = [
+          "AWS/Elasticache",
+          "Evictions",
+          "ReplicationGroupId",
+          "valkey-${k}-${var.environment}"
+        ]
+        period = 3600
+        stat   = "Sum"
+        region = var.region
+        title  = "Valkey ${title(split("-", k)[0])}${length(split("-", k)) > 1 ? " ${upper(split("-", k)[1])}" : ""} Key Evictions"
+      }
+    }
+  ]
+  latency_widgets = [
+    for k, v in local.redis : {
+      type   = "metric"
+      width  = 12
+      height = 6
+      properties = {
+        metrics = [
+          "AWS/Elasticache",
+          "KeyBasedCmdsLatency",
+          "ReplicationGroupId",
+          "valkey-${k}-${var.environment}"
+        ]
+        period = 3600
+        stat   = "Average"
+        region = var.region
+        title  = "Valkey ${title(split("-", k)[0])}${length(split("-", k)) > 1 ? " ${upper(split("-", k)[1])}" : ""} Latency (ms)"
+      }
+    }
+  ]
+}
+
+resource "aws_cloudwatch_dashboard" "valkey" {
+  dashboard_name = "Valkey-Stats-${title(var.environment)}"
+  dashboard_body = jsonencode({
+    widgets = [
+      {
+        type   = "text"
+        x      = 0
+        y      = 0
+        width  = 24
+        height = 4
+        properties = {
+          markdown = join("\n", [
+            "## Valkey Cluster Stats",
+            "Surfaces Valkey memory usage, key count, eviction rates, and RTTs (Round-Trip Time)"
+          ])
+        }
+      },
+      local.memory_use_widgets,
+      local.key_eviction_widgets,
+      local.latency_widgets,
+    ]
+  })
+}

--- a/environments/staging/common/redis.tf
+++ b/environments/staging/common/redis.tf
@@ -1,5 +1,5 @@
 locals {
-  redis = {
+  valkey = {
     "frontend"   = "cache.t3.micro",
     "backend-uk" = "cache.t3.micro",
     "backend-xi" = "cache.t3.micro",
@@ -26,7 +26,7 @@ resource "aws_elasticache_parameter_group" "sidekiq" {
 # Authenticated, encrypted clusters
 module "valkey" {
   source   = "../../../modules/elasticache/"
-  for_each = local.redis
+  for_each = local.valkey
 
   engine         = "valkey"
   engine_version = "8.2"
@@ -58,35 +58,41 @@ module "valkey" {
 
 # Generate a password for each cluster, to avoid credential sharing
 resource "random_password" "valkey_auth" {
-  for_each = local.redis
+  for_each = local.valkey
   length   = 16
   special  = false
 }
 
 resource "aws_secretsmanager_secret" "valkey_connection_string" {
-  for_each   = local.redis
+  for_each   = local.valkey
   name       = "valkey-${each.key}-connection-string"
   kms_key_id = aws_kms_key.secretsmanager_kms_key.arn
 }
 
 resource "aws_secretsmanager_secret_version" "valkey_connection_string_value" {
-  for_each      = local.redis
+  for_each      = local.valkey
   secret_id     = aws_secretsmanager_secret.valkey_connection_string[each.key].id
   secret_string = "rediss://:${random_password.valkey_auth[each.key].result}@${module.valkey[each.key].primary_endpoint}:6379"
 }
 
 locals {
+  # There are three nodes in each cluster; therefore we want three metrics for
+  # each graph, to group the nodes
+  cluster_nodes = range(1, 4)
+
   memory_use_widgets = [
-    for k, v in local.redis : {
+    for k, v in local.valkey : {
       type   = "metric"
-      width  = 12
-      height = 6
+      width  = 8
+      height = 4
       properties = {
         metrics = [
-          "AWS/Elasticache",
-          "DatabaseMemoryUsagePercentage",
-          "ReplicationGroupId",
-          "valkey-${k}-${var.environment}"
+          [
+            "AWS/ElastiCache",
+            "DatabaseMemoryUsageCountedForEvictPercentage",
+            "ReplicationGroupId",
+            "valkey-${k}-${var.environment}"
+          ]
         ]
         period = 3600
         stat   = "Average"
@@ -95,55 +101,68 @@ locals {
       }
     }
   ]
-  key_count = [
-    for k, v in local.redis : {
+
+  key_count_widgets = [
+    for k, v in local.valkey : {
       type   = "metric"
-      width  = 12
-      height = 6
+      width  = 8
+      height = 4
       properties = {
         metrics = [
-          "AWS/Elasticache",
-          "CurrItems",
-          "ReplicationGroupId"
+          for i in local.cluster_nodes : [
+            "AWS/ElastiCache",
+            "CurrVolatileItems", # Cache items with a TTL set
+            "CacheClusterId",
+            "valkey-${k}-${var.environment}-00${i}"
+          ]
         ]
+        period = 3600
+        stat   = "Average"
+        region = var.region
+        title  = "Valkey ${title(split("-", k)[0])}${length(split("-", k)) > 1 ? " ${upper(split("-", k)[1])}" : ""} Key Count"
       }
     }
   ]
+
   key_eviction_widgets = [
-    for k, v in local.redis : {
+    for k, v in local.valkey : {
       type   = "metric"
-      width  = 12
-      height = 6
+      width  = 8
+      height = 4
       properties = {
         metrics = [
-          "AWS/Elasticache",
-          "Evictions",
-          "ReplicationGroupId",
-          "valkey-${k}-${var.environment}"
+          for i in local.cluster_nodes : [
+            "AWS/ElastiCache",
+            "Evictions",
+            "CacheClusterId",
+            "valkey-${k}-${var.environment}-00${i}"
+          ]
         ]
         period = 3600
-        stat   = "Sum"
         region = var.region
         title  = "Valkey ${title(split("-", k)[0])}${length(split("-", k)) > 1 ? " ${upper(split("-", k)[1])}" : ""} Key Evictions"
       }
     }
   ]
+
   latency_widgets = [
-    for k, v in local.redis : {
+    for k, v in local.valkey : {
       type   = "metric"
-      width  = 12
-      height = 6
+      width  = 8
+      height = 4
       properties = {
         metrics = [
-          "AWS/Elasticache",
-          "KeyBasedCmdsLatency",
-          "ReplicationGroupId",
-          "valkey-${k}-${var.environment}"
+          for i in local.cluster_nodes : [
+            "AWS/ElastiCache",
+            "SuccessfulReadRequestLatency",
+            "CacheClusterId",
+            "valkey-${k}-${var.environment}-00${i}"
+          ]
         ]
         period = 3600
-        stat   = "Average"
+        stat   = "p99"
         region = var.region
-        title  = "Valkey ${title(split("-", k)[0])}${length(split("-", k)) > 1 ? " ${upper(split("-", k)[1])}" : ""} Latency (ms)"
+        title  = "Valkey ${title(split("-", k)[0])}${length(split("-", k)) > 1 ? " ${upper(split("-", k)[1])}" : ""} p99 Read Latency"
       }
     }
   ]
@@ -152,23 +171,54 @@ locals {
 resource "aws_cloudwatch_dashboard" "valkey" {
   dashboard_name = "Valkey-Stats-${title(var.environment)}"
   dashboard_body = jsonencode({
-    widgets = flatten([
-      {
+    widgets = concat(
+      [{
         type   = "text"
-        x      = 0
-        y      = 0
         width  = 24
-        height = 4
+        height = 2
         properties = {
           markdown = join("\n", [
             "## Valkey Cluster Stats",
-            "Surfaces Valkey memory usage, key count, eviction rates, and RTTs (Round-Trip Time)"
+            "Surfaces Valkey memory usage, key count, eviction rates, and latency"
           ])
         }
-      },
+        },
+        {
+          type   = "text"
+          width  = 24
+          height = 1
+          properties = {
+            markdown = "### Memory Usage Percentage"
+          }
+      }],
       local.memory_use_widgets,
+      [{
+        type   = "text"
+        width  = 24
+        height = 1
+        properties = {
+          markdown = "### Key Count (Cache keys with explicit TTL set)"
+        }
+      }],
+      local.key_count_widgets,
+      [{
+        type   = "text"
+        width  = 24
+        height = 1
+        properties = {
+          markdown = "### Key Evictions Count"
+        }
+      }],
       local.key_eviction_widgets,
+      [{
+        type   = "text"
+        width  = 24
+        height = 1
+        properties = {
+          markdown = "### p99 Read Latency"
+        }
+      }],
       local.latency_widgets,
-    ])
+    )
   })
 }

--- a/environments/staging/common/redis.tf
+++ b/environments/staging/common/redis.tf
@@ -152,7 +152,7 @@ locals {
 resource "aws_cloudwatch_dashboard" "valkey" {
   dashboard_name = "Valkey-Stats-${title(var.environment)}"
   dashboard_body = jsonencode({
-    widgets = [
+    widgets = flatten([
       {
         type   = "text"
         x      = 0
@@ -169,6 +169,6 @@ resource "aws_cloudwatch_dashboard" "valkey" {
       local.memory_use_widgets,
       local.key_eviction_widgets,
       local.latency_widgets,
-    ]
+    ])
   })
 }

--- a/environments/staging/common/slack-notify.tf
+++ b/environments/staging/common/slack-notify.tf
@@ -264,7 +264,7 @@ resource "aws_cloudwatch_metric_alarm" "valkey_memory_usage" {
   alarm_description   = "High memory usage (>80%) on ${each.key} Valkey cluster"
   comparison_operator = "GreaterThanThreshold"
   threshold           = 80
-  evaluation_periods  = 1
+  evaluation_periods  = 5
   datapoints_to_alarm = 5
   treat_missing_data  = "notBreaching"
   alarm_actions       = local.alert_actions
@@ -272,7 +272,7 @@ resource "aws_cloudwatch_metric_alarm" "valkey_memory_usage" {
 
   metric_name = "DatabaseMemoryUsagePercentage"
   namespace   = "AWS/Elasticache"
-  period      = 300
+  period      = 120
   statistic   = "Average"
   unit        = "Percent"
 

--- a/environments/staging/common/slack-notify.tf
+++ b/environments/staging/common/slack-notify.tf
@@ -258,7 +258,7 @@ resource "aws_cloudwatch_metric_alarm" "apigw_cache_hit_ratio" {
 
 # Alarms for Valkey clusters
 resource "aws_cloudwatch_metric_alarm" "valkey_memory_usage" {
-  for_each = local.redis
+  for_each = local.valkey
 
   alarm_name          = "valkey-${each.key}-high-memory-usage"
   alarm_description   = "High memory usage (>80%) on ${each.key} Valkey cluster"

--- a/environments/staging/common/slack-notify.tf
+++ b/environments/staging/common/slack-notify.tf
@@ -255,3 +255,28 @@ resource "aws_cloudwatch_metric_alarm" "apigw_cache_hit_ratio" {
     return_data = true
   }
 }
+
+# Alarms for Valkey clusters
+resource "aws_cloudwatch_metric_alarm" "valkey_memory_usage" {
+  for_each = local.redis
+
+  alarm_name          = "valkey-${each.key}-high-memory-usage"
+  alarm_description   = "High memory usage (>80%) on ${each.key} Valkey cluster"
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = 80
+  evaluation_periods  = 1
+  datapoints_to_alarm = 5
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = local.alert_actions
+  ok_actions          = local.alert_actions
+
+  metric_name = "DatabaseMemoryUsagePercentage"
+  namespace   = "AWS/Elasticache"
+  period      = 300
+  statistic   = "Average"
+  unit        = "Percent"
+
+  dimensions = {
+    ReplicationGroupId = "valkey-${each.key}-${var.environment}"
+  }
+}


### PR DESCRIPTION
# Jira link

[HMRC-2014](https://transformuk.atlassian.net/browse/HMRC-2014)

## What?

I have:

- Added a CloudWatch dashboard for Valkey metrics
- Added an alarm for Valkey cluster memory use >80%

## Why?

I am doing this because:

- We had no surfaced metrics for these clusters, and there were no alarms that could have alerted us prior to live incidents involving degraded cache performance