### PR TITLE
fix: disable state locking in development environment

### DIFF
--- a/environments/development/root.hcl
+++ b/environments/development/root.hcl
@@ -11,7 +11,7 @@ remote_state {
     key          = "${path_relative_to_include()}/terraform.tfstate"
     region       = "eu-west-2"
     encrypt      = true
-    use_lockfile = true
+    use_lockfile = false
   }
 
   disable_init = tobool(get_env("DISABLE_INIT", false))


### PR DESCRIPTION
## Summary

- Sets `use_lockfile = false` in `environments/development/root.hcl`
- Development is a single-PR environment with no concurrent apply risk, so state locking adds unnecessary overhead (`.tflock` object writes/deletes on every plan/apply)
