### PR TITLE
fix(mcp): route MCP domain directly to ALB, bypassing CloudFront WAF

### DIFF
--- a/environments/production/common/cloudfront.tf
+++ b/environments/production/common/cloudfront.tf
@@ -6,7 +6,6 @@ module "cdn" {
     "admin.${var.domain_name}",
     "hub.${var.domain_name}",
     "id.${var.domain_name}",
-    "mcp.${var.domain_name}",
     "www.${var.domain_name}",
   ]
 

--- a/environments/production/common/route53.tf
+++ b/environments/production/common/route53.tf
@@ -77,3 +77,15 @@ resource "aws_route53_record" "origin_wildcard" {
     evaluate_target_health = true
   }
 }
+
+resource "aws_route53_record" "mcp" {
+  zone_id = data.aws_route53_zone.this.zone_id
+  name    = "mcp.${var.domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = module.alb.dns_name
+    zone_id                = module.alb.zone_id
+    evaluate_target_health = true
+  }
+}

--- a/environments/production/common/waf.tf
+++ b/environments/production/common/waf.tf
@@ -118,26 +118,6 @@ module "waf" {
     }
   ]
 
-  # Allow OAuth endpoints on the MCP domain through managed rules.
-  # Managed rules (priority 10+) can block legitimate OAuth POST requests
-  # (e.g. CommonRuleSet body inspection). These allow rules fire at priority
-  # 2-3, before managed rules, so the OAuth flow is never incorrectly blocked.
-  host_path_allow_rules = [
-    {
-      name                  = "allow-mcp-oauth-token"
-      priority              = 10
-      host                  = "mcp.${var.domain_name}"
-      path_search_string    = "/token"
-      positional_constraint = "EXACTLY"
-    },
-    {
-      name                  = "allow-mcp-oauth-authorize"
-      priority              = 11
-      host                  = "mcp.${var.domain_name}"
-      path_search_string    = "/authorize"
-      positional_constraint = "STARTS_WITH"
-    },
-  ]
 }
 
 resource "aws_cloudwatch_log_group" "waf_logs" {

--- a/environments/staging/common/cloudfront.tf
+++ b/environments/staging/common/cloudfront.tf
@@ -34,7 +34,6 @@ module "cdn" {
     "admin.${var.domain_name}",
     "hub.${var.domain_name}",
     "id.${var.domain_name}",
-    "mcp.${var.domain_name}",
   ]
 
   create_alias    = true

--- a/environments/staging/common/route53.tf
+++ b/environments/staging/common/route53.tf
@@ -38,3 +38,15 @@ resource "aws_route53_record" "origin_wildcard" {
     evaluate_target_health = true
   }
 }
+
+resource "aws_route53_record" "mcp" {
+  zone_id = data.aws_route53_zone.this.zone_id
+  name    = "mcp.${var.domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = module.alb.dns_name
+    zone_id                = module.alb.zone_id
+    evaluate_target_health = true
+  }
+}

--- a/environments/staging/common/waf.tf
+++ b/environments/staging/common/waf.tf
@@ -59,22 +59,6 @@ module "waf" {
     }
   ]
 
-  host_path_allow_rules = [
-    {
-      name                  = "allow-mcp-oauth-token"
-      priority              = 10
-      host                  = "mcp.${var.domain_name}"
-      path_search_string    = "/token"
-      positional_constraint = "EXACTLY"
-    },
-    {
-      name                  = "allow-mcp-oauth-authorize"
-      priority              = 11
-      host                  = "mcp.${var.domain_name}"
-      path_search_string    = "/authorize"
-      positional_constraint = "STARTS_WITH"
-    },
-  ]
 }
 
 resource "aws_cloudwatch_log_group" "waf_logs" {


### PR DESCRIPTION
# Jira link

## What?

I have:

- Removed `mcp.${var.domain_name}` from the CloudFront distribution aliases (production and staging)
- Added a direct Route53 A alias record pointing `mcp.${var.domain_name}` at the ALB (production and staging)
- Removed the `host_path_allow_rules` WAF exceptions that were previously added as workarounds

## Why?

I am doing this because:

- The MCP server was sharing a CloudFront distribution and WAF with the browser-facing frontend. The WAF's TARGETED bot control blocks all programmatic HTTP clients (Claude Desktop, any MCP client) because they carry no browser cookies or JS signals, causing every MCP connection to 403 before reaching the application.
- Bot detection is the wrong protection layer for MCP — every request already requires a valid JWT obtained via OAuth with registered credentials, so an unauthenticated bot gets a 401 and can do nothing useful.
- The ALB already has an MCP listener rule (`hosts = ["mcp.*"]`) and the `acm_london` wildcard cert covers `mcp.{domain}`, so this is purely a DNS re-routing with no new infrastructure required.

This supersedes PR #647, which can be closed.