### PR TITLE
Add supporting infrastructure for self-hosted Flagsmith

### DIFF
--- a/environments/development/common/alb.tf
+++ b/environments/development/common/alb.tf
@@ -65,6 +65,25 @@ module "alb" {
     }
   }
 
+  # Flagsmith serves plain HTTP on 8000 (no in-container TLS), so it uses HTTP
+  # target groups. Deployed from the trade-tariff-flagsmith app repo, which
+  # registers tasks against these target groups by name.
+  http_services = {
+    flagsmith = {
+      hosts            = ["flags.*"]
+      healthcheck_path = "/health/"
+      container_port   = 8000
+      priority         = 30
+    }
+
+    flagsmith_edge = {
+      hosts            = ["flags-edge.*"]
+      healthcheck_path = "/proxy/health"
+      container_port   = 8000
+      priority         = 31
+    }
+  }
+
   gateway_services = {
     backend_xi = {
       paths            = ["/xi/api/*"]

--- a/environments/development/common/flagsmith.tf
+++ b/environments/development/common/flagsmith.tf
@@ -1,0 +1,224 @@
+# Supporting infrastructure for self-hosted Flagsmith.
+#
+# Flagsmith itself (the API + edge-proxy ECS services) is deployed from the
+# trade-tariff-flagsmith app repo via the shared ecs-service module, exactly
+# like devhub/frontend/backend. This file only declares the shared resources
+# that app reads via data sources: a dedicated database, security groups,
+# configuration secrets, and the public-facing CloudFront distributions.
+
+# ── Database ──────────────────────────────────────────────────────────────────
+# Dedicated Postgres instance, isolated from the shared tariff cluster so
+# Flagsmith's schema and load can't affect tariff data. The rds module also
+# creates a "flagsmith-connection-string" secret the app reads as DATABASE_URL.
+module "postgres_flagsmith" {
+  source = "../../../modules/rds"
+
+  environment    = var.environment
+  name           = "Flagsmith"
+  engine         = "postgres"
+  engine_version = "18.3"
+
+  multi_az = false
+
+  instance_type           = "db.t3.micro"
+  backup_window           = "22:00-23:00"
+  maintenance_window      = "Fri:23:00-Sat:01:00"
+  backup_retention_period = 7
+  private_subnet_ids      = data.terraform_remote_state.base.outputs.private_subnet_ids
+
+  allocated_storage  = 20
+  security_group_ids = [aws_security_group.flagsmith_rds.id]
+
+  secret_kms_key_arn = aws_kms_key.secretsmanager_kms_key.arn
+
+  depends_on = [
+    aws_security_group.flagsmith_rds
+  ]
+
+  tags = {
+    Name       = "FlagsmithPostgres${title(var.environment)}"
+    "RDS_Type" = "Instance"
+  }
+}
+
+# ── Security groups ───────────────────────────────────────────────────────────
+# Flagsmith's upstream image serves plain HTTP on 8000 (no in-container TLS),
+# so it gets a dedicated ECS security group rather than the shared 8443 one.
+resource "aws_security_group" "flagsmith_ecs" {
+  name        = "flagsmith-ecs-${var.environment}"
+  description = "Flagsmith ECS tasks: HTTP 8000 from the ALB, all egress."
+  vpc_id      = data.terraform_remote_state.base.outputs.vpc_id
+
+  ingress {
+    description     = "HTTP 8000 from ALB"
+    from_port       = 8000
+    to_port         = 8000
+    protocol        = "tcp"
+    security_groups = [module.alb-security-group.alb_security_group_id]
+  }
+
+  egress {
+    description = "Allow all egress (Docker Hub pulls, RDS, etc.)"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "flagsmith-ecs-${var.environment}"
+  }
+}
+
+resource "aws_security_group" "flagsmith_rds" {
+  name        = "flagsmith-rds-${var.environment}"
+  description = "Flagsmith database: PostgreSQL from Flagsmith ECS tasks only."
+  vpc_id      = data.terraform_remote_state.base.outputs.vpc_id
+
+  ingress {
+    description     = "PostgreSQL from Flagsmith ECS"
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = [aws_security_group.flagsmith_ecs.id]
+  }
+
+  tags = {
+    Name = "flagsmith-rds-${var.environment}"
+  }
+}
+
+# ── Configuration secrets ─────────────────────────────────────────────────────
+# Populated by operators after the first deploy (SECRET_KEY etc. for the API,
+# the server-side environment key for the edge proxy).
+module "flagsmith_configuration" {
+  source          = "../../../modules/secret/"
+  name            = "flagsmith-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+}
+
+module "flagsmith_edge_configuration" {
+  source          = "../../../modules/secret/"
+  name            = "flagsmith-edge-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+}
+
+# ── CloudFront ────────────────────────────────────────────────────────────────
+# Flagsmith gets its own distributions rather than sharing the main CDN: its
+# /api/v1/* paths would otherwise collide with the tariff API cache behaviours
+# (long cache + auth lambda). Each distribution forwards the viewer Host header
+# (via forward_all_qsa/allViewer) to the ALB origin, which routes flags.* and
+# flags-edge.* to the Flagsmith HTTP target groups by host.
+module "flags_cdn" {
+  source = "../../../modules/cloudfront"
+
+  aliases         = ["flags.${var.domain_name}"]
+  create_alias    = true
+  route53_zone_id = data.aws_route53_zone.this.id
+  comment         = "Flagsmith ${title(var.environment)} CDN"
+
+  enabled         = true
+  is_ipv6_enabled = true
+  price_class     = "PriceClass_100"
+
+  web_acl_id = module.waf.web_acl_id
+
+  logging_config = {
+    bucket = module.logs.s3_bucket_bucket_domain_name
+    prefix = "cloudfront/${var.environment}"
+  }
+
+  origin = {
+    alb = {
+      domain_name = local.origin_domain_name
+      custom_origin_config = {
+        http_port              = 80
+        https_port             = 443
+        origin_protocol_policy = "https-only"
+        origin_ssl_protocols   = ["TLSv1.2"]
+        origin_read_timeout    = 60
+      }
+
+      custom_header = [{
+        name  = random_password.origin_header[0].result
+        value = random_password.origin_header[1].result
+      }]
+    }
+  }
+
+  cache_behaviors = [
+    {
+      name                       = "default"
+      target_origin_id           = "alb"
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+  ]
+
+  viewer_certificate = {
+    ssl_support_method  = "sni-only"
+    acm_certificate_arn = module.acm.validated_certificate_arn
+    depends_on = [
+      module.acm.validated_certificate_arn
+    ]
+  }
+}
+
+module "flags_edge_cdn" {
+  source = "../../../modules/cloudfront"
+
+  aliases         = ["flags-edge.${var.domain_name}"]
+  create_alias    = true
+  route53_zone_id = data.aws_route53_zone.this.id
+  comment         = "Flagsmith Edge Proxy ${title(var.environment)} CDN"
+
+  enabled         = true
+  is_ipv6_enabled = true
+  price_class     = "PriceClass_100"
+
+  web_acl_id = module.waf.web_acl_id
+
+  logging_config = {
+    bucket = module.logs.s3_bucket_bucket_domain_name
+    prefix = "cloudfront/${var.environment}"
+  }
+
+  origin = {
+    alb = {
+      domain_name = local.origin_domain_name
+      custom_origin_config = {
+        http_port              = 80
+        https_port             = 443
+        origin_protocol_policy = "https-only"
+        origin_ssl_protocols   = ["TLSv1.2"]
+        origin_read_timeout    = 60
+      }
+
+      custom_header = [{
+        name  = random_password.origin_header[0].result
+        value = random_password.origin_header[1].result
+      }]
+    }
+  }
+
+  cache_behaviors = [
+    {
+      name                       = "default"
+      target_origin_id           = "alb"
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+  ]
+
+  viewer_certificate = {
+    ssl_support_method  = "sni-only"
+    acm_certificate_arn = module.acm.validated_certificate_arn
+    depends_on = [
+      module.acm.validated_certificate_arn
+    ]
+  }
+}

--- a/environments/development/common/flagsmith.tf
+++ b/environments/development/common/flagsmith.tf
@@ -31,6 +31,8 @@ module "postgres_flagsmith" {
 
   secret_kms_key_arn = aws_kms_key.secretsmanager_kms_key.arn
 
+  performance_insights_enabled = true
+
   depends_on = [
     aws_security_group.flagsmith_rds
   ]

--- a/environments/development/common/iam-roles.tf
+++ b/environments/development/common/iam-roles.tf
@@ -222,6 +222,7 @@ resource "aws_iam_role" "ci_ecs_deployments_role" {
               "repo:trade-tariff/trade-tariff-classification-examples:*",
               "repo:trade-tariff/trade-tariff-commodi-tea:*",
               "repo:trade-tariff/trade-tariff-dev-hub:*",
+              "repo:trade-tariff/trade-tariff-flagsmith:*",
               "repo:trade-tariff/trade-tariff-frontend:*",
               "repo:trade-tariff/trade-tariff-lambdas-fpo-search:*",
               "repo:trade-tariff/trade-tariff-tools:*",

--- a/environments/production/common/alb.tf
+++ b/environments/production/common/alb.tf
@@ -56,6 +56,22 @@ module "alb" {
       priority         = 99 # Most generic rule for frontend should match last
     }
   }
+  http_services = {
+    flagsmith = {
+      hosts            = ["flags.*"]
+      healthcheck_path = "/health/"
+      container_port   = 8000
+      priority         = 30
+    }
+
+    flagsmith_edge = {
+      hosts            = ["flags-edge.*"]
+      healthcheck_path = "/proxy/health"
+      container_port   = 8000
+      priority         = 31
+    }
+  }
+
   gateway_services = {
     backend_xi = {
       paths            = ["/xi/api/*"]

--- a/environments/production/common/flagsmith.tf
+++ b/environments/production/common/flagsmith.tf
@@ -31,6 +31,8 @@ module "postgres_flagsmith" {
 
   secret_kms_key_arn = aws_kms_key.secretsmanager_kms_key.arn
 
+  performance_insights_enabled = true
+
   depends_on = [
     aws_security_group.flagsmith_rds
   ]

--- a/environments/production/common/flagsmith.tf
+++ b/environments/production/common/flagsmith.tf
@@ -1,0 +1,224 @@
+# Supporting infrastructure for self-hosted Flagsmith.
+#
+# Flagsmith itself (the API + edge-proxy ECS services) is deployed from the
+# trade-tariff-flagsmith app repo via the shared ecs-service module, exactly
+# like devhub/frontend/backend. This file only declares the shared resources
+# that app reads via data sources: a dedicated database, security groups,
+# configuration secrets, and the public-facing CloudFront distributions.
+
+# ── Database ──────────────────────────────────────────────────────────────────
+# Dedicated Postgres instance, isolated from the shared tariff cluster so
+# Flagsmith's schema and load can't affect tariff data. The rds module also
+# creates a "flagsmith-connection-string" secret the app reads as DATABASE_URL.
+module "postgres_flagsmith" {
+  source = "../../../modules/rds"
+
+  environment    = var.environment
+  name           = "Flagsmith"
+  engine         = "postgres"
+  engine_version = "18.3"
+
+  multi_az = true
+
+  instance_type           = "db.t3.small"
+  backup_window           = "22:00-23:00"
+  maintenance_window      = "Fri:23:00-Sat:01:00"
+  backup_retention_period = 7
+  private_subnet_ids      = data.terraform_remote_state.base.outputs.private_subnet_ids
+
+  allocated_storage  = 20
+  security_group_ids = [aws_security_group.flagsmith_rds.id]
+
+  secret_kms_key_arn = aws_kms_key.secretsmanager_kms_key.arn
+
+  depends_on = [
+    aws_security_group.flagsmith_rds
+  ]
+
+  tags = {
+    Name       = "FlagsmithPostgres${title(var.environment)}"
+    "RDS_Type" = "Instance"
+  }
+}
+
+# ── Security groups ───────────────────────────────────────────────────────────
+# Flagsmith's upstream image serves plain HTTP on 8000 (no in-container TLS),
+# so it gets a dedicated ECS security group rather than the shared 8443 one.
+resource "aws_security_group" "flagsmith_ecs" {
+  name        = "flagsmith-ecs-${var.environment}"
+  description = "Flagsmith ECS tasks: HTTP 8000 from the ALB, all egress."
+  vpc_id      = data.terraform_remote_state.base.outputs.vpc_id
+
+  ingress {
+    description     = "HTTP 8000 from ALB"
+    from_port       = 8000
+    to_port         = 8000
+    protocol        = "tcp"
+    security_groups = [module.alb-security-group.alb_security_group_id]
+  }
+
+  egress {
+    description = "Allow all egress (Docker Hub pulls, RDS, etc.)"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "flagsmith-ecs-${var.environment}"
+  }
+}
+
+resource "aws_security_group" "flagsmith_rds" {
+  name        = "flagsmith-rds-${var.environment}"
+  description = "Flagsmith database: PostgreSQL from Flagsmith ECS tasks only."
+  vpc_id      = data.terraform_remote_state.base.outputs.vpc_id
+
+  ingress {
+    description     = "PostgreSQL from Flagsmith ECS"
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = [aws_security_group.flagsmith_ecs.id]
+  }
+
+  tags = {
+    Name = "flagsmith-rds-${var.environment}"
+  }
+}
+
+# ── Configuration secrets ─────────────────────────────────────────────────────
+# Populated by operators after the first deploy (SECRET_KEY etc. for the API,
+# the server-side environment key for the edge proxy).
+module "flagsmith_configuration" {
+  source          = "../../../modules/secret/"
+  name            = "flagsmith-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+}
+
+module "flagsmith_edge_configuration" {
+  source          = "../../../modules/secret/"
+  name            = "flagsmith-edge-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+}
+
+# ── CloudFront ────────────────────────────────────────────────────────────────
+# Flagsmith gets its own distributions rather than sharing the main CDN: its
+# /api/v1/* paths would otherwise collide with the tariff API cache behaviours
+# (long cache + auth lambda). Each distribution forwards the viewer Host header
+# (via forward_all_qsa/allViewer) to the ALB origin, which routes flags.* and
+# flags-edge.* to the Flagsmith HTTP target groups by host.
+module "flags_cdn" {
+  source = "../../../modules/cloudfront"
+
+  aliases         = ["flags.${var.domain_name}"]
+  create_alias    = true
+  route53_zone_id = data.aws_route53_zone.this.id
+  comment         = "Flagsmith ${title(var.environment)} CDN"
+
+  enabled         = true
+  is_ipv6_enabled = true
+  price_class     = "PriceClass_100"
+
+  web_acl_id = module.waf.web_acl_id
+
+  logging_config = {
+    bucket = module.logs.s3_bucket_bucket_domain_name
+    prefix = "cloudfront/${var.environment}"
+  }
+
+  origin = {
+    alb = {
+      domain_name = local.origin_domain_name
+      custom_origin_config = {
+        http_port              = 80
+        https_port             = 443
+        origin_protocol_policy = "https-only"
+        origin_ssl_protocols   = ["TLSv1.2"]
+        origin_read_timeout    = 60
+      }
+
+      custom_header = [{
+        name  = random_password.origin_header[0].result
+        value = random_password.origin_header[1].result
+      }]
+    }
+  }
+
+  cache_behaviors = [
+    {
+      name                       = "default"
+      target_origin_id           = "alb"
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+  ]
+
+  viewer_certificate = {
+    ssl_support_method  = "sni-only"
+    acm_certificate_arn = module.acm.validated_certificate_arn
+    depends_on = [
+      module.acm.validated_certificate_arn
+    ]
+  }
+}
+
+module "flags_edge_cdn" {
+  source = "../../../modules/cloudfront"
+
+  aliases         = ["flags-edge.${var.domain_name}"]
+  create_alias    = true
+  route53_zone_id = data.aws_route53_zone.this.id
+  comment         = "Flagsmith Edge Proxy ${title(var.environment)} CDN"
+
+  enabled         = true
+  is_ipv6_enabled = true
+  price_class     = "PriceClass_100"
+
+  web_acl_id = module.waf.web_acl_id
+
+  logging_config = {
+    bucket = module.logs.s3_bucket_bucket_domain_name
+    prefix = "cloudfront/${var.environment}"
+  }
+
+  origin = {
+    alb = {
+      domain_name = local.origin_domain_name
+      custom_origin_config = {
+        http_port              = 80
+        https_port             = 443
+        origin_protocol_policy = "https-only"
+        origin_ssl_protocols   = ["TLSv1.2"]
+        origin_read_timeout    = 60
+      }
+
+      custom_header = [{
+        name  = random_password.origin_header[0].result
+        value = random_password.origin_header[1].result
+      }]
+    }
+  }
+
+  cache_behaviors = [
+    {
+      name                       = "default"
+      target_origin_id           = "alb"
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+  ]
+
+  viewer_certificate = {
+    ssl_support_method  = "sni-only"
+    acm_certificate_arn = module.acm.validated_certificate_arn
+    depends_on = [
+      module.acm.validated_certificate_arn
+    ]
+  }
+}

--- a/environments/production/common/iam-roles.tf
+++ b/environments/production/common/iam-roles.tf
@@ -288,6 +288,7 @@ resource "aws_iam_role" "ci_ecs_deployments_role" {
               "repo:trade-tariff/trade-tariff-backend:*",
               "repo:trade-tariff/trade-tariff-commodi-tea:*",
               "repo:trade-tariff/trade-tariff-dev-hub:*",
+              "repo:trade-tariff/trade-tariff-flagsmith:*",
               "repo:trade-tariff/trade-tariff-frontend:*",
             ]
           }

--- a/environments/staging/common/alb.tf
+++ b/environments/staging/common/alb.tf
@@ -59,6 +59,22 @@ module "alb" {
     }
   }
 
+  http_services = {
+    flagsmith = {
+      hosts            = ["flags.*"]
+      healthcheck_path = "/health/"
+      container_port   = 8000
+      priority         = 30
+    }
+
+    flagsmith_edge = {
+      hosts            = ["flags-edge.*"]
+      healthcheck_path = "/proxy/health"
+      container_port   = 8000
+      priority         = 31
+    }
+  }
+
   gateway_services = {
     backend_xi = {
       paths            = ["/xi/api/*"]

--- a/environments/staging/common/flagsmith.tf
+++ b/environments/staging/common/flagsmith.tf
@@ -1,0 +1,224 @@
+# Supporting infrastructure for self-hosted Flagsmith.
+#
+# Flagsmith itself (the API + edge-proxy ECS services) is deployed from the
+# trade-tariff-flagsmith app repo via the shared ecs-service module, exactly
+# like devhub/frontend/backend. This file only declares the shared resources
+# that app reads via data sources: a dedicated database, security groups,
+# configuration secrets, and the public-facing CloudFront distributions.
+
+# ── Database ──────────────────────────────────────────────────────────────────
+# Dedicated Postgres instance, isolated from the shared tariff cluster so
+# Flagsmith's schema and load can't affect tariff data. The rds module also
+# creates a "flagsmith-connection-string" secret the app reads as DATABASE_URL.
+module "postgres_flagsmith" {
+  source = "../../../modules/rds"
+
+  environment    = var.environment
+  name           = "Flagsmith"
+  engine         = "postgres"
+  engine_version = "18.3"
+
+  multi_az = false
+
+  instance_type           = "db.t3.micro"
+  backup_window           = "22:00-23:00"
+  maintenance_window      = "Fri:23:00-Sat:01:00"
+  backup_retention_period = 7
+  private_subnet_ids      = data.terraform_remote_state.base.outputs.private_subnet_ids
+
+  allocated_storage  = 20
+  security_group_ids = [aws_security_group.flagsmith_rds.id]
+
+  secret_kms_key_arn = aws_kms_key.secretsmanager_kms_key.arn
+
+  depends_on = [
+    aws_security_group.flagsmith_rds
+  ]
+
+  tags = {
+    Name       = "FlagsmithPostgres${title(var.environment)}"
+    "RDS_Type" = "Instance"
+  }
+}
+
+# ── Security groups ───────────────────────────────────────────────────────────
+# Flagsmith's upstream image serves plain HTTP on 8000 (no in-container TLS),
+# so it gets a dedicated ECS security group rather than the shared 8443 one.
+resource "aws_security_group" "flagsmith_ecs" {
+  name        = "flagsmith-ecs-${var.environment}"
+  description = "Flagsmith ECS tasks: HTTP 8000 from the ALB, all egress."
+  vpc_id      = data.terraform_remote_state.base.outputs.vpc_id
+
+  ingress {
+    description     = "HTTP 8000 from ALB"
+    from_port       = 8000
+    to_port         = 8000
+    protocol        = "tcp"
+    security_groups = [module.alb-security-group.alb_security_group_id]
+  }
+
+  egress {
+    description = "Allow all egress (Docker Hub pulls, RDS, etc.)"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "flagsmith-ecs-${var.environment}"
+  }
+}
+
+resource "aws_security_group" "flagsmith_rds" {
+  name        = "flagsmith-rds-${var.environment}"
+  description = "Flagsmith database: PostgreSQL from Flagsmith ECS tasks only."
+  vpc_id      = data.terraform_remote_state.base.outputs.vpc_id
+
+  ingress {
+    description     = "PostgreSQL from Flagsmith ECS"
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = [aws_security_group.flagsmith_ecs.id]
+  }
+
+  tags = {
+    Name = "flagsmith-rds-${var.environment}"
+  }
+}
+
+# ── Configuration secrets ─────────────────────────────────────────────────────
+# Populated by operators after the first deploy (SECRET_KEY etc. for the API,
+# the server-side environment key for the edge proxy).
+module "flagsmith_configuration" {
+  source          = "../../../modules/secret/"
+  name            = "flagsmith-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+}
+
+module "flagsmith_edge_configuration" {
+  source          = "../../../modules/secret/"
+  name            = "flagsmith-edge-configuration"
+  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window = 7
+}
+
+# ── CloudFront ────────────────────────────────────────────────────────────────
+# Flagsmith gets its own distributions rather than sharing the main CDN: its
+# /api/v1/* paths would otherwise collide with the tariff API cache behaviours
+# (long cache + auth lambda). Each distribution forwards the viewer Host header
+# (via forward_all_qsa/allViewer) to the ALB origin, which routes flags.* and
+# flags-edge.* to the Flagsmith HTTP target groups by host.
+module "flags_cdn" {
+  source = "../../../modules/cloudfront"
+
+  aliases         = ["flags.${var.domain_name}"]
+  create_alias    = true
+  route53_zone_id = data.aws_route53_zone.this.id
+  comment         = "Flagsmith ${title(var.environment)} CDN"
+
+  enabled         = true
+  is_ipv6_enabled = true
+  price_class     = "PriceClass_100"
+
+  web_acl_id = module.waf.web_acl_id
+
+  logging_config = {
+    bucket = module.logs.s3_bucket_bucket_domain_name
+    prefix = "cloudfront/${var.environment}"
+  }
+
+  origin = {
+    alb = {
+      domain_name = local.origin_domain_name
+      custom_origin_config = {
+        http_port              = 80
+        https_port             = 443
+        origin_protocol_policy = "https-only"
+        origin_ssl_protocols   = ["TLSv1.2"]
+        origin_read_timeout    = 60
+      }
+
+      custom_header = [{
+        name  = random_password.origin_header[0].result
+        value = random_password.origin_header[1].result
+      }]
+    }
+  }
+
+  cache_behaviors = [
+    {
+      name                       = "default"
+      target_origin_id           = "alb"
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+  ]
+
+  viewer_certificate = {
+    ssl_support_method  = "sni-only"
+    acm_certificate_arn = module.acm.validated_certificate_arn
+    depends_on = [
+      module.acm.validated_certificate_arn
+    ]
+  }
+}
+
+module "flags_edge_cdn" {
+  source = "../../../modules/cloudfront"
+
+  aliases         = ["flags-edge.${var.domain_name}"]
+  create_alias    = true
+  route53_zone_id = data.aws_route53_zone.this.id
+  comment         = "Flagsmith Edge Proxy ${title(var.environment)} CDN"
+
+  enabled         = true
+  is_ipv6_enabled = true
+  price_class     = "PriceClass_100"
+
+  web_acl_id = module.waf.web_acl_id
+
+  logging_config = {
+    bucket = module.logs.s3_bucket_bucket_domain_name
+    prefix = "cloudfront/${var.environment}"
+  }
+
+  origin = {
+    alb = {
+      domain_name = local.origin_domain_name
+      custom_origin_config = {
+        http_port              = 80
+        https_port             = 443
+        origin_protocol_policy = "https-only"
+        origin_ssl_protocols   = ["TLSv1.2"]
+        origin_read_timeout    = 60
+      }
+
+      custom_header = [{
+        name  = random_password.origin_header[0].result
+        value = random_password.origin_header[1].result
+      }]
+    }
+  }
+
+  cache_behaviors = [
+    {
+      name                       = "default"
+      target_origin_id           = "alb"
+      cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+    }
+  ]
+
+  viewer_certificate = {
+    ssl_support_method  = "sni-only"
+    acm_certificate_arn = module.acm.validated_certificate_arn
+    depends_on = [
+      module.acm.validated_certificate_arn
+    ]
+  }
+}

--- a/environments/staging/common/flagsmith.tf
+++ b/environments/staging/common/flagsmith.tf
@@ -31,6 +31,8 @@ module "postgres_flagsmith" {
 
   secret_kms_key_arn = aws_kms_key.secretsmanager_kms_key.arn
 
+  performance_insights_enabled = true
+
   depends_on = [
     aws_security_group.flagsmith_rds
   ]

--- a/environments/staging/common/iam-roles.tf
+++ b/environments/staging/common/iam-roles.tf
@@ -218,6 +218,7 @@ resource "aws_iam_role" "ci_ecs_deployments_role" {
               "repo:trade-tariff/trade-tariff-backend:*",
               "repo:trade-tariff/trade-tariff-commodi-tea:*",
               "repo:trade-tariff/trade-tariff-dev-hub:*",
+              "repo:trade-tariff/trade-tariff-flagsmith:*",
               "repo:trade-tariff/trade-tariff-frontend:*",
               "repo:trade-tariff/trade-tariff-tools:*",
             ]

--- a/modules/application-load-balancer/README.md
+++ b/modules/application-load-balancer/README.md
@@ -48,8 +48,10 @@ No modules.
 | [aws_lb.application_load_balancer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
 | [aws_lb_listener.redirect_http](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
 | [aws_lb_listener.trade_tariff_listeners](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
+| [aws_lb_listener_rule.http_services](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener_rule) | resource |
 | [aws_lb_listener_rule.redirect_http_rules](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener_rule) | resource |
 | [aws_lb_listener_rule.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener_rule) | resource |
+| [aws_lb_target_group.http_target_groups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
 | [aws_lb_target_group.trade_tariff_https_target_groups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
 | [aws_s3_bucket.access_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_lifecycle_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
@@ -74,6 +76,7 @@ No modules.
 | <a name="input_enable_deletion_protection"></a> [enable\_deletion\_protection](#input\_enable\_deletion\_protection) | If true, deletion of the load balancer will be disabled via the AWS API. | `bool` | `true` | no |
 | <a name="input_enable_http2"></a> [enable\_http2](#input\_enable\_http2) | Indicates whether HTTP/2 is enabled in application load balancers | `bool` | `true` | no |
 | <a name="input_gateway_services"></a> [gateway\_services](#input\_gateway\_services) | Map of services to make ALB target groups and listener rules for routable from API Gateway. | <pre>map(<br/>    object({<br/>      healthcheck_path = string<br/>      hosts            = optional(list(string))<br/>      paths            = optional(list(string))<br/>      priority         = number<br/>    })<br/>  )</pre> | `{}` | no |
+| <a name="input_http_services"></a> [http\_services](#input\_http\_services) | Map of services whose containers serve plain HTTP (not the in-container TLS<br/>on 8443 that `services` assumes). Used for upstream images that don't<br/>terminate TLS themselves (e.g. self-hosted Flagsmith). The ALB still<br/>listens on HTTPS:443 and terminates TLS; it forwards to an HTTP target<br/>group on `container_port`. | <pre>map(<br/>    object({<br/>      healthcheck_path = string<br/>      container_port   = optional(number, 8000)<br/>      hosts            = optional(list(string))<br/>      paths            = optional(list(string))<br/>      priority         = number<br/>    })<br/>  )</pre> | `{}` | no |
 | <a name="input_idle_timeout"></a> [idle\_timeout](#input\_idle\_timeout) | The time in seconds that the connection is allowed to be idle. | `string` | `60` | no |
 | <a name="input_listening_port"></a> [listening\_port](#input\_listening\_port) | Port on which the load balancer listens to. | `string` | `443` | no |
 | <a name="input_public_subnet_ids"></a> [public\_subnet\_ids](#input\_public\_subnet\_ids) | Public subnet IDs | `list(any)` | n/a | yes |
@@ -88,6 +91,7 @@ No modules.
 | <a name="output_arn_suffix"></a> [arn\_suffix](#output\_arn\_suffix) | arn\_suffix of the load balancer. |
 | <a name="output_dns_name"></a> [dns\_name](#output\_dns\_name) | DNS name of the load balancer. |
 | <a name="output_http_listener_arn"></a> [http\_listener\_arn](#output\_http\_listener\_arn) | n/a |
+| <a name="output_http_target_groups"></a> [http\_target\_groups](#output\_http\_target\_groups) | Map of HTTP target groups. |
 | <a name="output_https_listener_arn"></a> [https\_listener\_arn](#output\_https\_listener\_arn) | n/a |
 | <a name="output_lb_arn"></a> [lb\_arn](#output\_lb\_arn) | The ARN of the application load balancer. |
 | <a name="output_lb_dns_name"></a> [lb\_dns\_name](#output\_lb\_dns\_name) | The DNS name of the load balancer. |

--- a/modules/application-load-balancer/main.tf
+++ b/modules/application-load-balancer/main.tf
@@ -147,6 +147,68 @@ resource "aws_lb_listener_rule" "this" {
   }
 }
 
+# HTTP target groups — for services whose containers serve plain HTTP.
+# The ALB terminates TLS on the HTTPS listener and forwards here over HTTP.
+resource "aws_lb_target_group" "http_target_groups" {
+  for_each = var.http_services
+
+  name                 = "${replace(each.key, "_", "-")}-http"
+  port                 = each.value.container_port
+  protocol             = "HTTP"
+  target_type          = "ip"
+  vpc_id               = var.vpc_id
+  deregistration_delay = 20
+
+  health_check {
+    enabled             = true
+    interval            = 30
+    path                = each.value.healthcheck_path
+    port                = "traffic-port"
+    healthy_threshold   = 2
+    unhealthy_threshold = 3
+    timeout             = 6
+    protocol            = "HTTP"
+    matcher             = "200"
+  }
+}
+
+resource "aws_lb_listener_rule" "http_services" {
+  for_each     = var.http_services
+  listener_arn = aws_lb_listener.trade_tariff_listeners.arn
+
+  priority = each.value.priority
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.http_target_groups[each.key].arn
+  }
+
+  dynamic "condition" {
+    for_each = lookup(var.http_services[each.key], "hosts", null) != null ? [true] : []
+    content {
+      host_header {
+        values = each.value.hosts
+      }
+    }
+  }
+
+  dynamic "condition" {
+    for_each = lookup(var.http_services[each.key], "paths", null) != null ? [true] : []
+    content {
+      path_pattern {
+        values = each.value.paths
+      }
+    }
+  }
+
+  condition {
+    http_header {
+      http_header_name = var.custom_header.name
+      values           = [var.custom_header.value]
+    }
+  }
+}
+
 resource "aws_s3_bucket" "access_logs" {
   count  = var.enable_access_logs && var.access_logs_bucket == null ? 1 : 0
   bucket = "${var.alb_name}-access-logs-${local.account_id}"

--- a/modules/application-load-balancer/outputs.tf
+++ b/modules/application-load-balancer/outputs.tf
@@ -25,6 +25,18 @@ output "target_groups" {
   }
 }
 
+output "http_target_groups" {
+  description = "Map of HTTP target groups."
+  value = {
+    for tg in aws_lb_target_group.http_target_groups :
+    tg.name => {
+      name       = tg.name,
+      arn        = tg.arn
+      arn_suffix = tg.arn_suffix
+    }
+  }
+}
+
 output "lb_arn" {
   description = "The ARN of the application load balancer."
   value       = aws_lb.application_load_balancer.arn

--- a/modules/application-load-balancer/variables.tf
+++ b/modules/application-load-balancer/variables.tf
@@ -73,6 +73,26 @@ variable "services" {
   )
 }
 
+variable "http_services" {
+  description = <<-EOT
+    Map of services whose containers serve plain HTTP (not the in-container TLS
+    on 8443 that `services` assumes). Used for upstream images that don't
+    terminate TLS themselves (e.g. self-hosted Flagsmith). The ALB still
+    listens on HTTPS:443 and terminates TLS; it forwards to an HTTP target
+    group on `container_port`.
+  EOT
+  type = map(
+    object({
+      healthcheck_path = string
+      container_port   = optional(number, 8000)
+      hosts            = optional(list(string))
+      paths            = optional(list(string))
+      priority         = number
+    })
+  )
+  default = {}
+}
+
 variable "gateway_services" {
   description = "Map of services to make ALB target groups and listener rules for routable from API Gateway."
   type = map(


### PR DESCRIPTION
# Jira link

_TODO: add Jira link_

## What?

I have:

- **Restructured this PR per review feedback.** Flagsmith is now treated as "just another Django app" and follows the **devhub pattern** exactly — supporting infra in the `common` stacks here, the running services in a separate app repo.
- Added, per environment, `common/flagsmith.tf`:
  - A **dedicated Postgres RDS instance** (isolated from the shared tariff cluster). The `rds` module also creates the `flagsmith-connection-string` secret the app reads as `DATABASE_URL`.
  - `flagsmith-configuration` / `flagsmith-edge-configuration` secrets for operators to populate.
  - Dedicated **ECS + RDS security groups** (Flagsmith serves plain HTTP on 8000).
  - Two **CloudFront distributions** (`flags.` and `flags-edge.`).
- Added an `http_services` block to each `common/alb.tf` registering `flags.*` / `flags-edge.*` HTTP target groups.
- Added an `http_services` variable to the **`application-load-balancer` module** that creates HTTP target groups + listener rules (the ALB still terminates TLS on the HTTPS listener and forwards to the container over HTTP).
- Removed the standalone per-environment Flagsmith terragrunt root from the earlier revision.

The running ECS services (API + edge proxy) live in a **new `trade-tariff-flagsmith` app repo** (scaffolded separately), which calls the shared `aws/ecs-service` module and reads the resources above via data sources.

## Why?

I am doing this because:

- The reviewer rightly flagged that a standalone Flagsmith terragrunt root was a **new pattern**. devhub is the precedent: its dedicated RDS + secrets live in `common/`, and the app deploys from its own repo.
- Splitting **supporting infra (this repo, aws `>= 6`)** from the **service deployment (app repo, aws `~> 5`)** also dissolves the provider-version conflict that previously forced raw ECS resources — the `ecs-service` module pins aws `~> 5` and can't coexist with this repo's local modules in one root.
- A **dedicated RDS instance** keeps Flagsmith's schema/load off the shared tariff cluster.
- **Dedicated CloudFront distributions** (not the main CDN) are required because Flagsmith's `/api/v1/*` paths would otherwise collide with the tariff API cache behaviours (long cache + auth lambda).

## Answering the review questions

> Can we make a module for it (in our modules repo)?

No bespoke module needed — Flagsmith reuses the existing `aws/ecs-service` module like every other app. A custom wrapper would add maintenance surface for no gain.

> Should that module be called via a new repo (like the other ecs services)?

Yes — that's exactly the new `trade-tariff-flagsmith` repo.

> Not sure about it having its own terraform root (new pattern)

Agreed and removed. Supporting infra now lives in `common/`, matching devhub.

## Notes for reviewers

- **TLS:** Flagsmith's upstream image serves plain HTTP:8000 and doesn't do the in-container TLS-on-8443 our own images use, hence the new HTTP target group support on the ALB.
- **Images:** the app repo pulls `flagsmith/flagsmith` + `flagsmith/edge-proxy` straight from Docker Hub (no ECR mirror) — see that repo's README for the CI implication.
- The companion app repo + post-deploy operator steps (SECRET_KEY, first admin user, edge proxy key) are documented in `trade-tariff-flagsmith`.

## TODO

- [ ] Add Jira link (above)
- [ ] Merge + **apply this PR before** the app repo (trade-tariff/trade-tariff-flagsmith#1) — that repo reads these target groups, secrets and security group by name
- [ ] Grant `PRIVATE_SSH_KEY` to the new repo (add `trade-tariff-flagsmith` to the org secret's selected repos, or set it as a repo secret) — needed for its deploy workflows' `terraform init` over SSH
- [ ] Pin `flagsmith_tag` / `edge_proxy_tag` off `latest` in the app repo's `config_production.tfvars` before the prod deploy
- [ ] Post-deploy (per environment): populate `flagsmith-configuration` with `SECRET_KEY`, create the first admin user, then populate `flagsmith-edge-configuration` with the server-side environment key
