### PR TITLE
Force delete development secrets

### DIFF
--- a/environments/development/common/flagsmith.tf
+++ b/environments/development/common/flagsmith.tf
@@ -29,7 +29,8 @@ module "postgres_flagsmith" {
   allocated_storage  = 20
   security_group_ids = [aws_security_group.flagsmith_rds.id]
 
-  secret_kms_key_arn = aws_kms_key.secretsmanager_kms_key.arn
+  secret_kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  secret_recovery_window = local.development_secret_recovery_window
 
   performance_insights_enabled = true
 
@@ -97,14 +98,14 @@ module "flagsmith_configuration" {
   source          = "../../../modules/secret/"
   name            = "flagsmith-configuration"
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window = 7
+  recovery_window = local.development_secret_recovery_window
 }
 
 module "flagsmith_edge_configuration" {
   source          = "../../../modules/secret/"
   name            = "flagsmith-edge-configuration"
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window = 7
+  recovery_window = local.development_secret_recovery_window
 }
 
 # ── CloudFront ────────────────────────────────────────────────────────────────

--- a/environments/development/common/locals.tf
+++ b/environments/development/common/locals.tf
@@ -2,6 +2,8 @@ locals {
   account_id         = data.aws_caller_identity.current.account_id
   origin_domain_name = "origin.${var.domain_name}"
 
+  development_secret_recovery_window = 0
+
   cloudfront_auth = templatefile(
     "../../../modules/cloudfront-auth.js.tpl",
     { base64 = data.aws_secretsmanager_secret_version.backups_basic_auth.secret_string }

--- a/environments/development/common/rds.tf
+++ b/environments/development/common/rds.tf
@@ -105,7 +105,8 @@ module "postgres_developer_hub" {
   allocated_storage  = 10
   security_group_ids = [module.alb-security-group.be_to_rds_security_group_id]
 
-  secret_kms_key_arn = aws_kms_key.secretsmanager_kms_key.arn
+  secret_kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
+  secret_recovery_window = local.development_secret_recovery_window
 
   depends_on = [
     module.alb-security-group
@@ -151,7 +152,7 @@ module "rw_aurora_connection_string" {
   source          = "../../../modules/secret/"
   name            = "aurora-postgres-rw-connection-string"
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window = 7
+  recovery_window = local.development_secret_recovery_window
   secret_string   = module.postgres_aurora.rw_connection_string
 }
 
@@ -159,7 +160,7 @@ module "ro_aurora_connection_string" {
   source          = "../../../modules/secret/"
   name            = "aurora-postgres-ro-connection-string"
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window = 7
+  recovery_window = local.development_secret_recovery_window
   secret_string   = module.postgres_aurora.ro_connection_string
 }
 
@@ -196,7 +197,7 @@ module "admin_connection_string" {
   source          = "../../../modules/secret/"
   name            = "admin-connection-string"
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window = 7
+  recovery_window = local.development_secret_recovery_window
   secret_string   = module.postgres_admin_aurora.rw_connection_string
 }
 

--- a/environments/development/common/redis.tf
+++ b/environments/development/common/redis.tf
@@ -68,9 +68,10 @@ resource "random_password" "valkey_auth" {
 }
 
 resource "aws_secretsmanager_secret" "valkey_connection_string" {
-  for_each   = local.valkey
-  name       = "valkey-${each.key}-connection-string"
-  kms_key_id = aws_kms_key.secretsmanager_kms_key.arn
+  for_each                = local.valkey
+  name                    = "valkey-${each.key}-connection-string"
+  kms_key_id              = aws_kms_key.secretsmanager_kms_key.arn
+  recovery_window_in_days = local.development_secret_recovery_window
 }
 
 resource "aws_secretsmanager_secret_version" "valkey_connection_string_value" {

--- a/environments/development/common/secrets.tf
+++ b/environments/development/common/secrets.tf
@@ -2,70 +2,70 @@ module "admin_configuration" {
   source          = "../../../modules/secret/"
   name            = "admin-configuration"
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window = 7
+  recovery_window = local.development_secret_recovery_window
 }
 
 module "dev_hub_configuration" {
   source          = "../../../modules/secret/"
   name            = "dev-hub-configuration"
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window = 7
+  recovery_window = local.development_secret_recovery_window
 }
 
 module "dev_hub_job_configuration" {
   source          = "../../../modules/secret/"
   name            = "dev-hub-job-configuration"
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window = 7
+  recovery_window = local.development_secret_recovery_window
 }
 
 module "frontend_configuration" {
   source          = "../../../modules/secret/"
   name            = "frontend-configuration"
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window = 7
+  recovery_window = local.development_secret_recovery_window
 }
 
 module "mcp_configuration" {
   source          = "../../../modules/secret/"
   name            = "mcp-configuration"
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window = 7
+  recovery_window = local.development_secret_recovery_window
 }
 
 module "backend_uk_worker_configuration" {
   source          = "../../../modules/secret/"
   name            = "backend-uk-worker-configuration"
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window = 7
+  recovery_window = local.development_secret_recovery_window
 }
 
 module "backend_xi_worker_configuration" {
   source          = "../../../modules/secret/"
   name            = "backend-xi-worker-configuration"
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window = 7
+  recovery_window = local.development_secret_recovery_window
 }
 
 module "backend_uk_api_configuration" {
   source          = "../../../modules/secret/"
   name            = "backend-uk-api-configuration"
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window = 7
+  recovery_window = local.development_secret_recovery_window
 }
 
 module "backend_xi_api_configuration" {
   source          = "../../../modules/secret/"
   name            = "backend-xi-api-configuration"
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window = 7
+  recovery_window = local.development_secret_recovery_window
 }
 
 module "backend_job_configuration" {
   source          = "../../../modules/secret/"
   name            = "backend-job-configuration"
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window = 7
+  recovery_window = local.development_secret_recovery_window
 }
 
 # TODO: Remove me once migrated to consistent naming above
@@ -73,42 +73,42 @@ module "db_replicate_configuration" {
   source          = "../../../modules/secret/"
   name            = "db-replicate-configuration"
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window = 7
+  recovery_window = local.development_secret_recovery_window
 }
 
 module "identity_configuration" {
   source          = "../../../modules/secret/"
   name            = "identity-configuration"
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window = 7
+  recovery_window = local.development_secret_recovery_window
 }
 
 module "fpo_search_training_pem" {
   source          = "../../../modules/secret/"
   name            = "fpo-search-training-pem"
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window = 7
+  recovery_window = local.development_secret_recovery_window
 }
 
 module "fpo_search_configuration" {
   source          = "../../../modules/secret/"
   name            = "fpo-search-configuration"
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window = 7
+  recovery_window = local.development_secret_recovery_window
 }
 
 module "examples_configuration" {
   source          = "../../../modules/secret/"
   name            = "examples-configuration"
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window = 7
+  recovery_window = local.development_secret_recovery_window
 }
 
 module "identity_create_auth_challenge_configuration" {
   source          = "../../../modules/secret/"
   name            = "identity-create-auth-challenge-configuration"
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window = 7
+  recovery_window = local.development_secret_recovery_window
 }
 
 # Other non-configuration secrets
@@ -117,28 +117,28 @@ module "slack_notify_lambda_slack_webhook_url" {
   source          = "../../../modules/secret/"
   name            = "slack-notify-lambda-slack-webhook-url"
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window = 7
+  recovery_window = local.development_secret_recovery_window
 }
 
 module "backups_basic_auth" {
   source          = "../../../modules/secret/"
   name            = "backups-basic-auth"
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window = 7
+  recovery_window = local.development_secret_recovery_window
 }
 
 module "apigw_internal_test_key" {
   source          = "../../../modules/secret/"
   name            = "apigw-${var.environment}-internal-test-api-key"
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window = 7
+  recovery_window = local.development_secret_recovery_window
 }
 
 module "ecs_tls_certificate" {
   source          = "../../../modules/secret/"
   name            = "ecs-tls-certificate"
   kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window = 7
+  recovery_window = local.development_secret_recovery_window
 
   secret_string = jsonencode({
     private_key = tls_private_key.ecs_tls.private_key_pem

--- a/modules/rds/README.md
+++ b/modules/rds/README.md
@@ -59,6 +59,7 @@ No modules.
 | <a name="input_performance_insights_retention_period"></a> [performance\_insights\_retention\_period](#input\_performance\_insights\_retention\_period) | Amount of time, in days, (minimum 7, maximum 731, or any multiple of 31) to retain performance insights data. | `number` | `31` | no |
 | <a name="input_private_subnet_ids"></a> [private\_subnet\_ids](#input\_private\_subnet\_ids) | A list of private subnet IDs | `list(string)` | n/a | yes |
 | <a name="input_secret_kms_key_arn"></a> [secret\_kms\_key\_arn](#input\_secret\_kms\_key\_arn) | ARN of the KMS Key to use to encrypt the connection string secret. | `string` | n/a | yes |
+| <a name="input_secret_recovery_window"></a> [secret\_recovery\_window](#input\_secret\_recovery\_window) | Recovery window in days for the connection string secret. | `number` | `7` | no |
 | <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | A list of security group IDs to associate with this RDS instance. | `list(string)` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Map of tags to apply to all taggable resources. | `map(string)` | `{}` | no |
 

--- a/modules/rds/data.tf
+++ b/modules/rds/data.tf
@@ -24,7 +24,7 @@ resource "random_string" "private_subnet_suffix" {
 resource "aws_secretsmanager_secret" "this" {
   name                    = "${lower(var.name)}-connection-string"
   kms_key_id              = var.secret_kms_key_arn
-  recovery_window_in_days = 7
+  recovery_window_in_days = var.secret_recovery_window
 }
 
 resource "aws_secretsmanager_secret_version" "this" {

--- a/modules/rds/variables.tf
+++ b/modules/rds/variables.tf
@@ -97,6 +97,12 @@ variable "secret_kms_key_arn" {
   type        = string
 }
 
+variable "secret_recovery_window" {
+  description = "Recovery window in days for the connection string secret."
+  type        = number
+  default     = 7
+}
+
 variable "multi_az" {
   description = "If the RDS instance is multi-AZ."
   type        = bool


### PR DESCRIPTION
## What?

- Set development Secrets Manager resources to use a zero-day recovery window.
- Add a defaulted `secret_recovery_window` input to the RDS module so development can opt into force deletion while other environments keep the 7-day default.
- Regenerate the RDS module README for the new input.

## Why?

PR #629 failed in the development apply because `mcp-configuration` was still scheduled for deletion, so Secrets Manager rejected recreating a secret with the same name. Development is disposable enough to force-delete these secrets and avoid retry overhead; staging and production remain gated by their existing recovery windows.

## Risk

**Risk level:** 🟢 `low-risk`

**Reason for rating:** The force-delete behaviour is explicitly gated to development Secrets Manager resources. Staging and production retain their existing 7-day recovery windows, so this only affects disposable development infrastructure and removes retry overhead when development applies are rerun.

Related: #629