### PR TITLE
HMRC-2202: Improve DB upgrade process

### DIFF
--- a/modules/elasticache/README.md
+++ b/modules/elasticache/README.md
@@ -31,7 +31,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_apply_immediately"></a> [apply\_immediately](#input\_apply\_immediately) | Whether to apply changes to the replication group immediately (`true`), or to wait for the next maintenance window (`false`). | `bool` | `true` | no |
+| <a name="input_apply_immediately"></a> [apply\_immediately](#input\_apply\_immediately) | Whether to apply changes to the replication group immediately (`true`), or to wait for the next maintenance window (`false`). | `bool` | `false` | no |
 | <a name="input_at_rest_encryption_enabled"></a> [at\_rest\_encryption\_enabled](#input\_at\_rest\_encryption\_enabled) | Encryption at rest. | `bool` | `false` | no |
 | <a name="input_auth_token"></a> [auth\_token](#input\_auth\_token) | Password used to access the cluster. Requires `transit_encryption_enabled` to be `true`. Defaults to "", not set. | `string` | `""` | no |
 | <a name="input_auth_token_update_strategy"></a> [auth\_token\_update\_strategy](#input\_auth\_token\_update\_strategy) | Method to use in updating the auth token on a cluster.<br/>Can be one of `SET`, `ROTATE`, or `DELETE`:<br/>  - `SET` should be used when setting a new auth token.<br/>  - `ROTATE` is the default, for changing an auth token.<br/>  - `DELETE` should be used, with an empty auth token, to remove password protection on a cluster. | `string` | `"ROTATE"` | no |

--- a/modules/elasticache/variables.tf
+++ b/modules/elasticache/variables.tf
@@ -28,7 +28,7 @@ variable "replication_group_id" {
 variable "apply_immediately" {
   description = "Whether to apply changes to the replication group immediately (`true`), or to wait for the next maintenance window (`false`)."
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "multi_az_enabled" {

--- a/modules/rds/README.md
+++ b/modules/rds/README.md
@@ -42,6 +42,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_allocated_storage"></a> [allocated\_storage](#input\_allocated\_storage) | Storage to allocate initially to the instance in gibibytes (i.e. 2^30 bytes). Can autoscale. | `number` | `5` | no |
+| <a name="input_allow_major_version_upgrade"></a> [allow\_major\_version\_upgrade](#input\_allow\_major\_version\_upgrade) | Whether to allow major version upgrades. | `bool` | `false` | no |
 | <a name="input_backup_retention_period"></a> [backup\_retention\_period](#input\_backup\_retention\_period) | Amount of time, in days, (between 0 and 35) that backups should be retained for. | `number` | `30` | no |
 | <a name="input_backup_window"></a> [backup\_window](#input\_backup\_window) | The daily time range (in UTC) during which automated backups are created if they are enabled, eg: `09:46-10:16` | `string` | n/a | yes |
 | <a name="input_database_insights_mode"></a> [database\_insights\_mode](#input\_database\_insights\_mode) | The mode of Database Insights that is enabled for the instance. Valid values: standard, advanced. | `string` | `"standard"` | no |

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -16,7 +16,7 @@ resource "aws_db_instance" "this" {
   maintenance_window      = var.maintenance_window
   skip_final_snapshot     = true
 
-  allow_major_version_upgrade = true
+  allow_major_version_upgrade = var.allow_major_version_upgrade
   auto_minor_version_upgrade  = true
   # apply db modifications during maintenance windows only
   # this prevents downtime as the server restarts

--- a/modules/rds/variables.tf
+++ b/modules/rds/variables.tf
@@ -102,3 +102,9 @@ variable "multi_az" {
   type        = bool
   default     = false
 }
+
+variable "allow_major_version_upgrade" {
+  description = "Whether to allow major version upgrades."
+  type        = bool
+  default     = false
+}

--- a/modules/rds_cluster/README.md
+++ b/modules/rds_cluster/README.md
@@ -34,6 +34,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_allow_major_version_upgrade"></a> [allow\_major\_version\_upgrade](#input\_allow\_major\_version\_upgrade) | Whether to allow major version upgrades. | `bool` | `false` | no |
 | <a name="input_apply_immediately"></a> [apply\_immediately](#input\_apply\_immediately) | Whether to apply changes immediately. Set to `true` when required. Defaults to `false`. | `bool` | `false` | no |
 | <a name="input_cloudwatch_log_exports"></a> [cloudwatch\_log\_exports](#input\_cloudwatch\_log\_exports) | A list of log types to export to CloudWatch Logs. Supported values: `postgresql`, `upgrade`, `iam-db-auth-error`. | `list(string)` | `[]` | no |
 | <a name="input_cluster_instances"></a> [cluster\_instances](#input\_cluster\_instances) | n/a | `number` | `0` | no |
@@ -51,6 +52,7 @@ No modules.
 | <a name="input_instance_class"></a> [instance\_class](#input\_instance\_class) | n/a | `string` | n/a | yes |
 | <a name="input_instance_identifiers"></a> [instance\_identifiers](#input\_instance\_identifiers) | To avoid renames after a snapshot restore, we manually pass the cluster identifiers to have these identifiers reflected in terraform state and avoid alterations to the writer/reader instances. | `list(string)` | `[]` | no |
 | <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | KMS key ARN for encryption at rest. | `string` | `null` | no |
+| <a name="input_maintenance_window"></a> [maintenance\_window](#input\_maintenance\_window) | The time window (in UTC) to perform maintenance in. Syntax: `ddd:hh24:mi-ddd:hh24:mi`, eg: `Mon:00:00-Mon:01:30`. | `string` | `"sun:05:00-sun:06:00"` | no |
 | <a name="input_max_capacity"></a> [max\_capacity](#input\_max\_capacity) | Maximum capacity (ACUs). Defaults to `256`. | `number` | `256` | no |
 | <a name="input_min_capacity"></a> [min\_capacity](#input\_min\_capacity) | Minimum capacity (ACUs). Defaults to `0`. | `number` | `0` | no |
 | <a name="input_performance_insights_enabled"></a> [performance\_insights\_enabled](#input\_performance\_insights\_enabled) | Whether to enable Performance Insights. Defaults to `true`. | `bool` | `false` | no |

--- a/modules/rds_cluster/main.tf
+++ b/modules/rds_cluster/main.tf
@@ -5,7 +5,8 @@ resource "aws_rds_cluster" "this" {
   engine_mode    = var.engine_mode
   engine_version = var.engine_version
 
-  allow_major_version_upgrade = true
+  allow_major_version_upgrade  = var.allow_major_version_upgrade
+  preferred_maintenance_window = var.maintenance_window
 
   master_username = var.username
   master_password = random_password.master_password.result
@@ -54,6 +55,11 @@ resource "aws_rds_cluster_instance" "this" {
   db_subnet_group_name = var.create_subnet_group ? aws_db_subnet_group.rds_private_subnet[0].name : var.db_subnet_group_name
 
   instance_class = var.instance_class
+
+  auto_minor_version_upgrade = true
+  # apply db modifications during maintenance windows only
+  # this prevents downtime as the server restarts
+  apply_immediately = false
 
   lifecycle {
     prevent_destroy = true

--- a/modules/rds_cluster/variables.tf
+++ b/modules/rds_cluster/variables.tf
@@ -133,3 +133,16 @@ variable "instance_identifiers" {
   description = "To avoid renames after a snapshot restore, we manually pass the cluster identifiers to have these identifiers reflected in terraform state and avoid alterations to the writer/reader instances."
   default     = []
 }
+
+# Set it to true during the upgrade
+# Set it back to false After upgrade
+variable "allow_major_version_upgrade" {
+  description = "Whether to allow major version upgrades. "
+  type        = bool
+  default     = false
+}
+variable "maintenance_window" {
+  description = "The time window (in UTC) to perform maintenance in. Syntax: `ddd:hh24:mi-ddd:hh24:mi`, eg: `Mon:00:00-Mon:01:30`."
+  type        = string
+  default     = "sun:05:00-sun:06:00"
+}


### PR DESCRIPTION
# Jira link
(HMRC-2202)[https://transformuk.atlassian.net/browse/HMRC-2202]

## What?

I have:

- Set `allow_major_version_upgrade = false` (controlled via PR when needed)
- Enabled `auto_minor_version_upgrade` where applicable
- Ensured changes are applied during maintenance windows
- Fixed gap in Aurora cluster instance configuration

## Why?

I am doing this because:

- Reduce risk of unintended breaking changes from major upgrades
- Ensure security patches are applied consistently
- Avoid unexpected downtime from immediate applies