### PR TITLE
Update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @neilmiddleton @AigulDj @amberstarlight
+*       @neilmiddleton @AigulDj @amberstarlight @morganism

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @neilmiddleton @AigulDj @amberstarlight @morganism
+*       @trade-tariff/trade-tariff-platform


### PR DESCRIPTION
# Jira link

## What?

I have:

- Replace users with the `platform` gh team

## Why?

I am doing this because:

- Easier maintenance. Instead of editing CODEOWNERS every time someone joins/leaves:
  - Add/remove people in the GitHub team
  - CODEOWNERS stays unchanged 