### PR TITLE
BAU: Downgrade WAF bot detection from TARGETED to COMMON

### DIFF
--- a/environments/production/common/waf.tf
+++ b/environments/production/common/waf.tf
@@ -45,17 +45,10 @@ module "waf" {
   bot_control_rule = {
     priority                = 70
     override_action         = "none"
-    inspection_level        = "TARGETED"
-    enable_machine_learning = true
+    inspection_level        = "COMMON"
+    enable_machine_learning = false
     excluded_uri_prefixes   = ["/uk/api/", "/xi/api/", "/api/", "/healthcheck"]
-    captcha_override_rules = [
-      "TGT_VolumetricIpTokenAbsent",
-      "TGT_VolumetricSession",
-      "TGT_TokenReuseIpDetected",
-      "TGT_ML_CoordinatedActivityLow",
-      "TGT_ML_CoordinatedActivityMedium",
-      "TGT_ML_CoordinatedActivityHigh",
-    ]
+    captcha_override_rules  = []
   }
 
   ip_rate_url_based_rules = [


### PR DESCRIPTION
## What:
Switch the production WAF bot control inspection level from `TARGETED` to `COMMON`, removing the associated `TGT_`-prefixed captcha override rules and disabling machine learning.

## Why:
The TARGETED inspection level includes ML-based coordinated activity detection but comes at a higher per-request cost. COMMON provides solid standard bot detection at lower cost without the machine learning overhead.

## Ticket:
N/A

## Risk:
**Risk level:** 🟠

**Reason for rating:**
This modifies a WAF bot control rule in production. The change reduces the depth of bot detection (dropping ML-based coordinated activity signals), which could allow some bot traffic that was previously blocked or challenged to pass through. The API paths remain excluded from bot control as before.