### PR TITLE
fix(alb): allow direct access to MCP service without CloudFront header

### DIFF
--- a/environments/production/common/alb.tf
+++ b/environments/production/common/alb.tf
@@ -51,9 +51,10 @@ module "alb" {
     }
 
     mcp = {
-      hosts            = ["mcp.*"]
-      healthcheck_path = "/healthcheckz"
-      priority         = 26
+      hosts                = ["mcp.*"]
+      healthcheck_path     = "/healthcheckz"
+      priority             = 26
+      bypass_custom_header = true
     }
 
     frontend = {

--- a/environments/staging/common/alb.tf
+++ b/environments/staging/common/alb.tf
@@ -53,9 +53,10 @@ module "alb" {
     }
 
     mcp = {
-      hosts            = ["mcp.*"]
-      healthcheck_path = "/healthcheckz"
-      priority         = 26
+      hosts                = ["mcp.*"]
+      healthcheck_path     = "/healthcheckz"
+      priority             = 26
+      bypass_custom_header = true
     }
 
     frontend = {

--- a/modules/application-load-balancer/README.md
+++ b/modules/application-load-balancer/README.md
@@ -80,7 +80,7 @@ No modules.
 | <a name="input_idle_timeout"></a> [idle\_timeout](#input\_idle\_timeout) | The time in seconds that the connection is allowed to be idle. | `string` | `60` | no |
 | <a name="input_listening_port"></a> [listening\_port](#input\_listening\_port) | Port on which the load balancer listens to. | `string` | `443` | no |
 | <a name="input_public_subnet_ids"></a> [public\_subnet\_ids](#input\_public\_subnet\_ids) | Public subnet IDs | `list(any)` | n/a | yes |
-| <a name="input_services"></a> [services](#input\_services) | Map of services to make ALB target groups and listener rules for. | <pre>map(<br/>    object({<br/>      healthcheck_path = string<br/>      hosts            = optional(list(string))<br/>      paths            = optional(list(string))<br/>      priority         = number<br/>    })<br/>  )</pre> | n/a | yes |
+| <a name="input_services"></a> [services](#input\_services) | Map of services to make ALB target groups and listener rules for. | <pre>map(<br/>    object({<br/>      healthcheck_path      = string<br/>      hosts                 = optional(list(string))<br/>      paths                 = optional(list(string))<br/>      priority              = number<br/>      bypass_custom_header  = optional(bool, false)<br/>    })<br/>  )</pre> | n/a | yes |
 | <a name="input_tls_application_port"></a> [tls\_application\_port](#input\_tls\_application\_port) | Port the application exposes on HTTPS. | `string` | `8443` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | ID of the VPC to place the load balancer into. | `string` | n/a | yes |
 

--- a/modules/application-load-balancer/main.tf
+++ b/modules/application-load-balancer/main.tf
@@ -139,10 +139,13 @@ resource "aws_lb_listener_rule" "this" {
     }
   }
 
-  condition {
-    http_header {
-      http_header_name = var.custom_header.name
-      values           = [var.custom_header.value]
+  dynamic "condition" {
+    for_each = lookup(var.services[each.key], "bypass_custom_header", false) ? [] : [true]
+    content {
+      http_header {
+        http_header_name = var.custom_header.name
+        values           = [var.custom_header.value]
+      }
     }
   }
 }

--- a/modules/application-load-balancer/variables.tf
+++ b/modules/application-load-balancer/variables.tf
@@ -65,10 +65,11 @@ variable "services" {
   description = "Map of services to make ALB target groups and listener rules for."
   type = map(
     object({
-      healthcheck_path = string
-      hosts            = optional(list(string))
-      paths            = optional(list(string))
-      priority         = number
+      healthcheck_path      = string
+      hosts                 = optional(list(string))
+      paths                 = optional(list(string))
+      priority              = number
+      bypass_custom_header  = optional(bool, false)
     })
   )
 }


### PR DESCRIPTION
# Jira link

## What?

I have:

- Added `bypass_custom_header = optional(bool, false)` to the ALB module's services variable
- Made the `http_header` condition on HTTPS listener rules dynamic — omitted when `bypass_custom_header = true`
- Set `bypass_custom_header = true` for the `mcp` service in production and staging

## Why?

I am doing this because:

- MCP is now routed directly to the ALB (bypassing CloudFront) to avoid the bot-control WAF that blocks all programmatic HTTP clients
- The ALB default action returns `403 Access denied` for any request that does not match a listener rule
- Every listener rule previously required the custom header that CloudFront injects — requests arriving directly (without CloudFront) never carry that header, so they fell through to the 403 default
- The `bypass_custom_header` flag lets the MCP service receive direct requests while all other services continue to require the CloudFront header