### PR TITLE
HMRC-2250: Add Terraform module test coverage

### DIFF
--- a/.github/workflows/deploy-to-development.yml
+++ b/.github/workflows/deploy-to-development.yml
@@ -69,6 +69,8 @@ jobs:
         run: terraform init -backend=false
         working-directory: environments/development/common
 
+      - run: scripts/run-terraform-tests
+
       - run: pip install pre-commit
 
       - run: pre-commit run --all-files --show-diff-on-failure

--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ terragrunt run --all init
 changes. These keep the Terraform documentation up to date, prevent linting
 errors, and ensure your changes conform to the repository standards.
 
+- Run Terraform module tests when changing module behaviour:
+
+```shell
+scripts/run-terraform-tests
+```
+
+Module tests live in `modules/<module>/tests/*.tftest.hcl`. Prefer fast
+plan-time tests that assert module contracts, defaults, and derived resource
+configuration. Avoid tests that create real AWS infrastructure; deployment
+confidence still comes from the Terragrunt plan and apply workflow.
+
 - Open a Pull Request with your changes. This will deploy the feature over the
 development environment to proof that `terraform apply` runs without failure.
 

--- a/modules/api-gateway/tests/cache_defaults.tftest.hcl
+++ b/modules/api-gateway/tests/cache_defaults.tftest.hcl
@@ -1,0 +1,91 @@
+provider "aws" {
+  region                      = "eu-west-2"
+  access_key                  = "test"
+  secret_key                  = "test"
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+}
+
+run "cache_defaults_cover_backend_query_params" {
+  command = plan
+
+  variables {
+    environment               = "test"
+    domain_name               = "example.test"
+    validated_certificate_arn = "arn:aws:acm:eu-west-2:123456789012:certificate/00000000-0000-0000-0000-000000000000"
+    zone_id                   = "Z0000000000000000000"
+    security_group_ids        = ["sg-00000000000000000"]
+    private_subnet_ids        = ["subnet-00000000000000000", "subnet-11111111111111111"]
+    lb_arn                    = "arn:aws:elasticloadbalancing:eu-west-2:123456789012:loadbalancer/app/test/0000000000000000"
+    alb_secret_header         = ["X-Origin-Secret", "test-secret"]
+  }
+
+  assert {
+    condition = alltrue([
+      for param in [
+        "as_of",
+        "country_code",
+        "heading_code",
+        "include",
+        "limit",
+        "page",
+        "per_page",
+        "type",
+        "code",
+        "description",
+        "order_number",
+        "year",
+        "month",
+        "day",
+        "name",
+        "cas",
+        "source",
+        "excluded",
+        "q",
+        "query.letter",
+        "filter.cas_rn",
+        "filter.cus",
+        "filter.exclude_none",
+        "filter.from_date",
+        "filter.geographical_area_id",
+        "filter.goods_nomenclature_item_id",
+        "filter.goods_nomenclature_sid",
+        "filter.has_article",
+        "filter.meursing_additional_code_id",
+        "filter.simplified_procedural_code",
+        "filter.status",
+        "filter.to_date",
+        "filter.type",
+      ] : contains(var.cache_key_params, param)
+    ])
+
+    error_message = "cache_key_params must include every backend-supported query parameter that can change cached API responses."
+  }
+
+  assert {
+    condition = alltrue([
+      for path in [
+        "chemical_substances",
+        "description_intercepts",
+        "search",
+        "search_suggestions",
+      ] : contains(var.uk_uncached_paths, path)
+    ])
+
+    error_message = "UK uncached paths must carve out top-level search/filter endpoints where API Gateway response caching is not aligned with backend behavior."
+  }
+
+  assert {
+    condition = alltrue([
+      for path in [
+        "chemical_substances",
+        "description_intercepts",
+        "search",
+        "search_suggestions",
+      ] : contains(var.xi_uncached_paths, path)
+    ])
+
+    error_message = "XI uncached paths must carve out top-level search/filter endpoints where API Gateway response caching is not aligned with backend behavior."
+  }
+}

--- a/scripts/run-terraform-tests
+++ b/scripts/run-terraform-tests
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+found_tests=0
+
+for module in modules/*; do
+  if [ ! -d "$module" ] || ! find "$module/tests" -maxdepth 1 -name "*.tftest.hcl" -print -quit 2> /dev/null | grep -q .; then
+    continue
+  fi
+
+  found_tests=1
+  echo "Running Terraform tests in $module"
+  terraform -chdir="$module" test -no-color
+done
+
+if [ "$found_tests" -eq 0 ]; then
+  echo "No Terraform module tests found"
+fi


### PR DESCRIPTION
## What

- Add a native `terraform test` runner for module-level tests.
- Backfill API Gateway coverage around cache key query params and uncached endpoint carve-outs.
- Wire the module test runner into the development PR lint workflow.
- Document the module test convention in the README.

## Why

The API Gateway cache behaviour now has a cheap regression test around the backend-supported query params and the paths where gateway response caching is deliberately disabled. This gives us a small, repo-local unit testing idiom without creating AWS infrastructure.