### PR TITLE
Route mcp.* through CloudFront instead of directly to ALB

### DIFF
--- a/environments/development/common/cloudfront.tf
+++ b/environments/development/common/cloudfront.tf
@@ -36,6 +36,7 @@ module "cdn" {
     "examples.${var.domain_name}",
     "hub.${var.domain_name}",
     "id.${var.domain_name}",
+    "mcp.${var.domain_name}",
   ]
 
   create_alias    = true

--- a/environments/development/common/route53.tf
+++ b/environments/development/common/route53.tf
@@ -38,15 +38,3 @@ resource "aws_route53_record" "origin_wildcard" {
     evaluate_target_health = true
   }
 }
-
-resource "aws_route53_record" "mcp" {
-  zone_id = data.aws_route53_zone.this.zone_id
-  name    = "mcp.${var.domain_name}"
-  type    = "A"
-
-  alias {
-    name                   = module.alb.dns_name
-    zone_id                = module.alb.zone_id
-    evaluate_target_health = true
-  }
-}

--- a/environments/production/common/cloudfront.tf
+++ b/environments/production/common/cloudfront.tf
@@ -6,6 +6,7 @@ module "cdn" {
     "admin.${var.domain_name}",
     "hub.${var.domain_name}",
     "id.${var.domain_name}",
+    "mcp.${var.domain_name}",
     "www.${var.domain_name}",
   ]
 

--- a/environments/production/common/route53.tf
+++ b/environments/production/common/route53.tf
@@ -77,15 +77,3 @@ resource "aws_route53_record" "origin_wildcard" {
     evaluate_target_health = true
   }
 }
-
-resource "aws_route53_record" "mcp" {
-  zone_id = data.aws_route53_zone.this.zone_id
-  name    = "mcp.${var.domain_name}"
-  type    = "A"
-
-  alias {
-    name                   = module.alb.dns_name
-    zone_id                = module.alb.zone_id
-    evaluate_target_health = true
-  }
-}

--- a/environments/staging/common/cloudfront.tf
+++ b/environments/staging/common/cloudfront.tf
@@ -34,6 +34,7 @@ module "cdn" {
     "admin.${var.domain_name}",
     "hub.${var.domain_name}",
     "id.${var.domain_name}",
+    "mcp.${var.domain_name}",
   ]
 
   create_alias    = true

--- a/environments/staging/common/route53.tf
+++ b/environments/staging/common/route53.tf
@@ -38,15 +38,3 @@ resource "aws_route53_record" "origin_wildcard" {
     evaluate_target_health = true
   }
 }
-
-resource "aws_route53_record" "mcp" {
-  zone_id = data.aws_route53_zone.this.zone_id
-  name    = "mcp.${var.domain_name}"
-  type    = "A"
-
-  alias {
-    name                   = module.alb.dns_name
-    zone_id                = module.alb.zone_id
-    evaluate_target_health = true
-  }
-}


### PR DESCRIPTION
## Summary

- Adds `mcp.*` as an alias on the existing CDN in all three environments (development, staging, production)
- Removes the dedicated Route53 A records that pointed `mcp.*` directly at the ALB

## Why

The ALB requires all requests to carry a custom CloudFront origin header — direct requests return 403. Routing MCP through the existing CloudFront distribution (which has caching disabled on the default behaviour) means CloudFront adds the required header automatically before forwarding to the ALB. No caching occurs.

## Risk

low-risk — additive CDN alias change with no behaviour change for existing services. The MCP service is new and not yet in production use.