### PR TITLE
Added GithubActions-Identity-ECS-Deployments-Role and ci-identity-ecs-lambda-policy in development, staging, and production

### DIFF
--- a/environments/development/common/.terraform.lock.hcl
+++ b/environments/development/common/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/archive" {
   constraints = ">= 2.0.0, 2.7.1"
   hashes = [
     "h1:62VrkalDPMKB9zerCBS4iKTbvxejwnAWn/XXYZZQWD4=",
+    "h1:A7EnRBVm4h9ryO9LwxYnKr4fy7ExPMwD5a1DsY7m1Y0=",
     "h1:Tr6LvLbm30zX4BRNPHhXo8SnOP0vg5UKAeunRNfnas8=",
     "zh:19881bb356a4a656a865f48aee70c0b8a03c35951b7799b6113883f67f196e8e",
     "zh:2fcfbf6318dd514863268b09bbe19bfc958339c636bcbcc3664b45f2b8bf5cc6",
@@ -24,9 +25,10 @@ provider "registry.terraform.io/hashicorp/archive" {
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "6.38.0"
-  constraints = ">= 4.9.0, >= 6.0.0"
+  constraints = ">= 6.0.0, >= 6.28.0"
   hashes = [
     "h1:7F3W4qGLTbr4aploSI8eIqE4AueoNe/Tq5Osuo0IgJ4=",
+    "h1:RDoKIzXmt7H1mNFcNIyRT+nA/gTJyO3+iW9QGN5I2eQ=",
     "h1:fJlpWm8M4RGM5TZGeblUiP3WqhUI0zV0hM+NAJ9lVlY=",
     "zh:143f118ae71059a7a7026c6b950da23fef04a06e2362ffa688bef75e43e869ed",
     "zh:29ee220a017306effd877e1280f8b2934dc957e16e0e72ca0222e5514d0db522",
@@ -51,6 +53,7 @@ provider "registry.terraform.io/hashicorp/external" {
   constraints = ">= 1.0.0, >= 2.3.5"
   hashes = [
     "h1:1JSWWSmVSxzHGbD4RmaNUsdGsr2hPo+WwYaluyWv7vY=",
+    "h1:FnUk98MI5nOh3VJ16cHf8mchQLewLfN1qZG/MqNgPrI=",
     "h1:smKSos4zs57pJjQrNuvGBpSWth2el9SgePPbPHo0aps=",
     "zh:6e89509d056091266532fa64de8c06950010498adf9070bf6ff85bc485a82562",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
@@ -73,6 +76,7 @@ provider "registry.terraform.io/hashicorp/local" {
   hashes = [
     "h1:2RYa3j7m/0WmET2fqotY4CHxE1Hpk0fgn47/126l+Og=",
     "h1:SY06ZmR7rY7QMGoVEkeFrERVitBp2GKl/ATz9tbjXlk=",
+    "h1:sSwlfp2etjCaE9hIF7bJBDjRIhDCVFglEOVyiCI7vgs=",
     "zh:261fec71bca13e0a7812dc0d8ae9af2b4326b24d9b2e9beab3d2400fab5c5f9a",
     "zh:308da3b5376a9ede815042deec5af1050ec96a5a5410a2206ae847d82070a23e",
     "zh:3d056924c420464dc8aba10e1915956b2e5c4d55b11ffff79aa8be563fbfe298",
@@ -93,6 +97,7 @@ provider "registry.terraform.io/hashicorp/null" {
   constraints = ">= 2.0.0, >= 3.0.0"
   hashes = [
     "h1:127ts0CG8hFk1bHIfrBsKxcnt9bAYQCq3udWM+AACH8=",
+    "h1:L5V05xwp/Gto1leRryuesxjMfgZwjb7oool4WS1UEFQ=",
     "h1:hkf5w5B6q8e2A42ND2CjAvgvSN3puAosDmOJb3zCVQM=",
     "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
@@ -115,6 +120,7 @@ provider "registry.terraform.io/hashicorp/random" {
   hashes = [
     "h1:Eexl06+6J+s75uD46+WnZtpJZYRVUMB0AiuPBifK6Jc=",
     "h1:fdfOl1HabDT42XLH8qjmfTbVZpgQZ5lyOyOa+GQhm0w=",
+    "h1:u8AKlWVDTH5r9YLSeswoVEjiY72Rt4/ch7U+61ZDkiQ=",
     "zh:08dd03b918c7b55713026037c5400c48af5b9f468f483463321bd18e17b907b4",
     "zh:0eee654a5542dc1d41920bbf2419032d6f0d5625b03bd81339e5b33394a3e0ae",
     "zh:229665ddf060aa0ed315597908483eee5b818a17d09b6417a0f52fd9405c4f57",
@@ -135,6 +141,7 @@ provider "registry.terraform.io/hashicorp/tls" {
   constraints = ">= 4.0.0"
   hashes = [
     "h1:F5d6bQY8UlBo0D71Sv7CsV+3aZOFz0yeNF+vufog7h4=",
+    "h1:akFNuHwvrtnYMBofieoeXhPJDhYZzJVu/Q/BgZK2fgg=",
     "h1:wTIzrwUB7NINYwLFYLdWkJQwg1r9XT6rVOGrZ1+lMmI=",
     "zh:0d1e7d07ac973b97fa228f46596c800de830820506ee145626f079dd6bbf8d8a",
     "zh:5c7e3d4348cb4861ab812973ef493814a4b224bdd3e9d534a7c8a7c992382b86",

--- a/environments/development/common/iam-policies.tf
+++ b/environments/development/common/iam-policies.tf
@@ -168,6 +168,17 @@ resource "aws_iam_policy" "ci_ecs_deployment_policy" {
           "kms:Decrypt",
           "kms:DescribeKey",
           "kms:GenerateDataKey",
+          # Lambda - identity Cognito app client count monitor (Terraform-managed)
+          "lambda:AddPermission",
+          "lambda:CreateFunction",
+          "lambda:DeleteFunction",
+          "lambda:GetFunction",
+          "lambda:GetFunctionConfiguration",
+          "lambda:GetPolicy",
+          "lambda:RemovePermission",
+          "lambda:TagResource",
+          "lambda:UpdateFunctionCode",
+          "lambda:UpdateFunctionConfiguration",
           # Logs - log groups for ECS containers
           "logs:CreateLogGroup",
           "logs:DeleteLogGroup",

--- a/environments/development/common/iam-policies.tf
+++ b/environments/development/common/iam-policies.tf
@@ -168,17 +168,6 @@ resource "aws_iam_policy" "ci_ecs_deployment_policy" {
           "kms:Decrypt",
           "kms:DescribeKey",
           "kms:GenerateDataKey",
-          # Lambda - identity Cognito app client count monitor (Terraform-managed)
-          "lambda:AddPermission",
-          "lambda:CreateFunction",
-          "lambda:DeleteFunction",
-          "lambda:GetFunction",
-          "lambda:GetFunctionConfiguration",
-          "lambda:GetPolicy",
-          "lambda:RemovePermission",
-          "lambda:TagResource",
-          "lambda:UpdateFunctionCode",
-          "lambda:UpdateFunctionConfiguration",
           # Logs - log groups for ECS containers
           "logs:CreateLogGroup",
           "logs:DeleteLogGroup",
@@ -231,6 +220,36 @@ resource "aws_iam_policy" "ci_ecs_deployment_policy" {
         Resource = [
           "arn:aws:s3:::terraform-state-${var.environment}-${local.account_id}",
           "arn:aws:s3:::terraform-state-${var.environment}-${local.account_id}/*"
+        ]
+      },
+    ]
+  })
+}
+
+resource "aws_iam_policy" "ci_identity_ecs_lambda_policy" {
+  name        = "ci-identity-ecs-lambda-policy"
+  description = "Lambda permissions for identity app Terraform deployments"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "IdentityCognitoAppClientCountLambda"
+        Effect = "Allow"
+        Action = [
+          "lambda:AddPermission",
+          "lambda:CreateFunction",
+          "lambda:DeleteFunction",
+          "lambda:GetFunction",
+          "lambda:GetFunctionConfiguration",
+          "lambda:GetPolicy",
+          "lambda:RemovePermission",
+          "lambda:TagResource",
+          "lambda:UpdateFunctionCode",
+          "lambda:UpdateFunctionConfiguration",
+        ]
+        Resource = [
+          "arn:aws:lambda:${var.region}:${local.account_id}:function:trade-tariff-identity-cognito-app-client-count-*",
         ]
       },
     ]

--- a/environments/development/common/iam-roles.tf
+++ b/environments/development/common/iam-roles.tf
@@ -216,7 +216,6 @@ resource "aws_iam_role" "ci_ecs_deployments_role" {
           },
           StringLike = {
             "${aws_iam_openid_connect_provider.github_oidc.url}:sub" = [
-              "repo:trade-tariff/identity:*",
               "repo:trade-tariff/trade-tariff-admin:*",
               "repo:trade-tariff/trade-tariff-api-docs:*",
               "repo:trade-tariff/trade-tariff-backend:*",
@@ -237,6 +236,43 @@ resource "aws_iam_role" "ci_ecs_deployments_role" {
 resource "aws_iam_role_policy_attachment" "ecs_deployments_ci_policy_attachment" {
   role       = aws_iam_role.ci_ecs_deployments_role.name
   policy_arn = aws_iam_policy.ci_ecs_deployment_policy.arn
+}
+
+resource "aws_iam_role" "ci_identity_ecs_deployments_role" {
+  name = "GithubActions-Identity-ECS-Deployments-Role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.github_oidc.arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "${aws_iam_openid_connect_provider.github_oidc.url}:aud" = "sts.amazonaws.com"
+          }
+          StringLike = {
+            "${aws_iam_openid_connect_provider.github_oidc.url}:sub" = [
+              "repo:trade-tariff/identity:*",
+            ]
+          }
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "identity_ecs_deployments_ci_policy" {
+  role       = aws_iam_role.ci_identity_ecs_deployments_role.name
+  policy_arn = aws_iam_policy.ci_ecs_deployment_policy.arn
+}
+
+resource "aws_iam_role_policy_attachment" "identity_ecs_deployments_lambda_policy" {
+  role       = aws_iam_role.ci_identity_ecs_deployments_role.name
+  policy_arn = aws_iam_policy.ci_identity_ecs_lambda_policy.arn
 }
 
 resource "aws_iam_role" "ci_api_docs_role" {

--- a/environments/production/common/iam-policies.tf
+++ b/environments/production/common/iam-policies.tf
@@ -249,6 +249,17 @@ resource "aws_iam_policy" "ci_ecs_deployment_policy" {
           "kms:Decrypt",
           "kms:DescribeKey",
           "kms:GenerateDataKey",
+          # Lambda - identity Cognito app client count monitor (Terraform-managed)
+          "lambda:AddPermission",
+          "lambda:CreateFunction",
+          "lambda:DeleteFunction",
+          "lambda:GetFunction",
+          "lambda:GetFunctionConfiguration",
+          "lambda:GetPolicy",
+          "lambda:RemovePermission",
+          "lambda:TagResource",
+          "lambda:UpdateFunctionCode",
+          "lambda:UpdateFunctionConfiguration",
           # Logs - log groups for ECS containers
           "logs:CreateLogGroup",
           "logs:DeleteLogGroup",

--- a/environments/production/common/iam-policies.tf
+++ b/environments/production/common/iam-policies.tf
@@ -249,17 +249,6 @@ resource "aws_iam_policy" "ci_ecs_deployment_policy" {
           "kms:Decrypt",
           "kms:DescribeKey",
           "kms:GenerateDataKey",
-          # Lambda - identity Cognito app client count monitor (Terraform-managed)
-          "lambda:AddPermission",
-          "lambda:CreateFunction",
-          "lambda:DeleteFunction",
-          "lambda:GetFunction",
-          "lambda:GetFunctionConfiguration",
-          "lambda:GetPolicy",
-          "lambda:RemovePermission",
-          "lambda:TagResource",
-          "lambda:UpdateFunctionCode",
-          "lambda:UpdateFunctionConfiguration",
           # Logs - log groups for ECS containers
           "logs:CreateLogGroup",
           "logs:DeleteLogGroup",
@@ -348,6 +337,36 @@ resource "aws_iam_policy" "ci_terraform_teams_policy" {
         Resource = [
           "arn:aws:s3:::terraform-state-${var.environment}-${local.account_id}",
           "arn:aws:s3:::terraform-state-${var.environment}-${local.account_id}/*"
+        ]
+      },
+    ]
+  })
+}
+
+resource "aws_iam_policy" "ci_identity_ecs_lambda_policy" {
+  name        = "ci-identity-ecs-lambda-policy"
+  description = "Lambda permissions for identity app Terraform deployments"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "IdentityCognitoAppClientCountLambda"
+        Effect = "Allow"
+        Action = [
+          "lambda:AddPermission",
+          "lambda:CreateFunction",
+          "lambda:DeleteFunction",
+          "lambda:GetFunction",
+          "lambda:GetFunctionConfiguration",
+          "lambda:GetPolicy",
+          "lambda:RemovePermission",
+          "lambda:TagResource",
+          "lambda:UpdateFunctionCode",
+          "lambda:UpdateFunctionConfiguration",
+        ]
+        Resource = [
+          "arn:aws:lambda:${var.region}:${local.account_id}:function:trade-tariff-identity-cognito-app-client-count-*",
         ]
       },
     ]

--- a/environments/production/common/iam-roles.tf
+++ b/environments/production/common/iam-roles.tf
@@ -282,7 +282,6 @@ resource "aws_iam_role" "ci_ecs_deployments_role" {
           },
           StringLike = {
             "${aws_iam_openid_connect_provider.github_oidc.url}:sub" = [
-              "repo:trade-tariff/identity:*",
               "repo:trade-tariff/trade-tariff-admin:*",
               "repo:trade-tariff/trade-tariff-api-docs:*",
               "repo:trade-tariff/trade-tariff-backend:*",
@@ -300,6 +299,43 @@ resource "aws_iam_role" "ci_ecs_deployments_role" {
 resource "aws_iam_role_policy_attachment" "ecs_deployments_ci_policy_attachment" {
   role       = aws_iam_role.ci_ecs_deployments_role.name
   policy_arn = aws_iam_policy.ci_ecs_deployment_policy.arn
+}
+
+resource "aws_iam_role" "ci_identity_ecs_deployments_role" {
+  name = "GithubActions-Identity-ECS-Deployments-Role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.github_oidc.arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "${aws_iam_openid_connect_provider.github_oidc.url}:aud" = "sts.amazonaws.com"
+          }
+          StringLike = {
+            "${aws_iam_openid_connect_provider.github_oidc.url}:sub" = [
+              "repo:trade-tariff/identity:*",
+            ]
+          }
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "identity_ecs_deployments_ci_policy" {
+  role       = aws_iam_role.ci_identity_ecs_deployments_role.name
+  policy_arn = aws_iam_policy.ci_ecs_deployment_policy.arn
+}
+
+resource "aws_iam_role_policy_attachment" "identity_ecs_deployments_lambda_policy" {
+  role       = aws_iam_role.ci_identity_ecs_deployments_role.name
+  policy_arn = aws_iam_policy.ci_identity_ecs_lambda_policy.arn
 }
 
 resource "aws_iam_role" "ci_terraform_teams_role" {

--- a/environments/staging/common/.terraform.lock.hcl
+++ b/environments/staging/common/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/archive" {
   constraints = ">= 2.0.0, 2.7.1"
   hashes = [
     "h1:62VrkalDPMKB9zerCBS4iKTbvxejwnAWn/XXYZZQWD4=",
+    "h1:A7EnRBVm4h9ryO9LwxYnKr4fy7ExPMwD5a1DsY7m1Y0=",
     "h1:Tr6LvLbm30zX4BRNPHhXo8SnOP0vg5UKAeunRNfnas8=",
     "zh:19881bb356a4a656a865f48aee70c0b8a03c35951b7799b6113883f67f196e8e",
     "zh:2fcfbf6318dd514863268b09bbe19bfc958339c636bcbcc3664b45f2b8bf5cc6",
@@ -24,9 +25,10 @@ provider "registry.terraform.io/hashicorp/archive" {
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "6.38.0"
-  constraints = ">= 4.9.0, >= 6.0.0"
+  constraints = ">= 6.0.0, >= 6.28.0"
   hashes = [
     "h1:7F3W4qGLTbr4aploSI8eIqE4AueoNe/Tq5Osuo0IgJ4=",
+    "h1:RDoKIzXmt7H1mNFcNIyRT+nA/gTJyO3+iW9QGN5I2eQ=",
     "h1:fJlpWm8M4RGM5TZGeblUiP3WqhUI0zV0hM+NAJ9lVlY=",
     "zh:143f118ae71059a7a7026c6b950da23fef04a06e2362ffa688bef75e43e869ed",
     "zh:29ee220a017306effd877e1280f8b2934dc957e16e0e72ca0222e5514d0db522",
@@ -51,6 +53,7 @@ provider "registry.terraform.io/hashicorp/external" {
   constraints = ">= 1.0.0, >= 2.3.5"
   hashes = [
     "h1:1JSWWSmVSxzHGbD4RmaNUsdGsr2hPo+WwYaluyWv7vY=",
+    "h1:FnUk98MI5nOh3VJ16cHf8mchQLewLfN1qZG/MqNgPrI=",
     "h1:smKSos4zs57pJjQrNuvGBpSWth2el9SgePPbPHo0aps=",
     "zh:6e89509d056091266532fa64de8c06950010498adf9070bf6ff85bc485a82562",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
@@ -73,6 +76,7 @@ provider "registry.terraform.io/hashicorp/local" {
   hashes = [
     "h1:2RYa3j7m/0WmET2fqotY4CHxE1Hpk0fgn47/126l+Og=",
     "h1:SY06ZmR7rY7QMGoVEkeFrERVitBp2GKl/ATz9tbjXlk=",
+    "h1:sSwlfp2etjCaE9hIF7bJBDjRIhDCVFglEOVyiCI7vgs=",
     "zh:261fec71bca13e0a7812dc0d8ae9af2b4326b24d9b2e9beab3d2400fab5c5f9a",
     "zh:308da3b5376a9ede815042deec5af1050ec96a5a5410a2206ae847d82070a23e",
     "zh:3d056924c420464dc8aba10e1915956b2e5c4d55b11ffff79aa8be563fbfe298",
@@ -93,6 +97,7 @@ provider "registry.terraform.io/hashicorp/null" {
   constraints = ">= 2.0.0, >= 3.0.0"
   hashes = [
     "h1:127ts0CG8hFk1bHIfrBsKxcnt9bAYQCq3udWM+AACH8=",
+    "h1:L5V05xwp/Gto1leRryuesxjMfgZwjb7oool4WS1UEFQ=",
     "h1:hkf5w5B6q8e2A42ND2CjAvgvSN3puAosDmOJb3zCVQM=",
     "zh:59f6b52ab4ff35739647f9509ee6d93d7c032985d9f8c6237d1f8a59471bbbe2",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
@@ -115,6 +120,7 @@ provider "registry.terraform.io/hashicorp/random" {
   hashes = [
     "h1:Eexl06+6J+s75uD46+WnZtpJZYRVUMB0AiuPBifK6Jc=",
     "h1:fdfOl1HabDT42XLH8qjmfTbVZpgQZ5lyOyOa+GQhm0w=",
+    "h1:u8AKlWVDTH5r9YLSeswoVEjiY72Rt4/ch7U+61ZDkiQ=",
     "zh:08dd03b918c7b55713026037c5400c48af5b9f468f483463321bd18e17b907b4",
     "zh:0eee654a5542dc1d41920bbf2419032d6f0d5625b03bd81339e5b33394a3e0ae",
     "zh:229665ddf060aa0ed315597908483eee5b818a17d09b6417a0f52fd9405c4f57",
@@ -135,6 +141,7 @@ provider "registry.terraform.io/hashicorp/tls" {
   constraints = ">= 4.0.0"
   hashes = [
     "h1:F5d6bQY8UlBo0D71Sv7CsV+3aZOFz0yeNF+vufog7h4=",
+    "h1:akFNuHwvrtnYMBofieoeXhPJDhYZzJVu/Q/BgZK2fgg=",
     "h1:wTIzrwUB7NINYwLFYLdWkJQwg1r9XT6rVOGrZ1+lMmI=",
     "zh:0d1e7d07ac973b97fa228f46596c800de830820506ee145626f079dd6bbf8d8a",
     "zh:5c7e3d4348cb4861ab812973ef493814a4b224bdd3e9d534a7c8a7c992382b86",
@@ -157,6 +164,7 @@ provider "registry.terraform.io/newrelic/newrelic" {
   hashes = [
     "h1:BacBfo4iCzWThRgNX/f26M0vt81ud1CG1kTYsCKVfZY=",
     "h1:In6ESu7ojzE/gklJbqIRIQmTDJjoJP41Js29I8c9b2M=",
+    "h1:JnOuc3JAIr2nNIKtg1EVZTfmNCInrZTAdCFJqMyO9zQ=",
     "zh:0a15f8e4103e7744e5292607f6e161bbf0fef753e699a1e2c27e6d42d8960a26",
     "zh:105b1e03306a33ef92a942b7974100092bb907aed5e3c715f99ccd1a3d0afb8e",
     "zh:16557e02b4dc2b7b96383323bc153b892142ff95b0be19de1d6a62537a6f854c",

--- a/environments/staging/common/iam-policies.tf
+++ b/environments/staging/common/iam-policies.tf
@@ -249,6 +249,17 @@ resource "aws_iam_policy" "ci_ecs_deployment_policy" {
           "kms:Decrypt",
           "kms:DescribeKey",
           "kms:GenerateDataKey",
+          # Lambda - identity Cognito app client count monitor (Terraform-managed)
+          "lambda:AddPermission",
+          "lambda:CreateFunction",
+          "lambda:DeleteFunction",
+          "lambda:GetFunction",
+          "lambda:GetFunctionConfiguration",
+          "lambda:GetPolicy",
+          "lambda:RemovePermission",
+          "lambda:TagResource",
+          "lambda:UpdateFunctionCode",
+          "lambda:UpdateFunctionConfiguration",
           # Logs - log groups for ECS containers
           "logs:CreateLogGroup",
           "logs:DeleteLogGroup",

--- a/environments/staging/common/iam-policies.tf
+++ b/environments/staging/common/iam-policies.tf
@@ -249,17 +249,6 @@ resource "aws_iam_policy" "ci_ecs_deployment_policy" {
           "kms:Decrypt",
           "kms:DescribeKey",
           "kms:GenerateDataKey",
-          # Lambda - identity Cognito app client count monitor (Terraform-managed)
-          "lambda:AddPermission",
-          "lambda:CreateFunction",
-          "lambda:DeleteFunction",
-          "lambda:GetFunction",
-          "lambda:GetFunctionConfiguration",
-          "lambda:GetPolicy",
-          "lambda:RemovePermission",
-          "lambda:TagResource",
-          "lambda:UpdateFunctionCode",
-          "lambda:UpdateFunctionConfiguration",
           # Logs - log groups for ECS containers
           "logs:CreateLogGroup",
           "logs:DeleteLogGroup",
@@ -312,6 +301,36 @@ resource "aws_iam_policy" "ci_ecs_deployment_policy" {
         Resource = [
           "arn:aws:s3:::terraform-state-${var.environment}-${local.account_id}",
           "arn:aws:s3:::terraform-state-${var.environment}-${local.account_id}/*"
+        ]
+      },
+    ]
+  })
+}
+
+resource "aws_iam_policy" "ci_identity_ecs_lambda_policy" {
+  name        = "ci-identity-ecs-lambda-policy"
+  description = "Lambda permissions for identity app Terraform deployments"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "IdentityCognitoAppClientCountLambda"
+        Effect = "Allow"
+        Action = [
+          "lambda:AddPermission",
+          "lambda:CreateFunction",
+          "lambda:DeleteFunction",
+          "lambda:GetFunction",
+          "lambda:GetFunctionConfiguration",
+          "lambda:GetPolicy",
+          "lambda:RemovePermission",
+          "lambda:TagResource",
+          "lambda:UpdateFunctionCode",
+          "lambda:UpdateFunctionConfiguration",
+        ]
+        Resource = [
+          "arn:aws:lambda:${var.region}:${local.account_id}:function:trade-tariff-identity-cognito-app-client-count-*",
         ]
       },
     ]

--- a/environments/staging/common/iam-roles.tf
+++ b/environments/staging/common/iam-roles.tf
@@ -213,7 +213,6 @@ resource "aws_iam_role" "ci_ecs_deployments_role" {
           },
           StringLike = {
             "${aws_iam_openid_connect_provider.github_oidc.url}:sub" = [
-              "repo:trade-tariff/identity:*",
               "repo:trade-tariff/trade-tariff-admin:*",
               "repo:trade-tariff/trade-tariff-api-docs:*",
               "repo:trade-tariff/trade-tariff-backend:*",
@@ -232,6 +231,43 @@ resource "aws_iam_role" "ci_ecs_deployments_role" {
 resource "aws_iam_role_policy_attachment" "ecs_deployments_ci_policy_attachment" {
   role       = aws_iam_role.ci_ecs_deployments_role.name
   policy_arn = aws_iam_policy.ci_ecs_deployment_policy.arn
+}
+
+resource "aws_iam_role" "ci_identity_ecs_deployments_role" {
+  name = "GithubActions-Identity-ECS-Deployments-Role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.github_oidc.arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "${aws_iam_openid_connect_provider.github_oidc.url}:aud" = "sts.amazonaws.com"
+          }
+          StringLike = {
+            "${aws_iam_openid_connect_provider.github_oidc.url}:sub" = [
+              "repo:trade-tariff/identity:*",
+            ]
+          }
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "identity_ecs_deployments_ci_policy" {
+  role       = aws_iam_role.ci_identity_ecs_deployments_role.name
+  policy_arn = aws_iam_policy.ci_ecs_deployment_policy.arn
+}
+
+resource "aws_iam_role_policy_attachment" "identity_ecs_deployments_lambda_policy" {
+  role       = aws_iam_role.ci_identity_ecs_deployments_role.name
+  policy_arn = aws_iam_policy.ci_identity_ecs_lambda_policy.arn
 }
 
 resource "aws_iam_role" "ci_api_docs_role" {


### PR DESCRIPTION
# Jira link

https://transformuk.atlassian.net/browse/OTTIMP-536

What?

I have:

- Added GithubActions-Identity-ECS-Deployments-Role and ci-identity-ecs-lambda-policy in development, staging, and production
- Attached the existing ci-ecs-deployment-policy plus scoped Lambda permissions for trade-tariff-identity-cognito-app-client-count-* to that role
- Restricted the new role’s GitHub OIDC trust to repo:trade-tariff/identity:* only
- Removed repo:trade-tariff/identity:* from GithubActions-ECS-Deployments-Role so identity no longer uses the shared ECS deploy role

Why?
I am doing this because:

- Identity Terraform deploys a Cognito app-client count Lambda and alarm; CI failed with lambda:CreateFunction on the standard ECS deploy role
- We should not widen ci-ecs-deployment-policy for all ECS apps when only identity needs Lambda today
- A dedicated role keeps ECS deploy permissions for identity while adding narrowly scoped Lambda permissions, matching the pattern discussed with the team
