### PR TITLE
Add risk label workflow

### DIFF
--- a/.github/workflows/risk-label.yml
+++ b/.github/workflows/risk-label.yml
@@ -1,0 +1,12 @@
+name: "Risk Label"
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize]
+
+jobs:
+  risk-label:
+    uses: trade-tariff/trade-tariff-tools/.github/workflows/risk-label-reusable.yml@main
+    permissions:
+      contents: read
+      pull-requests: write


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/risk-label.yml` using the shared `risk-label-reusable.yml` from `trade-tariff-tools`
- Brings this repo in line with other platform repos (e.g. backend) that already use this workflow
- PRs will now be automatically checked for a risk label (low-risk / medium-risk / high-risk) on open, edit, and sync

## Risk

low-risk — additive CI config with safe defaults, no code or infrastructure changes.

## Test plan

- [ ] Verify the workflow triggers on a test PR after merge