### PR TITLE
BAU: Enable state locking

### DIFF
--- a/environments/development/root.hcl
+++ b/environments/development/root.hcl
@@ -7,10 +7,11 @@ remote_state {
   }
 
   config = {
-    bucket  = "terraform-state-development-844815912454"
-    key     = "${path_relative_to_include()}/terraform.tfstate"
-    region  = "eu-west-2"
-    encrypt = true
+    bucket       = "terraform-state-development-844815912454"
+    key          = "${path_relative_to_include()}/terraform.tfstate"
+    region       = "eu-west-2"
+    encrypt      = true
+    use_lockfile = true
   }
 
   disable_init = tobool(get_env("DISABLE_INIT", false))

--- a/environments/production/common/iam-policies.tf
+++ b/environments/production/common/iam-policies.tf
@@ -16,8 +16,6 @@ resource "aws_iam_policy" "ci_terraform_policy" {
 
           # S3 (data loss + policy hijack)
           "s3:DeleteBucket",
-          "s3:DeleteObject",
-          "s3:DeleteObjectVersion",
           "s3:DeleteBucketPolicy",
 
           # IAM (privilege escalation)
@@ -97,6 +95,17 @@ resource "aws_iam_policy" "ci_terraform_policy" {
             "route53:ChangeResourceRecordSetsActions" = ["CREATE", "UPSERT"]
           }
         }
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "s3:DeleteObject",
+          "s3:DeleteObjectVersion"
+        ],
+        Resource = [
+          "arn:aws:s3:::terraform-state-${var.environment}-${local.account_id}/*/*.tflock",
+          "arn:aws:s3:::terraform-state-${var.environment}-${local.account_id}/*.tflock"
+        ]
       },
       {
         Effect = "Allow",

--- a/environments/production/root.hcl
+++ b/environments/production/root.hcl
@@ -7,10 +7,11 @@ remote_state {
   }
 
   config = {
-    bucket  = "terraform-state-production-382373577178"
-    key     = "${path_relative_to_include()}/terraform.tfstate"
-    region  = "eu-west-2"
-    encrypt = true
+    bucket       = "terraform-state-production-382373577178"
+    key          = "${path_relative_to_include()}/terraform.tfstate"
+    region       = "eu-west-2"
+    encrypt      = true
+    use_lockfile = true
   }
 
   disable_init = tobool(get_env("DISABLE_INIT", false))

--- a/environments/staging/common/iam-policies.tf
+++ b/environments/staging/common/iam-policies.tf
@@ -16,8 +16,6 @@ resource "aws_iam_policy" "ci_terraform_policy" {
 
           # S3 (data loss + policy hijack)
           "s3:DeleteBucket",
-          "s3:DeleteObject",
-          "s3:DeleteObjectVersion",
           "s3:DeleteBucketPolicy",
 
           # IAM (privilege escalation)
@@ -84,6 +82,17 @@ resource "aws_iam_policy" "ci_terraform_policy" {
             "route53:ChangeResourceRecordSetsActions" = ["DELETE"]
           }
         }
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "s3:DeleteObject",
+          "s3:DeleteObjectVersion"
+        ],
+        Resource = [
+          "arn:aws:s3:::terraform-state-${var.environment}-${local.account_id}/*/*.tflock",
+          "arn:aws:s3:::terraform-state-${var.environment}-${local.account_id}/*.tflock"
+        ]
       },
       {
         Sid    = "AllowRoute53RecordCreateAndUpdate"

--- a/environments/staging/root.hcl
+++ b/environments/staging/root.hcl
@@ -7,10 +7,11 @@ remote_state {
   }
 
   config = {
-    bucket  = "terraform-state-staging-451934005581"
-    key     = "${path_relative_to_include()}/terraform.tfstate"
-    region  = "eu-west-2"
-    encrypt = true
+    bucket       = "terraform-state-staging-451934005581"
+    key          = "${path_relative_to_include()}/terraform.tfstate"
+    region       = "eu-west-2"
+    encrypt      = true
+    use_lockfile = true
   }
 
   disable_init = tobool(get_env("DISABLE_INIT", false))


### PR DESCRIPTION
# Jira link
[HMRC-2410](https://transformuk.atlassian.net/browse/HMRC-2410)

## What?

- Enabled S3 native state locking for Terraform/Terragrunt remote state by adding `use_lockfile = true` to the S3 backend configuration for all environments.
- Allowed Terraform to perform s3:DeleteObject on *.tflock files.

## Why?

- State locking prevents concurrent Terraform operations from modifying the same state file, reducing the risk of state corruption and inconsistent infrastructure changes. S3 native locking is the recommended approach and removes the need for external locking mechanisms.

### Risk:
Risk level: 🟢

Reason for rating:
- No infrastructure resources are modified.
- Change is limited to Terraform state management.
