### PR TITLE
BAU: Update API GAteway usage plan rate limit

### DIFF
--- a/environments/production/common/gateway.tf
+++ b/environments/production/common/gateway.tf
@@ -30,13 +30,13 @@ module "gateway" {
 variable "apigw_default_rate_limit" {
   description = "Steady-state requests per second for usage plan"
   type        = number
-  default     = 8
+  default     = 13
 }
 
 variable "apigw_default_burst_limit" {
   description = "Burst limit for usage plan"
   type        = number
-  default     = 16
+  default     = 25
 }
 
 # Usage plan linked to THIS environment's deployed stage

--- a/environments/staging/common/gateway.tf
+++ b/environments/staging/common/gateway.tf
@@ -30,13 +30,13 @@ module "gateway" {
 variable "apigw_default_rate_limit" {
   description = "Steady-state requests per second for usage plan"
   type        = number
-  default     = 8
+  default     = 13
 }
 
 variable "apigw_default_burst_limit" {
   description = "Burst limit for usage plan"
   type        = number
-  default     = 16
+  default     = 25
 }
 
 # Usage plan linked to THIS environment's deployed stage


### PR DESCRIPTION
## What:
- Changed API Gateway default rate limit from 8 to 13 rps in prod and staging
- Changed the API Gateway default burst limit from 16 to 25 rps in prod and staging

## Why:
This is needed to comply with the documented rate limit of 750 rpm

## Ticket:
BAU

## Risk:
**Risk level:** 🟢 

**Reason for rating:**
<!-- One or two sentences explaining your assessment, especially for Amber or Red -->