### PR TITLE
Fix WAF e2e bypass variable casing and wire bypass token into post-apply smoke test

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -68,6 +68,8 @@ jobs:
     uses: trade-tariff/trade-tariff-tools/.github/workflows/e2e-tests.yml@main
     with:
       test-environment: production
+    secrets:
+      waf_bypass_token: ${{ secrets.WAF_BYPASS_TOKEN }}
 
   notifications:
       runs-on: ubuntu-latest

--- a/environments/production/common/variables.tf
+++ b/environments/production/common/variables.tf
@@ -38,8 +38,8 @@ variable "waf_mcp_secret_token" {
   default     = ""
 }
 
-variable "waf_e2e_secret_token" {
-  description = "Secret token sent by the e2e test suite in X-E2E-Bypass. Requests presenting this header bypass bot control and are allowed unconditionally."
+variable "WAF_E2E_SECRET_TOKEN" {
+  description = "Secret token sent by the e2e test suite in X-WAF-Bypass. Requests presenting this header bypass bot control and are allowed unconditionally."
   type        = string
   sensitive   = true
   default     = ""

--- a/environments/production/common/waf.tf
+++ b/environments/production/common/waf.tf
@@ -32,12 +32,12 @@ module "waf" {
         header_value = var.waf_mcp_secret_token
       }
     ] : [],
-    var.waf_e2e_secret_token != "" ? [
+    var.WAF_E2E_SECRET_TOKEN != "" ? [
       {
         name         = "allow-e2e-tests"
         priority     = 7
         header_name  = "x-waf-bypass"
-        header_value = var.waf_e2e_secret_token
+        header_value = var.WAF_E2E_SECRET_TOKEN
       }
     ] : []
   )


### PR DESCRIPTION
# Jira link

## What?

I have:

- Renamed `waf_e2e_secret_token` → `WAF_E2E_SECRET_TOKEN` to match GitHub's forced uppercasing of secret names
- Wired `WAF_BYPASS_TOKEN` into the `post-apply-production` e2e smoke test job in `deploy-to-production.yml`

## Why?

I am doing this because:

- GitHub uppercases all secret names, so the org secret `TF_VAR_WAF_E2E_SECRET_TOKEN` maps to `var.WAF_E2E_SECRET_TOKEN` in Terraform — the previous lowercase variable name `waf_e2e_secret_token` never matched, so the WAF allow rule was never created
- The `post-apply-production` smoke test was also missing the `secrets:` block, causing `WAF_BYPASS_TOKEN` to be empty and the post-deploy e2e run to fail against bot control