### PR TITLE
HMRC-2354: Upgrade ElastiCache engine version

### DIFF
--- a/environments/development/common/redis.tf
+++ b/environments/development/common/redis.tf
@@ -21,6 +21,10 @@ resource "aws_elasticache_parameter_group" "sidekiq" {
     name  = "maxmemory-policy"
     value = "noeviction"
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 # Authenticated, encrypted clusters

--- a/environments/development/common/redis.tf
+++ b/environments/development/common/redis.tf
@@ -14,8 +14,8 @@ resource "aws_elasticache_subnet_group" "this" {
 }
 
 resource "aws_elasticache_parameter_group" "sidekiq" {
-  name   = "valkey8-noeviction"
-  family = "valkey8"
+  name   = "valkey9-noeviction"
+  family = "valkey9"
 
   parameter {
     name  = "maxmemory-policy"
@@ -29,11 +29,11 @@ module "valkey" {
   for_each = local.valkey
 
   engine         = "valkey"
-  engine_version = "8.2"
+  engine_version = "9.0"
 
   replication_group_id        = "valkey-${each.key}-${var.environment}"
   description                 = "valkey-${each.key}-${var.environment}"
-  parameter_group_name        = strcontains(each.key, "sidekiq") ? aws_elasticache_parameter_group.sidekiq.name : "default.valkey8"
+  parameter_group_name        = strcontains(each.key, "sidekiq") ? aws_elasticache_parameter_group.sidekiq.name : "default.valkey9"
   num_node_groups             = 1
   replicas_per_node_group     = 2
   node_type                   = each.value

--- a/environments/production/common/redis.tf
+++ b/environments/production/common/redis.tf
@@ -21,6 +21,10 @@ resource "aws_elasticache_parameter_group" "sidekiq" {
     name  = "maxmemory-policy"
     value = "noeviction"
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 # Authenticated, encrypted clusters

--- a/environments/production/common/redis.tf
+++ b/environments/production/common/redis.tf
@@ -14,8 +14,8 @@ resource "aws_elasticache_subnet_group" "this" {
 }
 
 resource "aws_elasticache_parameter_group" "sidekiq" {
-  name   = "valkey8-noeviction"
-  family = "valkey8"
+  name   = "valkey9-noeviction"
+  family = "valkey9"
 
   parameter {
     name  = "maxmemory-policy"
@@ -29,11 +29,11 @@ module "valkey" {
   for_each = local.valkey
 
   engine         = "valkey"
-  engine_version = "8.2"
+  engine_version = "9.0"
 
   replication_group_id        = "valkey-${each.key}-${var.environment}"
   description                 = "valkey-${each.key}-${var.environment}"
-  parameter_group_name        = strcontains(each.key, "sidekiq") ? aws_elasticache_parameter_group.sidekiq.name : "default.valkey8"
+  parameter_group_name        = strcontains(each.key, "sidekiq") ? aws_elasticache_parameter_group.sidekiq.name : "default.valkey9"
   num_node_groups             = 1
   replicas_per_node_group     = 2
   node_type                   = each.value

--- a/environments/staging/common/redis.tf
+++ b/environments/staging/common/redis.tf
@@ -21,6 +21,10 @@ resource "aws_elasticache_parameter_group" "sidekiq" {
     name  = "maxmemory-policy"
     value = "noeviction"
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 # Authenticated, encrypted clusters

--- a/environments/staging/common/redis.tf
+++ b/environments/staging/common/redis.tf
@@ -14,8 +14,8 @@ resource "aws_elasticache_subnet_group" "this" {
 }
 
 resource "aws_elasticache_parameter_group" "sidekiq" {
-  name   = "valkey8-noeviction"
-  family = "valkey8"
+  name   = "valkey9-noeviction"
+  family = "valkey9"
 
   parameter {
     name  = "maxmemory-policy"
@@ -29,11 +29,11 @@ module "valkey" {
   for_each = local.valkey
 
   engine         = "valkey"
-  engine_version = "8.2"
+  engine_version = "9.0"
 
   replication_group_id        = "valkey-${each.key}-${var.environment}"
   description                 = "valkey-${each.key}-${var.environment}"
-  parameter_group_name        = strcontains(each.key, "sidekiq") ? aws_elasticache_parameter_group.sidekiq.name : "default.valkey8"
+  parameter_group_name        = strcontains(each.key, "sidekiq") ? aws_elasticache_parameter_group.sidekiq.name : "default.valkey9"
   num_node_groups             = 1
   replicas_per_node_group     = 2
   node_type                   = each.value


### PR DESCRIPTION
# Jira link
[HMRC-2354](https://transformuk.atlassian.net/browse/HMRC-2354)

## What?

I have:

- Upgraded ElastiCache engine version from 8.2 → 9.0 

## Why?

I am doing this because:

https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/engine-versions.html