### PR TITLE
BAU: Fix rule priority for flags.* hosts in ALB

### DIFF
--- a/environments/development/common/alb.tf
+++ b/environments/development/common/alb.tf
@@ -73,14 +73,14 @@ module "alb" {
       hosts            = ["flags.*"]
       healthcheck_path = "/health/"
       container_port   = 8000
-      priority         = 30
+      priority         = 21
     }
 
     flagsmith_edge = {
       hosts            = ["flags-edge.*"]
       healthcheck_path = "/proxy/health"
       container_port   = 8000
-      priority         = 31
+      priority         = 22
     }
   }
 

--- a/environments/production/common/alb.tf
+++ b/environments/production/common/alb.tf
@@ -61,14 +61,14 @@ module "alb" {
       hosts            = ["flags.*"]
       healthcheck_path = "/health/"
       container_port   = 8000
-      priority         = 30
+      priority         = 21
     }
 
     flagsmith_edge = {
       hosts            = ["flags-edge.*"]
       healthcheck_path = "/proxy/health"
       container_port   = 8000
-      priority         = 31
+      priority         = 22
     }
   }
 

--- a/environments/staging/common/alb.tf
+++ b/environments/staging/common/alb.tf
@@ -64,14 +64,14 @@ module "alb" {
       hosts            = ["flags.*"]
       healthcheck_path = "/health/"
       container_port   = 8000
-      priority         = 30
+      priority         = 21
     }
 
     flagsmith_edge = {
       hosts            = ["flags-edge.*"]
       healthcheck_path = "/proxy/health"
       container_port   = 8000
-      priority         = 31
+      priority         = 22
     }
   }
 


### PR DESCRIPTION
# Jira link

## What?

I have:

- Added higher priority rules to match flags.* subdomains to the backend-flags target-group in development
- Added higher priority rules to match flags.* subdomains to the backend-flags target-group in staging
- Added higher priority rules to match flags.* subdomains to the backend-flags target-group in production

## Why?

I am doing this because:

- flags use `/api/v1` paths which matched a higher priority rule to the backend-uk target-group
- this change means we match flags.* first as per the other subdomain-based target-group rule sets

