### PR TITLE
HMRC-2156: Upgrade OpenSerach from 2.19 to 3.5

### DIFF
--- a/environments/development/common/opensearch.tf
+++ b/environments/development/common/opensearch.tf
@@ -63,7 +63,7 @@ module "opensearch" {
 
   cluster_name    = "tariff-search-${var.environment}"
   cluster_domain  = var.domain_name
-  cluster_version = "2.19" # Upgrade to 3.5 with the next PR
+  cluster_version = "3.5"
 
   master_instance_enabled = false
   warm_instance_enabled   = false

--- a/environments/production/common/opensearch.tf
+++ b/environments/production/common/opensearch.tf
@@ -63,7 +63,7 @@ module "opensearch" {
 
   cluster_name    = "tariff-search-${var.environment}"
   cluster_domain  = var.domain_name
-  cluster_version = "2.19" # Upgrade to 3.5 with the next PR
+  cluster_version = "3.5"
 
   master_instance_enabled = false
   warm_instance_enabled   = false

--- a/environments/staging/common/opensearch.tf
+++ b/environments/staging/common/opensearch.tf
@@ -63,7 +63,7 @@ module "opensearch" {
 
   cluster_name    = "tariff-search-${var.environment}"
   cluster_domain  = var.domain_name
-  cluster_version = "2.19" # Upgrade to 3.5 with the next PR
+  cluster_version = "3.5"
 
   master_instance_enabled = false
   warm_instance_enabled   = false


### PR DESCRIPTION
### Jira link
[HMRC-2156](https://transformuk.atlassian.net/browse/HMRC-2156)

### What?
I have:

- Upgraded OpenSearch engine from v2.19 → v3.5

### Why?
- This is the latest available version

Note:
Make sure to deploy the previous changes (Upgrade to version 2.19) to prod before merging these changes to main
