### PR TITLE
HMRC-2400: Enable CloudFront caching for preference code endpoints

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: terragrunt-hcl-fmt
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.105.0
+    rev: v1.108.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -27,7 +27,7 @@ repos:
       - id: check-merge-conflict
 
   - repo: https://github.com/rhysd/actionlint.git
-    rev: v1.7.11
+    rev: v1.7.12
     hooks:
       - id: actionlint-docker
 

--- a/environments/development/common/.terraform.lock.hcl
+++ b/environments/development/common/.terraform.lock.hcl
@@ -1,9 +1,12 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/archive" {
   version     = "2.7.1"
-  constraints = ">= 2.0.0"
+  constraints = ">= 2.0.0, 2.7.1"
   hashes = [
     "h1:62VrkalDPMKB9zerCBS4iKTbvxejwnAWn/XXYZZQWD4=",
+    "h1:A7EnRBVm4h9ryO9LwxYnKr4fy7ExPMwD5a1DsY7m1Y0=",
     "zh:19881bb356a4a656a865f48aee70c0b8a03c35951b7799b6113883f67f196e8e",
     "zh:2fcfbf6318dd514863268b09bbe19bfc958339c636bcbcc3664b45f2b8bf5cc6",
     "zh:3323ab9a504ce0a115c28e64d0739369fe85151291a2ce480d51ccbb0c381ac5",
@@ -21,8 +24,9 @@ provider "registry.terraform.io/hashicorp/archive" {
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "6.51.0"
-  constraints = ">= 6.0.0"
+  constraints = ">= 6.0.0, >= 6.28.0"
   hashes = [
+    "h1:QWxF+1ePJ4qFCHEc6PyHNeXc865wLvrWVl71d/nABa8=",
     "h1:bclp+xS1fYeOCil0XZO6mKvEeHFESt5K/XotVSZND54=",
     "zh:03fcea0a1ea2ca81d62d4d2e2961181bef9068b1c701f2cddc4aa5fac105818a",
     "zh:1213944cd623143974ea5c9b70b22ae1ccca33d743924c149ed089d34b8e08b4",
@@ -45,8 +49,9 @@ provider "registry.terraform.io/hashicorp/aws" {
 
 provider "registry.terraform.io/hashicorp/external" {
   version     = "2.4.0"
-  constraints = ">= 2.3.5"
+  constraints = ">= 1.0.0, >= 2.3.5"
   hashes = [
+    "h1:AmY6ZeIvqoTT5ZjzD+P49PeQH6Va1QLMkX+7MUQfYoA=",
     "h1:K0eLC86zbhVoyS4THmY00KJZKAQORuz6dt9Ro3xo/wA=",
     "zh:0772afb42b658468ac5e15df33bf2080456f8f0b8ab163bfe9c50d2b2ea02135",
     "zh:0ac31a9aaa43dfcff5944b791596cdc94e153348e4bb4642282d034dff548134",
@@ -66,9 +71,10 @@ provider "registry.terraform.io/hashicorp/external" {
 
 provider "registry.terraform.io/hashicorp/local" {
   version     = "2.9.0"
-  constraints = "2.9.0"
+  constraints = ">= 1.0.0"
   hashes = [
     "h1:9rBZCMNpxKwMlRbWH2QpwD3kqUCAejdOZQ/aiiDObXQ=",
+    "h1:m24fjcInWvTVZ1XSo2MaNuKPe+X/gfG8SIi09rA7a7M=",
     "zh:0baa4566cf77f1ff52f4293d1c8536202dd23edc197c3196413a28343c3ac3a0",
     "zh:16b5559c3c07088ddad11a9bb9e9c0799999363c2958e9a5be2bcbbf2cd9ca64",
     "zh:197c79015a10d1cce904a8ea722cbc750c42aeae2da53f44a6a0751d9fd1aa90",
@@ -87,8 +93,9 @@ provider "registry.terraform.io/hashicorp/local" {
 
 provider "registry.terraform.io/hashicorp/null" {
   version     = "3.3.0"
-  constraints = "3.3.0"
+  constraints = ">= 2.0.0, >= 3.0.0"
   hashes = [
+    "h1:a14TKo7Xvg4W8+H1VA6p+oLZTLxVQnYUD8LOaOs14A8=",
     "h1:l+dm3lhmu4ys7GbvIldfn544olSPH0DOiYruuFSfQkY=",
     "zh:021748b5ea3b5f6956f2e75c42c5cdc113b391fb98ac71364a4965d23b37000f",
     "zh:3b27956f8541d46704fda234e0d535c2ae2a4b33411848b1ee262a1ec03568b0",
@@ -110,6 +117,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.9.0"
   constraints = ">= 3.0.0"
   hashes = [
+    "h1:OO+IuvQJSPmWdN8AyyIEvPJbLvDQpgX/zbktoa9KsJE=",
     "h1:UlBuNVuCGJ39tTv2c5gz2NRZnQbXfbIWbTzWcth5o74=",
     "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
     "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
@@ -131,6 +139,7 @@ provider "registry.terraform.io/hashicorp/tls" {
   version     = "4.3.0"
   constraints = ">= 4.0.0"
   hashes = [
+    "h1:5bCU/c+2HUh7GhclzNSH6gAuoCS4inW3obEtRAwu6WQ=",
     "h1:j/BqLS2N2AScZyotd9nZpHdieJ7e5S8y+A+ZfIu8kL8=",
     "zh:0ab58d6f8991d436c7d2dbd89ed814709b949b07ac5a54ee53b0aec1fa772a8b",
     "zh:60b347abcb56f45d97c56f14d895069cd15a83993f199777f571b79fea3642ee",

--- a/environments/development/common/cloudfront.tf
+++ b/environments/development/common/cloudfront.tf
@@ -326,7 +326,25 @@ module "cdn" {
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     },
-
+    # Preference codes endpoints
+    {
+      name                        = "preference_codes"
+      path_pattern                = "/measure_types/*/preference_codes/*"
+      target_origin_id            = "alb"
+      cache_policy_id             = aws_cloudfront_cache_policy.long_cache.id
+      origin_request_policy_id    = aws_cloudfront_origin_request_policy.forward_all_qsa.id
+      response_headers_policy_id  = aws_cloudfront_response_headers_policy.this.id
+      lambda_function_association = local.lambda_assoc
+    },
+    {
+      name                        = "xi_preference_codes"
+      path_pattern                = "/xi/measure_types/*/preference_codes/*"
+      target_origin_id            = "alb"
+      cache_policy_id             = aws_cloudfront_cache_policy.long_cache.id
+      origin_request_policy_id    = aws_cloudfront_origin_request_policy.forward_all_qsa.id
+      response_headers_policy_id  = aws_cloudfront_response_headers_policy.this.id
+      lambda_function_association = local.lambda_assoc
+    },
     # DEFAULT BEHAVIOR (no path_pattern)
     {
       name                       = "default"

--- a/environments/production/common/.terraform.lock.hcl
+++ b/environments/production/common/.terraform.lock.hcl
@@ -1,9 +1,12 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/archive" {
   version     = "2.7.1"
-  constraints = ">= 2.0.0"
+  constraints = ">= 2.0.0, 2.7.1"
   hashes = [
     "h1:62VrkalDPMKB9zerCBS4iKTbvxejwnAWn/XXYZZQWD4=",
+    "h1:A7EnRBVm4h9ryO9LwxYnKr4fy7ExPMwD5a1DsY7m1Y0=",
     "zh:19881bb356a4a656a865f48aee70c0b8a03c35951b7799b6113883f67f196e8e",
     "zh:2fcfbf6318dd514863268b09bbe19bfc958339c636bcbcc3664b45f2b8bf5cc6",
     "zh:3323ab9a504ce0a115c28e64d0739369fe85151291a2ce480d51ccbb0c381ac5",
@@ -21,8 +24,9 @@ provider "registry.terraform.io/hashicorp/archive" {
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "6.51.0"
-  constraints = ">= 6.0.0"
+  constraints = ">= 6.0.0, >= 6.28.0"
   hashes = [
+    "h1:QWxF+1ePJ4qFCHEc6PyHNeXc865wLvrWVl71d/nABa8=",
     "h1:bclp+xS1fYeOCil0XZO6mKvEeHFESt5K/XotVSZND54=",
     "zh:03fcea0a1ea2ca81d62d4d2e2961181bef9068b1c701f2cddc4aa5fac105818a",
     "zh:1213944cd623143974ea5c9b70b22ae1ccca33d743924c149ed089d34b8e08b4",
@@ -45,8 +49,9 @@ provider "registry.terraform.io/hashicorp/aws" {
 
 provider "registry.terraform.io/hashicorp/external" {
   version     = "2.4.0"
-  constraints = ">= 2.3.5"
+  constraints = ">= 1.0.0, >= 2.3.5"
   hashes = [
+    "h1:AmY6ZeIvqoTT5ZjzD+P49PeQH6Va1QLMkX+7MUQfYoA=",
     "h1:K0eLC86zbhVoyS4THmY00KJZKAQORuz6dt9Ro3xo/wA=",
     "zh:0772afb42b658468ac5e15df33bf2080456f8f0b8ab163bfe9c50d2b2ea02135",
     "zh:0ac31a9aaa43dfcff5944b791596cdc94e153348e4bb4642282d034dff548134",
@@ -66,9 +71,10 @@ provider "registry.terraform.io/hashicorp/external" {
 
 provider "registry.terraform.io/hashicorp/local" {
   version     = "2.9.0"
-  constraints = "2.9.0"
+  constraints = ">= 1.0.0"
   hashes = [
     "h1:9rBZCMNpxKwMlRbWH2QpwD3kqUCAejdOZQ/aiiDObXQ=",
+    "h1:m24fjcInWvTVZ1XSo2MaNuKPe+X/gfG8SIi09rA7a7M=",
     "zh:0baa4566cf77f1ff52f4293d1c8536202dd23edc197c3196413a28343c3ac3a0",
     "zh:16b5559c3c07088ddad11a9bb9e9c0799999363c2958e9a5be2bcbbf2cd9ca64",
     "zh:197c79015a10d1cce904a8ea722cbc750c42aeae2da53f44a6a0751d9fd1aa90",
@@ -87,8 +93,9 @@ provider "registry.terraform.io/hashicorp/local" {
 
 provider "registry.terraform.io/hashicorp/null" {
   version     = "3.3.0"
-  constraints = "3.3.0"
+  constraints = ">= 2.0.0, >= 3.0.0"
   hashes = [
+    "h1:a14TKo7Xvg4W8+H1VA6p+oLZTLxVQnYUD8LOaOs14A8=",
     "h1:l+dm3lhmu4ys7GbvIldfn544olSPH0DOiYruuFSfQkY=",
     "zh:021748b5ea3b5f6956f2e75c42c5cdc113b391fb98ac71364a4965d23b37000f",
     "zh:3b27956f8541d46704fda234e0d535c2ae2a4b33411848b1ee262a1ec03568b0",
@@ -110,6 +117,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.9.0"
   constraints = ">= 3.0.0"
   hashes = [
+    "h1:OO+IuvQJSPmWdN8AyyIEvPJbLvDQpgX/zbktoa9KsJE=",
     "h1:UlBuNVuCGJ39tTv2c5gz2NRZnQbXfbIWbTzWcth5o74=",
     "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
     "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
@@ -131,6 +139,7 @@ provider "registry.terraform.io/hashicorp/tls" {
   version     = "4.3.0"
   constraints = ">= 4.0.0"
   hashes = [
+    "h1:5bCU/c+2HUh7GhclzNSH6gAuoCS4inW3obEtRAwu6WQ=",
     "h1:j/BqLS2N2AScZyotd9nZpHdieJ7e5S8y+A+ZfIu8kL8=",
     "zh:0ab58d6f8991d436c7d2dbd89ed814709b949b07ac5a54ee53b0aec1fa772a8b",
     "zh:60b347abcb56f45d97c56f14d895069cd15a83993f199777f571b79fea3642ee",
@@ -153,6 +162,7 @@ provider "registry.terraform.io/newrelic/newrelic" {
   constraints = ">= 3.78.0"
   hashes = [
     "h1:5fyvZAS7mNc1QrMrcD4aezZhedNJfz18GG8xoI5wJvU=",
+    "h1:IxtKhjfNamuiYiNSI87swaZifPN3s+YbbllTIdaObFY=",
     "zh:2e6c67c57a7fbe1cc5fe97019c4a7b3ceb9d463ee47d7a7fb9759ccdcc2b2490",
     "zh:3d31be6db4d2718af8ef594a9b8b43c4a213732721262105431eb4b071455456",
     "zh:40c29835f71f19e59bb18a2d17c2af232908a1bcf71652201482ed8799baa7b9",

--- a/environments/production/common/cloudfront.tf
+++ b/environments/production/common/cloudfront.tf
@@ -279,7 +279,23 @@ module "cdn" {
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     },
-
+    # Preference codes endpoints
+    {
+      name                        = "preference_codes"
+      path_pattern                = "/measure_types/*/preference_codes/*"
+      target_origin_id            = "alb"
+      cache_policy_id             = aws_cloudfront_cache_policy.long_cache.id
+      origin_request_policy_id    = aws_cloudfront_origin_request_policy.forward_all_qsa.id
+      response_headers_policy_id  = aws_cloudfront_response_headers_policy.this.id
+    },
+    {
+      name                        = "xi_preference_codes"
+      path_pattern                = "/xi/measure_types/*/preference_codes/*"
+      target_origin_id            = "alb"
+      cache_policy_id             = aws_cloudfront_cache_policy.long_cache.id
+      origin_request_policy_id    = aws_cloudfront_origin_request_policy.forward_all_qsa.id
+      response_headers_policy_id  = aws_cloudfront_response_headers_policy.this.id
+    },
     # DEFAULT BEHAVIOR (no path_pattern)
     {
       name                       = "default"

--- a/environments/production/common/cloudfront.tf
+++ b/environments/production/common/cloudfront.tf
@@ -281,20 +281,20 @@ module "cdn" {
     },
     # Preference codes endpoints
     {
-      name                        = "preference_codes"
-      path_pattern                = "/measure_types/*/preference_codes/*"
-      target_origin_id            = "alb"
-      cache_policy_id             = aws_cloudfront_cache_policy.long_cache.id
-      origin_request_policy_id    = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id  = aws_cloudfront_response_headers_policy.this.id
+      name                       = "preference_codes"
+      path_pattern               = "/measure_types/*/preference_codes/*"
+      target_origin_id           = "alb"
+      cache_policy_id            = aws_cloudfront_cache_policy.long_cache.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     },
     {
-      name                        = "xi_preference_codes"
-      path_pattern                = "/xi/measure_types/*/preference_codes/*"
-      target_origin_id            = "alb"
-      cache_policy_id             = aws_cloudfront_cache_policy.long_cache.id
-      origin_request_policy_id    = aws_cloudfront_origin_request_policy.forward_all_qsa.id
-      response_headers_policy_id  = aws_cloudfront_response_headers_policy.this.id
+      name                       = "xi_preference_codes"
+      path_pattern               = "/xi/measure_types/*/preference_codes/*"
+      target_origin_id           = "alb"
+      cache_policy_id            = aws_cloudfront_cache_policy.long_cache.id
+      origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
+      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     },
     # DEFAULT BEHAVIOR (no path_pattern)
     {

--- a/environments/staging/common/.terraform.lock.hcl
+++ b/environments/staging/common/.terraform.lock.hcl
@@ -1,9 +1,12 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/archive" {
   version     = "2.7.1"
-  constraints = ">= 2.0.0"
+  constraints = ">= 2.0.0, 2.7.1"
   hashes = [
     "h1:62VrkalDPMKB9zerCBS4iKTbvxejwnAWn/XXYZZQWD4=",
+    "h1:A7EnRBVm4h9ryO9LwxYnKr4fy7ExPMwD5a1DsY7m1Y0=",
     "zh:19881bb356a4a656a865f48aee70c0b8a03c35951b7799b6113883f67f196e8e",
     "zh:2fcfbf6318dd514863268b09bbe19bfc958339c636bcbcc3664b45f2b8bf5cc6",
     "zh:3323ab9a504ce0a115c28e64d0739369fe85151291a2ce480d51ccbb0c381ac5",
@@ -21,8 +24,9 @@ provider "registry.terraform.io/hashicorp/archive" {
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "6.51.0"
-  constraints = ">= 6.0.0"
+  constraints = ">= 6.0.0, >= 6.28.0"
   hashes = [
+    "h1:QWxF+1ePJ4qFCHEc6PyHNeXc865wLvrWVl71d/nABa8=",
     "h1:bclp+xS1fYeOCil0XZO6mKvEeHFESt5K/XotVSZND54=",
     "zh:03fcea0a1ea2ca81d62d4d2e2961181bef9068b1c701f2cddc4aa5fac105818a",
     "zh:1213944cd623143974ea5c9b70b22ae1ccca33d743924c149ed089d34b8e08b4",
@@ -45,8 +49,9 @@ provider "registry.terraform.io/hashicorp/aws" {
 
 provider "registry.terraform.io/hashicorp/external" {
   version     = "2.4.0"
-  constraints = ">= 2.3.5"
+  constraints = ">= 1.0.0, >= 2.3.5"
   hashes = [
+    "h1:AmY6ZeIvqoTT5ZjzD+P49PeQH6Va1QLMkX+7MUQfYoA=",
     "h1:K0eLC86zbhVoyS4THmY00KJZKAQORuz6dt9Ro3xo/wA=",
     "zh:0772afb42b658468ac5e15df33bf2080456f8f0b8ab163bfe9c50d2b2ea02135",
     "zh:0ac31a9aaa43dfcff5944b791596cdc94e153348e4bb4642282d034dff548134",
@@ -66,9 +71,10 @@ provider "registry.terraform.io/hashicorp/external" {
 
 provider "registry.terraform.io/hashicorp/local" {
   version     = "2.9.0"
-  constraints = "2.9.0"
+  constraints = ">= 1.0.0"
   hashes = [
     "h1:9rBZCMNpxKwMlRbWH2QpwD3kqUCAejdOZQ/aiiDObXQ=",
+    "h1:m24fjcInWvTVZ1XSo2MaNuKPe+X/gfG8SIi09rA7a7M=",
     "zh:0baa4566cf77f1ff52f4293d1c8536202dd23edc197c3196413a28343c3ac3a0",
     "zh:16b5559c3c07088ddad11a9bb9e9c0799999363c2958e9a5be2bcbbf2cd9ca64",
     "zh:197c79015a10d1cce904a8ea722cbc750c42aeae2da53f44a6a0751d9fd1aa90",
@@ -87,8 +93,9 @@ provider "registry.terraform.io/hashicorp/local" {
 
 provider "registry.terraform.io/hashicorp/null" {
   version     = "3.3.0"
-  constraints = "3.3.0"
+  constraints = ">= 2.0.0, >= 3.0.0"
   hashes = [
+    "h1:a14TKo7Xvg4W8+H1VA6p+oLZTLxVQnYUD8LOaOs14A8=",
     "h1:l+dm3lhmu4ys7GbvIldfn544olSPH0DOiYruuFSfQkY=",
     "zh:021748b5ea3b5f6956f2e75c42c5cdc113b391fb98ac71364a4965d23b37000f",
     "zh:3b27956f8541d46704fda234e0d535c2ae2a4b33411848b1ee262a1ec03568b0",
@@ -110,6 +117,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.9.0"
   constraints = ">= 3.0.0"
   hashes = [
+    "h1:OO+IuvQJSPmWdN8AyyIEvPJbLvDQpgX/zbktoa9KsJE=",
     "h1:UlBuNVuCGJ39tTv2c5gz2NRZnQbXfbIWbTzWcth5o74=",
     "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
     "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
@@ -131,6 +139,7 @@ provider "registry.terraform.io/hashicorp/tls" {
   version     = "4.3.0"
   constraints = ">= 4.0.0"
   hashes = [
+    "h1:5bCU/c+2HUh7GhclzNSH6gAuoCS4inW3obEtRAwu6WQ=",
     "h1:j/BqLS2N2AScZyotd9nZpHdieJ7e5S8y+A+ZfIu8kL8=",
     "zh:0ab58d6f8991d436c7d2dbd89ed814709b949b07ac5a54ee53b0aec1fa772a8b",
     "zh:60b347abcb56f45d97c56f14d895069cd15a83993f199777f571b79fea3642ee",
@@ -153,6 +162,7 @@ provider "registry.terraform.io/newrelic/newrelic" {
   constraints = ">= 3.78.0"
   hashes = [
     "h1:5fyvZAS7mNc1QrMrcD4aezZhedNJfz18GG8xoI5wJvU=",
+    "h1:IxtKhjfNamuiYiNSI87swaZifPN3s+YbbllTIdaObFY=",
     "zh:2e6c67c57a7fbe1cc5fe97019c4a7b3ceb9d463ee47d7a7fb9759ccdcc2b2490",
     "zh:3d31be6db4d2718af8ef594a9b8b43c4a213732721262105431eb4b071455456",
     "zh:40c29835f71f19e59bb18a2d17c2af232908a1bcf71652201482ed8799baa7b9",

--- a/environments/staging/common/cloudfront.tf
+++ b/environments/staging/common/cloudfront.tf
@@ -26,6 +26,7 @@ locals {
     }
   }
 }
+
 module "cdn" {
   source = "../../../modules/cloudfront"
 
@@ -324,7 +325,25 @@ module "cdn" {
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.forward_all_qsa.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
     },
-
+    # Preference codes endpoints
+    {
+      name                        = "preference_codes"
+      path_pattern                = "/measure_types/*/preference_codes/*"
+      target_origin_id            = "alb"
+      cache_policy_id             = aws_cloudfront_cache_policy.long_cache.id
+      origin_request_policy_id    = aws_cloudfront_origin_request_policy.forward_all_qsa.id
+      response_headers_policy_id  = aws_cloudfront_response_headers_policy.this.id
+      lambda_function_association = local.lambda_assoc
+    },
+    {
+      name                        = "xi_preference_codes"
+      path_pattern                = "/xi/measure_types/*/preference_codes/*"
+      target_origin_id            = "alb"
+      cache_policy_id             = aws_cloudfront_cache_policy.long_cache.id
+      origin_request_policy_id    = aws_cloudfront_origin_request_policy.forward_all_qsa.id
+      response_headers_policy_id  = aws_cloudfront_response_headers_policy.this.id
+      lambda_function_association = local.lambda_assoc
+    },
     # DEFAULT BEHAVIOR (no path_pattern)
     {
       name                       = "default"
@@ -343,7 +362,6 @@ module "cdn" {
     ]
   }
 }
-
 
 module "docs_cdn" {
   source = "../../../modules/cloudfront"


### PR DESCRIPTION
# Jira link
[HMRC-2400](https://transformuk.atlassian.net/browse/HMRC-2400)

## What?

I have:

- Added CloudFront cache behaviours for:
  - `/measure_types/*/preference_codes/*`
  - `/xi/measure_types/*/preference_codes/*`
- Applied the existing `long_cache` policy to these endpoints.

## Why?

I am doing this because:

- CloudFront Popular Objects reports show these endpoints receive high traffic but have a 0% cache hit rate, resulting in unnecessary origin requests to ECS/Fargate. Caching these largely static reference-data endpoints should improve response times and reduce application load.

## Risk:
Risk level: 🟢 

### Reason for rating:
- Change is limited to CloudFront behaviour configuration.
- Endpoints serve reference data that changes infrequently.
- No application code or database changes.
- Can be quickly reverted by removing the cache behaviours if required.