### PR TITLE
BAU: Allow FPO search to assume identity ECS role

### DIFF
--- a/environments/development/common/iam-roles.tf
+++ b/environments/development/common/iam-roles.tf
@@ -261,6 +261,7 @@ resource "aws_iam_role" "ci_identity_ecs_deployments_role" {
               "repo:trade-tariff/trade-tariff-backend:*",
               "repo:trade-tariff/trade-tariff-dev-hub:*",
               "repo:trade-tariff/trade-tariff-frontend:*",
+              "repo:trade-tariff/trade-tariff-lambdas-fpo-search:*",
               "repo:trade-tariff/trade-tariff-tools:*",
             ]
           }


### PR DESCRIPTION
### Jira link

_No Jira story — BAU CI fix._

### What?

- Adds `trade-tariff-lambdas-fpo-search` to the development GitHub OIDC trust policy for `GithubActions-Identity-ECS-Deployments-Role`.

### Why?

The `trade-tariff-lambdas-fpo-search` development PR deployment workflow starts `dev-hub identity` before E2E tests. The shared `start-services` action switches to `GithubActions-Identity-ECS-Deployments-Role` when `identity` is present, but the development role did not trust the FPO search repository, so AWS rejected `sts:AssumeRoleWithWebIdentity`.

Staging and production do not call `start-services` in this repository; they deploy with `GithubActions-Serverless-Lambda-Role`, so this change is limited to development.

Failure investigated from: https://github.com/trade-tariff/trade-tariff-lambdas-fpo-search/actions/runs/26844678462/job/79160864988?pr=251
