### PR TITLE
Allow stale workflow to delete branches

### DIFF
--- a/.github/workflows/close-stale-pull-requests.yml
+++ b/.github/workflows/close-stale-pull-requests.yml
@@ -23,7 +23,7 @@ on:
           - 'false'
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
### Jira link

No ticket/issue.

### What?

- [x] Grant `contents: write` to the close stale pull requests workflow.

### Why?

The reusable stale pull request workflow now deletes stale branches as well as closing stale pull requests. GitHub only lets a reusable workflow use permissions passed by the caller, so callers with `contents: read` fail at workflow startup before any job is created.

### Risk

**Risk level:** 🟢

**Reason for rating:** CI workflow permission-only change for a scheduled maintenance workflow. The permission is required by the reusable workflow contract and is limited to repository contents plus existing pull request write access.
