### PR TITLE
BAU: Fix scoped ALB alarm dimensions

### DIFF
--- a/environments/development/common/slack-notify.tf
+++ b/environments/development/common/slack-notify.tf
@@ -28,7 +28,7 @@ resource "aws_cloudwatch_metric_alarm" "high_5xx_codes" {
   metric_name         = "HTTPCode_Target_5XX_Count"
   namespace           = "AWS/ApplicationELB"
   period              = "300"
-  statistic           = "Average"
+  statistic           = "Sum"
   unit                = "Count"
   threshold           = 10
   alarm_description   = "Too many HTTP 5xx errors in ${var.environment} environment for target group ${each.value.name}"
@@ -39,7 +39,7 @@ resource "aws_cloudwatch_metric_alarm" "high_5xx_codes" {
 
   dimensions = {
     LoadBalancer = module.alb.arn_suffix
-    TargetGroup  = each.value.arn
+    TargetGroup  = each.value.arn_suffix
   }
 }
 
@@ -63,7 +63,7 @@ resource "aws_cloudwatch_metric_alarm" "long_response_times" {
 
   dimensions = {
     LoadBalancer = module.alb.arn_suffix
-    TargetGroup  = each.value.arn
+    TargetGroup  = each.value.arn_suffix
   }
 }
 

--- a/environments/production/common/slack-notify.tf
+++ b/environments/production/common/slack-notify.tf
@@ -28,7 +28,7 @@ resource "aws_cloudwatch_metric_alarm" "high_5xx_codes" {
   metric_name         = "HTTPCode_Target_5XX_Count"
   namespace           = "AWS/ApplicationELB"
   period              = "300"
-  statistic           = "Average"
+  statistic           = "Sum"
   unit                = "Count"
   threshold           = 10
   alarm_description   = "Too many HTTP 5xx errors in ${var.environment} environment for target group ${each.value.name}"
@@ -39,7 +39,7 @@ resource "aws_cloudwatch_metric_alarm" "high_5xx_codes" {
 
   dimensions = {
     LoadBalancer = module.alb.arn_suffix
-    TargetGroup  = each.value.arn
+    TargetGroup  = each.value.arn_suffix
   }
 }
 
@@ -63,7 +63,7 @@ resource "aws_cloudwatch_metric_alarm" "long_response_times" {
 
   dimensions = {
     LoadBalancer = module.alb.arn_suffix
-    TargetGroup  = each.value.arn
+    TargetGroup  = each.value.arn_suffix
   }
 }
 

--- a/environments/staging/common/slack-notify.tf
+++ b/environments/staging/common/slack-notify.tf
@@ -28,7 +28,7 @@ resource "aws_cloudwatch_metric_alarm" "high_5xx_codes" {
   metric_name         = "HTTPCode_Target_5XX_Count"
   namespace           = "AWS/ApplicationELB"
   period              = "300"
-  statistic           = "Average"
+  statistic           = "Sum"
   unit                = "Count"
   threshold           = 10
   alarm_description   = "Too many HTTP 5xx errors in ${var.environment} environment for target group ${each.value.name}"
@@ -39,7 +39,7 @@ resource "aws_cloudwatch_metric_alarm" "high_5xx_codes" {
 
   dimensions = {
     LoadBalancer = module.alb.arn_suffix
-    TargetGroup  = each.value.arn
+    TargetGroup  = each.value.arn_suffix
   }
 }
 
@@ -63,7 +63,7 @@ resource "aws_cloudwatch_metric_alarm" "long_response_times" {
 
   dimensions = {
     LoadBalancer = module.alb.arn_suffix
-    TargetGroup  = each.value.arn
+    TargetGroup  = each.value.arn_suffix
   }
 }
 

--- a/modules/application-load-balancer/outputs.tf
+++ b/modules/application-load-balancer/outputs.tf
@@ -18,8 +18,9 @@ output "target_groups" {
   value = {
     for tg in aws_lb_target_group.trade_tariff_https_target_groups :
     tg.name => {
-      name = tg.name,
-      arn  = tg.arn
+      name       = tg.name,
+      arn        = tg.arn
+      arn_suffix = tg.arn_suffix
     }
   }
 }


### PR DESCRIPTION
# Jira link

BAU

## What?

I have:

- [x] Added the target group `arn_suffix` to the ALB module target group output.
- [x] Altered the development, staging, and production ALB target-group alarms to use `each.value.arn_suffix` for the CloudWatch `TargetGroup` dimension.
- [x] Altered the target 5xx count alarms to use `Sum` rather than `Average` for `HTTPCode_Target_5XX_Count`.
- [x] Left target response time alarms on `Average`.

## Why?

I am doing this because:

- The existing scoped ALB alarms used the full target group ARN as the CloudWatch `TargetGroup` dimension.
- CloudWatch expects the target group ARN suffix for ALB target group metrics, for example `targetgroup/frontend-https/...`.
- Because the dimension was wrong, the scoped frontend/backend target-group alarms did not receive datapoints, so they could not identify whether 5xx responses came from frontend or backend targets.
- `HTTPCode_Target_5XX_Count` is a count metric, so summing the period gives the alarm the actual number of target 5xx responses.

## Risk

**Risk level:** 🟠

**Reason for rating:** This changes production alerting dimensions. The change is narrowly scoped and the affected Terraform roots validate, but the alarms should still be checked after apply to confirm CloudWatch shows datapoints per target group.
