### PR TITLE
BAU: Remove New Relic provider and related configs

### DIFF
--- a/environments/staging/common/locals.tf
+++ b/environments/staging/common/locals.tf
@@ -15,15 +15,4 @@ locals {
     create-auth-challenge = "trade-tariff-identity-create-auth-challenge"
     define-auth-challenge = "trade-tariff-identity-define-auth-challenge"
   }
-
-  newrelic_secret_value = try(
-    data.aws_secretsmanager_secret_version.newrelic_configuration.secret_string,
-    error("Failed to retrieve New Relic secret from AWS Secrets Manager. Please ensure the secret exists and is accessible.")
-  )
-  newrelic_secret_map = jsondecode(local.newrelic_secret_value)
-
-  newrelic_license_key            = local.newrelic_secret_map["license_key"]
-  newrelic_account_id             = local.newrelic_secret_map["account_id"]
-  newrelic_user_key               = local.newrelic_secret_map["user_key"]
-  newrelic_aws_trusted_account_id = local.newrelic_secret_map["aws_trusted_account_id"]
 }

--- a/environments/staging/common/newrelic-stream.tf
+++ b/environments/staging/common/newrelic-stream.tf
@@ -1,3 +1,0 @@
-data "aws_secretsmanager_secret_version" "newrelic_configuration" {
-  secret_id = module.newrelic_configuration.secret_arn
-}

--- a/environments/staging/common/secrets.tf
+++ b/environments/staging/common/secrets.tf
@@ -112,13 +112,6 @@ module "identity_create_auth_challenge_configuration" {
   recovery_window = 7
 }
 
-module "newrelic_configuration" {
-  source          = "../../../modules/secret/"
-  name            = "newrelic-configuration"
-  kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
-  recovery_window = 7
-}
-
 module "apigw_internal_test_key" {
   source          = "../../../modules/secret/"
   name            = "apigw-${var.environment}-internal-test-api-key"

--- a/environments/staging/common/versions.tf
+++ b/environments/staging/common/versions.tf
@@ -22,11 +22,6 @@ terraform {
       version = ">= 2.3.5"
     }
 
-    newrelic = {
-      source  = "newrelic/newrelic"
-      version = ">= 3.78.0"
-    }
-
     tls = {
       source  = "hashicorp/tls"
       version = ">= 4.0.0"
@@ -63,11 +58,4 @@ provider "aws" {
       BillingCode = "HMR:OTT"
     }
   }
-}
-
-
-provider "newrelic" {
-  account_id = local.newrelic_account_id
-  api_key    = local.newrelic_user_key
-  region     = "EU"
 }


### PR DESCRIPTION
## What:
Removes the New Relic provider and related configuration from the staging environment.

## Why:
Most of the New Relic resources were removed in a previous change, so the provider is no longer required. Removing the provider in a separate step avoids Terraform planning issues caused by resources still referencing the provider during removal.

## Notes
This is the second phase of the New Relic removal from staging and completes the decommissioning of the New Relic Terraform configuration for that environment.

## Ticket:
BAU

## Risk:
**Risk level:** 🟢 

**Reason for rating:**
<!-- One or two sentences explaining your assessment, especially for Amber or Red -->