### PR TITLE
HMRC-2011: Keep all WAF logs, not just those with BLOCK action

### DIFF
--- a/environments/production/common/waf.tf
+++ b/environments/production/common/waf.tf
@@ -37,7 +37,7 @@ module "waf" {
 resource "aws_cloudwatch_log_group" "waf_logs" {
   provider          = aws.us_east_1
   name              = "aws-waf-logs-tariff-${var.environment}"
-  retention_in_days = 30
+  retention_in_days = 60
 }
 
 resource "aws_wafv2_web_acl_logging_configuration" "waf_logs" {
@@ -47,29 +47,7 @@ resource "aws_wafv2_web_acl_logging_configuration" "waf_logs" {
   resource_arn            = module.waf.web_acl_id
 
   logging_filter {
-    default_behavior = "DROP"
-
-    # to remove noise in log group, since we are not blocking for no user agent
-    # header and instead COUNTing, drop all NoUserAgent_Header logs where rule
-    # action is COUNT.
-
-    filter {
-      behavior = "DROP"
-
-      condition {
-        label_name_condition {
-          label_name = "awswaf:managed:aws:core-rule-set:NoUserAgent_Header"
-        }
-      }
-
-      condition {
-        action_condition {
-          action = "COUNT"
-        }
-      }
-
-      requirement = "MEETS_ALL"
-    }
+    default_behavior = "KEEP"
 
     filter {
       behavior = "KEEP"


### PR DESCRIPTION
# Jira link

[HMRC-2011](https://transformuk.atlassian.net/browse/HMRC-2011)

## What?

I have:

- Changed production WAF logging behaviour to keep all logs by default
- Increased WAF log retention to 60 days

## Why?

I am doing this because:

- We currently drop any WAF logs that do not have the action `BLOCK`, and drop logs older than 30 days. This makes historical WAF data impossible to analyse, and stops us from being able to analyse the impact of changes to the WAF rulesets by running additional rules in COUNT mode.
- The WAF logs give us `httpRequest.country` that enable us to look at traffic patterns by-country, to assess the impact of changing our rate limiting rules by geolocation.

