### PR TITLE
HMRC-2248: Add production-observability slack alerting channel

### DIFF
--- a/environments/production/common/outputs.tf
+++ b/environments/production/common/outputs.tf
@@ -2,3 +2,8 @@ output "slack_topic_arn" {
   description = "The ARN of the SNS topic for Slack notifications"
   value       = module.notify_slack.slack_topic_arn
 }
+
+output "slack_observability_topic_arn" {
+  description = "The ARN of the SNS topic for Slack observability notifications"
+  value       = module.notify_slack_observability.slack_topic_arn
+}

--- a/environments/production/common/slack-notify.tf
+++ b/environments/production/common/slack-notify.tf
@@ -15,8 +15,24 @@ module "notify_slack" {
   cloudwatch_log_group_retention_in_days = 90
 }
 
+module "notify_slack_observability" {
+  source = "../../../modules/aws-notify-slack"
+
+  lambda_function_name = "notify_slack_observability_${var.environment}"
+  sns_topic_name       = "slack-observability-topic"
+
+  slack_webhook_url = data.aws_secretsmanager_secret_version.slack_notify_lambda_slack_webhook_url.secret_string
+  slack_channel     = "production-observability"
+  slack_username    = "AWS"
+
+  lambda_description                     = "Lambda function which sends non-critical notifications to Slack"
+  log_events                             = true
+  cloudwatch_log_group_retention_in_days = 90
+}
+
 locals {
-  alert_actions = var.enable_sns_alerts ? [module.notify_slack.slack_topic_arn] : []
+  alert_actions               = var.enable_sns_alerts ? [module.notify_slack.slack_topic_arn] : []
+  observability_alert_actions = var.enable_sns_alerts ? [module.notify_slack_observability.slack_topic_arn] : []
 }
 
 resource "aws_cloudwatch_metric_alarm" "high_5xx_codes" {
@@ -34,8 +50,8 @@ resource "aws_cloudwatch_metric_alarm" "high_5xx_codes" {
   alarm_description   = "Too many HTTP 5xx errors in ${var.environment} environment for target group ${each.value.name}"
   treat_missing_data  = "notBreaching"
 
-  alarm_actions = local.alert_actions
-  ok_actions    = local.alert_actions
+  alarm_actions = local.observability_alert_actions
+  ok_actions    = local.observability_alert_actions
 
   dimensions = {
     LoadBalancer = module.alb.arn_suffix
@@ -58,8 +74,8 @@ resource "aws_cloudwatch_metric_alarm" "long_response_times" {
   alarm_description   = "Long response times in ${var.environment} environment for target group ${each.value.name}"
   treat_missing_data  = "notBreaching"
 
-  alarm_actions = local.alert_actions
-  ok_actions    = local.alert_actions
+  alarm_actions = local.observability_alert_actions
+  ok_actions    = local.observability_alert_actions
 
   dimensions = {
     LoadBalancer = module.alb.arn_suffix


### PR DESCRIPTION
# Jira link
[HMRC-2248](https://transformuk.atlassian.net/browse/HMRC-2248)
## What?

I have:

- Added a second `notify_slack` module instance that routes lower-urgency CloudWatch alarms to a new `#production-observability` Slack channel, keeping `#production-alerts` for high-priority alarms only.
No changes to Lambda code — the existing `notify_slack.py` is reused. The module deploys a second Lambda function with a different `SLACK_CHANNEL` environment variable.
- Routed high_5xx_codes and long_response_times alarm to the `#production-observability` Slack channel

## Why?
I am doing this because:

 `#production-alerts` was receiving both critical and non-critical alarms, creating noise and risking alert fatigue. Splitting by urgency makes on-call response clearer.

## Risk
🟢 **Green** — additive change only. Existing alarms and the `#production-alerts` channel are untouched. The new Lambda and SNS topic are independent. Worst case the new channel receives no messages if misconfigured, with zero impact on current alerting.