### PR TITLE
HMRC-2234: Enable e2e-scheduler repo to assume Serverless Lambda role via OIDC

### DIFF
--- a/environments/production/common/iam-roles.tf
+++ b/environments/production/common/iam-roles.tf
@@ -53,6 +53,7 @@ resource "aws_iam_role" "serverless_lambda_ci_role" {
               "repo:trade-tariff/trade-tariff-lambdas-fpo-model-garbage-collection:*",
               "repo:trade-tariff/trade-tariff-lambdas-fpo-search:*",
               "repo:trade-tariff/trade-tariff-lambdas-uptime-monitor:*",
+              "repo:trade-tariff/trade-tariff-lambdas-e2e-scheduler:*"
             ]
           }
         }


### PR DESCRIPTION
# Jira link
[HMRC-2234](https://transformuk.atlassian.net/browse/HMRC-2234)
## What?

I have:

- Added e2e-scheduler repository to the trusted entities of GithubActions-Serverless-Lambda-Role

## Why?

I am doing this because:

- Unblocks CI/CD deployment of the E2E scheduler Lambda