### PR TITLE
Explicitly pass WAF secret tokens as env vars in production deploy

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -22,6 +22,8 @@ jobs:
       TERRAGRUNT_NON_INTERACTIVE: true
       TF_INPUT: false
       TF_IN_AUTOMATION: 1
+      TF_VAR_WAF_E2E_SECRET_TOKEN: ${{ secrets.TF_VAR_WAF_E2E_SECRET_TOKEN }}
+      TF_VAR_WAF_MCP_SECRET_TOKEN: ${{ secrets.TF_VAR_WAF_MCP_SECRET_TOKEN }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.3


### PR DESCRIPTION
# Jira link

## What?

I have:

- Added explicit `env:` mappings for `TF_VAR_WAF_E2E_SECRET_TOKEN` and `TF_VAR_WAF_MCP_SECRET_TOKEN` in the `apply-production` job

## Why?

I am doing this because:

- GitHub Actions secrets are not automatically exposed as environment variables — they must be explicitly referenced in the workflow with `${{ secrets.NAME }}`
- Without this mapping, Terraform never received the `TF_VAR_*` values, both WAF bypass variables defaulted to `""`, and neither `allow-e2e-tests` nor `allow-mcp-server` WAF rules were ever created
- The Terraform apply reported `No changes` against the WAF ACL on every production deploy as a result