### PR TITLE
HMRC-2156: Bump opensearch engine version

### DIFF
--- a/environments/development/common/opensearch.tf
+++ b/environments/development/common/opensearch.tf
@@ -63,7 +63,7 @@ module "opensearch" {
 
   cluster_name    = "tariff-search-${var.environment}"
   cluster_domain  = var.domain_name
-  cluster_version = "2.3"
+  cluster_version = "2.19" # Upgrade to 3.5 with the next PR
 
   master_instance_enabled = false
   warm_instance_enabled   = false

--- a/environments/production/common/opensearch.tf
+++ b/environments/production/common/opensearch.tf
@@ -63,7 +63,7 @@ module "opensearch" {
 
   cluster_name    = "tariff-search-${var.environment}"
   cluster_domain  = var.domain_name
-  cluster_version = "2.3"
+  cluster_version = "2.19" # Upgrade to 3.5 with the next PR
 
   master_instance_enabled = false
   warm_instance_enabled   = false

--- a/environments/staging/common/opensearch.tf
+++ b/environments/staging/common/opensearch.tf
@@ -63,7 +63,7 @@ module "opensearch" {
 
   cluster_name    = "tariff-search-${var.environment}"
   cluster_domain  = var.domain_name
-  cluster_version = "2.3"
+  cluster_version = "2.19" # Upgrade to 3.5 with the next PR
 
   master_instance_enabled = false
   warm_instance_enabled   = false


### PR DESCRIPTION
# Jira link
[HMRC-2156](https://transformuk.atlassian.net/browse/HMRC-2156)

## What?

I have:

- Upgraded OpenSearch engine from v2.3 → v2.19 as an intermediate step toward v3.5

## Why?

- OpenSearch recommends upgrading to v2.19 before moving to any 3.x version
- This staged approach reduces upgrade risk and ensures compatibility with breaking changes introduced in 3.x

Notes

This is a non-final upgrade step; a follow-up PR will upgrade the cluster to v3.5
No functional changes are expected at this stage aside from engine version improvements
