### PR TITLE
Enable WAF e2e bypass across environments

### DIFF
--- a/.github/workflows/deploy-to-development.yml
+++ b/.github/workflows/deploy-to-development.yml
@@ -125,6 +125,7 @@ jobs:
       TERRAGRUNT_NON_INTERACTIVE: true
       TF_INPUT: false
       TF_IN_AUTOMATION: 1
+      TF_VAR_WAF_E2E_SECRET_TOKEN: ${{ secrets.TF_VAR_WAF_E2E_SECRET_TOKEN }}
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -22,6 +22,7 @@ jobs:
       TERRAGRUNT_NON_INTERACTIVE: true
       TF_INPUT: false
       TF_IN_AUTOMATION: 1
+      TF_VAR_WAF_E2E_SECRET_TOKEN: ${{ secrets.TF_VAR_WAF_E2E_SECRET_TOKEN }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.3
@@ -69,7 +70,7 @@ jobs:
     with:
       test-environment: production
     secrets:
-      waf_bypass_token: ${{ secrets.WAF_BYPASS_TOKEN }}
+      waf_bypass_token: ${{ secrets.TF_VAR_WAF_E2E_SECRET_TOKEN }}
 
   notifications:
       runs-on: ubuntu-latest

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -25,6 +25,7 @@ jobs:
       TERRAGRUNT_NON_INTERACTIVE: true
       TF_INPUT: false
       TF_IN_AUTOMATION: 1
+      TF_VAR_WAF_E2E_SECRET_TOKEN: ${{ secrets.TF_VAR_WAF_E2E_SECRET_TOKEN }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.3
@@ -73,6 +74,7 @@ jobs:
       test-environment: staging
     secrets:
       basic_password: ${{ secrets.BASIC_PASSWORD }}
+      waf_bypass_token: ${{ secrets.TF_VAR_WAF_E2E_SECRET_TOKEN }}
 
   notifications:
       runs-on: ubuntu-latest

--- a/environments/development/common/variables.tf
+++ b/environments/development/common/variables.tf
@@ -29,6 +29,13 @@ variable "waf_mcp_secret_token" {
   default     = ""
 }
 
+variable "WAF_E2E_SECRET_TOKEN" {
+  description = "Secret token sent by the e2e test suite in X-WAF-Bypass. Requests presenting this header bypass bot control and are allowed unconditionally."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
 variable "enable_sns_alerts" {
   description = "Enable SNS alerts for all CloudWatch alarms"
   type        = bool

--- a/environments/development/common/waf.tf
+++ b/environments/development/common/waf.tf
@@ -23,14 +23,24 @@ module "waf" {
     }
   }
 
-  header_allow_rules = var.waf_mcp_secret_token != "" ? [
-    {
-      name         = "allow-mcp-server"
-      priority     = 0
-      header_name  = "x-mcp-token"
-      header_value = var.waf_mcp_secret_token
-    }
-  ] : []
+  header_allow_rules = concat(
+    var.waf_mcp_secret_token != "" ? [
+      {
+        name         = "allow-mcp-server"
+        priority     = 0
+        header_name  = "x-mcp-token"
+        header_value = var.waf_mcp_secret_token
+      }
+    ] : [],
+    var.WAF_E2E_SECRET_TOKEN != "" ? [
+      {
+        name         = "allow-e2e-tests"
+        priority     = 7
+        header_name  = "x-waf-bypass"
+        header_value = var.WAF_E2E_SECRET_TOKEN
+      }
+    ] : []
+  )
 
   uri_path_match_rules = [
     {

--- a/environments/staging/common/variables.tf
+++ b/environments/staging/common/variables.tf
@@ -29,6 +29,13 @@ variable "waf_mcp_secret_token" {
   default     = ""
 }
 
+variable "WAF_E2E_SECRET_TOKEN" {
+  description = "Secret token sent by the e2e test suite in X-WAF-Bypass. Requests presenting this header bypass bot control and are allowed unconditionally."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
 variable "enable_sns_alerts" {
   description = "Enable SNS alerts for all CloudWatch alarms"
   type        = bool

--- a/environments/staging/common/waf.tf
+++ b/environments/staging/common/waf.tf
@@ -23,14 +23,24 @@ module "waf" {
     }
   }
 
-  header_allow_rules = var.waf_mcp_secret_token != "" ? [
-    {
-      name         = "allow-mcp-server"
-      priority     = 0
-      header_name  = "x-mcp-token"
-      header_value = var.waf_mcp_secret_token
-    }
-  ] : []
+  header_allow_rules = concat(
+    var.waf_mcp_secret_token != "" ? [
+      {
+        name         = "allow-mcp-server"
+        priority     = 0
+        header_name  = "x-mcp-token"
+        header_value = var.waf_mcp_secret_token
+      }
+    ] : [],
+    var.WAF_E2E_SECRET_TOKEN != "" ? [
+      {
+        name         = "allow-e2e-tests"
+        priority     = 7
+        header_name  = "x-waf-bypass"
+        header_value = var.WAF_E2E_SECRET_TOKEN
+      }
+    ] : []
+  )
 
   uri_path_match_rules = [
     {


### PR DESCRIPTION
## What changed

- Added the WAF e2e bypass Terraform variable to development and staging.
- Added the `X-WAF-Bypass` header allow rule to development and staging WAF config, matching production.
- Passed `TF_VAR_WAF_E2E_SECRET_TOKEN` into development, staging, and production platform applies.
- Passed `secrets.TF_VAR_WAF_E2E_SECRET_TOKEN` into direct staging and production e2e workflow calls as `waf_bypass_token`.

## Why

E2e tests need to run successfully in all platform environments. The WAF bypass rule and workflow secret mapping need to be consistent across development, staging, and production.

## Risk

Low risk: this only adds an optional secret-backed allow rule and explicit workflow secret mappings for e2e test traffic.