### PR TITLE
Add WAF header bypass rule for e2e test suite

### DIFF
--- a/environments/production/common/variables.tf
+++ b/environments/production/common/variables.tf
@@ -38,6 +38,13 @@ variable "waf_mcp_secret_token" {
   default     = ""
 }
 
+variable "waf_e2e_secret_token" {
+  description = "Secret token sent by the e2e test suite in X-E2E-Bypass. Requests presenting this header bypass bot control and are allowed unconditionally."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
 variable "waf_page_rpm_limit" {
   description = "Rate limit per IP per minute for individual tariff page paths (commodities, headings, chapters, subheadings). Lower than the global limit to restrict scrapers walking the hierarchy."
   type        = number

--- a/environments/production/common/waf.tf
+++ b/environments/production/common/waf.tf
@@ -23,14 +23,24 @@ module "waf" {
     }
   }
 
-  header_allow_rules = var.waf_mcp_secret_token != "" ? [
-    {
-      name         = "allow-mcp-server"
-      priority     = 0
-      header_name  = "x-mcp-token"
-      header_value = var.waf_mcp_secret_token
-    }
-  ] : []
+  header_allow_rules = concat(
+    var.waf_mcp_secret_token != "" ? [
+      {
+        name         = "allow-mcp-server"
+        priority     = 0
+        header_name  = "x-mcp-token"
+        header_value = var.waf_mcp_secret_token
+      }
+    ] : [],
+    var.waf_e2e_secret_token != "" ? [
+      {
+        name         = "allow-e2e-tests"
+        priority     = 7
+        header_name  = "x-waf-bypass"
+        header_value = var.waf_e2e_secret_token
+      }
+    ] : []
+  )
 
   bot_control_rule = {
     priority                = 70


### PR DESCRIPTION
# Jira link

## What?

I have:

- Added a `waf_e2e_secret_token` Terraform variable to the production WAF config
- Added an `allow-e2e-tests` header allow rule at priority 7 that matches requests carrying `X-WAF-Bypass: <token>`
- Refactored `header_allow_rules` to use `concat()` to support multiple entries alongside the existing MCP server rule

## Why?

I am doing this because:

- The Bot Control rule (TARGETED + ML, `override_action = none`) correctly identifies Playwright running in GitHub Actions CI as a bot and blocks its requests
- This causes the production e2e suite to time out waiting for page elements that never render (because JS assets and secondary requests are blocked by bot control)
- A secret header sent only by CI lets the WAF distinguish legitimate test traffic from actual bots without changing bot control behaviour for real users
- The rule evaluates at priority 7, before bot control at priority 70, so matching requests are allowed immediately without passing through any further rules
- Set `TF_VAR_waf_e2e_secret_token` as a GitHub Actions secret in this repository (value must match `WAF_BYPASS_TOKEN` in the e2e-tests repo)

Companion PRs:
- trade-tariff-tools#156 — shared workflow accepts the secret
- trade-tariff-e2e-tests#93 — Playwright sends the header, production workflow passes the secret