### PR TITLE
Updated GithubActions-Identity-ECS-Deployments-Role in all three environments to allow orchestrated identity deploys.

### DIFF
--- a/environments/development/common/iam-roles.tf
+++ b/environments/development/common/iam-roles.tf
@@ -257,6 +257,11 @@ resource "aws_iam_role" "ci_identity_ecs_deployments_role" {
           StringLike = {
             "${aws_iam_openid_connect_provider.github_oidc.url}:sub" = [
               "repo:trade-tariff/identity:*",
+              "repo:trade-tariff/trade-tariff-admin:*",
+              "repo:trade-tariff/trade-tariff-backend:*",
+              "repo:trade-tariff/trade-tariff-dev-hub:*",
+              "repo:trade-tariff/trade-tariff-frontend:*",
+              "repo:trade-tariff/trade-tariff-tools:*",
             ]
           }
         }

--- a/environments/production/common/iam-roles.tf
+++ b/environments/production/common/iam-roles.tf
@@ -320,6 +320,11 @@ resource "aws_iam_role" "ci_identity_ecs_deployments_role" {
           StringLike = {
             "${aws_iam_openid_connect_provider.github_oidc.url}:sub" = [
               "repo:trade-tariff/identity:*",
+              "repo:trade-tariff/trade-tariff-admin:*",
+              "repo:trade-tariff/trade-tariff-backend:*",
+              "repo:trade-tariff/trade-tariff-dev-hub:*",
+              "repo:trade-tariff/trade-tariff-frontend:*",
+              "repo:trade-tariff/trade-tariff-tools:*",
             ]
           }
         }

--- a/environments/staging/common/iam-roles.tf
+++ b/environments/staging/common/iam-roles.tf
@@ -252,6 +252,11 @@ resource "aws_iam_role" "ci_identity_ecs_deployments_role" {
           StringLike = {
             "${aws_iam_openid_connect_provider.github_oidc.url}:sub" = [
               "repo:trade-tariff/identity:*",
+              "repo:trade-tariff/trade-tariff-admin:*",
+              "repo:trade-tariff/trade-tariff-backend:*",
+              "repo:trade-tariff/trade-tariff-dev-hub:*",
+              "repo:trade-tariff/trade-tariff-frontend:*",
+              "repo:trade-tariff/trade-tariff-tools:*",
             ]
           }
         }


### PR DESCRIPTION
# Jira link
https://transformuk.atlassian.net/browse/OTTIMP-616

## What?

I have:

- Added four orchestrator repos to the GithubActions-Identity-ECS-Deployments-Role OIDC trust policy: trade-tariff-admin, trade-tariff-backend, trade-tariff-dev-hub, and trade-tariff-frontend
- Altered the Identity ECS deployments role trust policy in development, staging, and production so GitHub Actions can assume the role when identity is deployed as part of a full-stack workflow

## Why?

I am doing this because:

- Identity deployments were moved onto a dedicated IAM role (GithubActions-Identity-ECS-Deployments-Role), which only trusted the identity repo
- Full-stack development deploys run from orchestrator repos (admin, backend, dev-hub, frontend) via deploy-multi-ecs.yml, so the OIDC token sub claim comes from the calling repo, not trade-tariff/identity
- This caused sts:AssumeRoleWithWebIdentity failures when the identity matrix job ran in workflows like Deploy to development full
- Extending the trust policy to the orchestrator repos allows those workflows to deploy identity without changing app-level workflow code
