### PR TITLE
Fix WAF /search rate limit catching /search_suggestions

### DIFF
--- a/environments/production/common/.terraform.lock.hcl
+++ b/environments/production/common/.terraform.lock.hcl
@@ -6,7 +6,6 @@ provider "registry.terraform.io/hashicorp/archive" {
   constraints = ">= 2.0.0, 2.7.1"
   hashes = [
     "h1:62VrkalDPMKB9zerCBS4iKTbvxejwnAWn/XXYZZQWD4=",
-    "h1:A7EnRBVm4h9ryO9LwxYnKr4fy7ExPMwD5a1DsY7m1Y0=",
     "h1:Tr6LvLbm30zX4BRNPHhXo8SnOP0vg5UKAeunRNfnas8=",
     "zh:19881bb356a4a656a865f48aee70c0b8a03c35951b7799b6113883f67f196e8e",
     "zh:2fcfbf6318dd514863268b09bbe19bfc958339c636bcbcc3664b45f2b8bf5cc6",
@@ -28,7 +27,6 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = ">= 6.0.0, >= 6.28.0"
   hashes = [
     "h1:4c8zjgtGH0QgP+p/cF1UqdqkvD7V5i0ZxqslieZLTbc=",
-    "h1:QWxF+1ePJ4qFCHEc6PyHNeXc865wLvrWVl71d/nABa8=",
     "h1:bclp+xS1fYeOCil0XZO6mKvEeHFESt5K/XotVSZND54=",
     "zh:03fcea0a1ea2ca81d62d4d2e2961181bef9068b1c701f2cddc4aa5fac105818a",
     "zh:1213944cd623143974ea5c9b70b22ae1ccca33d743924c149ed089d34b8e08b4",
@@ -53,7 +51,6 @@ provider "registry.terraform.io/hashicorp/external" {
   version     = "2.4.0"
   constraints = ">= 1.0.0, >= 2.3.5"
   hashes = [
-    "h1:AmY6ZeIvqoTT5ZjzD+P49PeQH6Va1QLMkX+7MUQfYoA=",
     "h1:K0eLC86zbhVoyS4THmY00KJZKAQORuz6dt9Ro3xo/wA=",
     "h1:vvIsrZAD5eNoNtXvNcBUxkA9k2A4JcC8JTDFbM9d8gc=",
     "zh:0772afb42b658468ac5e15df33bf2080456f8f0b8ab163bfe9c50d2b2ea02135",
@@ -77,7 +74,6 @@ provider "registry.terraform.io/hashicorp/local" {
   constraints = ">= 1.0.0"
   hashes = [
     "h1:9rBZCMNpxKwMlRbWH2QpwD3kqUCAejdOZQ/aiiDObXQ=",
-    "h1:m24fjcInWvTVZ1XSo2MaNuKPe+X/gfG8SIi09rA7a7M=",
     "h1:oF4vw1rikPMqQtMMBoUjc/pERp50DlWwO+C2I6/sNI8=",
     "zh:0baa4566cf77f1ff52f4293d1c8536202dd23edc197c3196413a28343c3ac3a0",
     "zh:16b5559c3c07088ddad11a9bb9e9c0799999363c2958e9a5be2bcbbf2cd9ca64",
@@ -100,7 +96,6 @@ provider "registry.terraform.io/hashicorp/null" {
   constraints = ">= 2.0.0, >= 3.0.0"
   hashes = [
     "h1:Gq+xRK4yvwDpBJ2KFJkrmcNZikDiAEuFhAWeDtzanJc=",
-    "h1:a14TKo7Xvg4W8+H1VA6p+oLZTLxVQnYUD8LOaOs14A8=",
     "h1:l+dm3lhmu4ys7GbvIldfn544olSPH0DOiYruuFSfQkY=",
     "zh:021748b5ea3b5f6956f2e75c42c5cdc113b391fb98ac71364a4965d23b37000f",
     "zh:3b27956f8541d46704fda234e0d535c2ae2a4b33411848b1ee262a1ec03568b0",
@@ -122,7 +117,6 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.9.0"
   constraints = ">= 3.0.0"
   hashes = [
-    "h1:OO+IuvQJSPmWdN8AyyIEvPJbLvDQpgX/zbktoa9KsJE=",
     "h1:UlBuNVuCGJ39tTv2c5gz2NRZnQbXfbIWbTzWcth5o74=",
     "h1:o0s5Mk9NXMP60nlheO1r0LsDGGratFb3oL0t7bD2QnM=",
     "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
@@ -145,7 +139,6 @@ provider "registry.terraform.io/hashicorp/tls" {
   version     = "4.3.0"
   constraints = ">= 4.0.0"
   hashes = [
-    "h1:5bCU/c+2HUh7GhclzNSH6gAuoCS4inW3obEtRAwu6WQ=",
     "h1:QjGpJjmvOB973D0BM9rPv/h9ln+wM64IGY/tfuOginw=",
     "h1:j/BqLS2N2AScZyotd9nZpHdieJ7e5S8y+A+ZfIu8kL8=",
     "zh:0ab58d6f8991d436c7d2dbd89ed814709b949b07ac5a54ee53b0aec1fa772a8b",
@@ -170,7 +163,6 @@ provider "registry.terraform.io/newrelic/newrelic" {
   hashes = [
     "h1:5fyvZAS7mNc1QrMrcD4aezZhedNJfz18GG8xoI5wJvU=",
     "h1:6NQZslIJrE5+dAwbCMX8SRvW1M7+kqb2dX7ieGnQmic=",
-    "h1:IxtKhjfNamuiYiNSI87swaZifPN3s+YbbllTIdaObFY=",
     "zh:2e6c67c57a7fbe1cc5fe97019c4a7b3ceb9d463ee47d7a7fb9759ccdcc2b2490",
     "zh:3d31be6db4d2718af8ef594a9b8b43c4a213732721262105431eb4b071455456",
     "zh:40c29835f71f19e59bb18a2d17c2af232908a1bcf71652201482ed8799baa7b9",

--- a/environments/production/common/.terraform.lock.hcl
+++ b/environments/production/common/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/archive" {
   constraints = ">= 2.0.0, 2.7.1"
   hashes = [
     "h1:62VrkalDPMKB9zerCBS4iKTbvxejwnAWn/XXYZZQWD4=",
+    "h1:A7EnRBVm4h9ryO9LwxYnKr4fy7ExPMwD5a1DsY7m1Y0=",
     "h1:Tr6LvLbm30zX4BRNPHhXo8SnOP0vg5UKAeunRNfnas8=",
     "zh:19881bb356a4a656a865f48aee70c0b8a03c35951b7799b6113883f67f196e8e",
     "zh:2fcfbf6318dd514863268b09bbe19bfc958339c636bcbcc3664b45f2b8bf5cc6",
@@ -27,6 +28,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = ">= 6.0.0, >= 6.28.0"
   hashes = [
     "h1:4c8zjgtGH0QgP+p/cF1UqdqkvD7V5i0ZxqslieZLTbc=",
+    "h1:QWxF+1ePJ4qFCHEc6PyHNeXc865wLvrWVl71d/nABa8=",
     "h1:bclp+xS1fYeOCil0XZO6mKvEeHFESt5K/XotVSZND54=",
     "zh:03fcea0a1ea2ca81d62d4d2e2961181bef9068b1c701f2cddc4aa5fac105818a",
     "zh:1213944cd623143974ea5c9b70b22ae1ccca33d743924c149ed089d34b8e08b4",
@@ -51,6 +53,7 @@ provider "registry.terraform.io/hashicorp/external" {
   version     = "2.4.0"
   constraints = ">= 1.0.0, >= 2.3.5"
   hashes = [
+    "h1:AmY6ZeIvqoTT5ZjzD+P49PeQH6Va1QLMkX+7MUQfYoA=",
     "h1:K0eLC86zbhVoyS4THmY00KJZKAQORuz6dt9Ro3xo/wA=",
     "h1:vvIsrZAD5eNoNtXvNcBUxkA9k2A4JcC8JTDFbM9d8gc=",
     "zh:0772afb42b658468ac5e15df33bf2080456f8f0b8ab163bfe9c50d2b2ea02135",
@@ -74,6 +77,7 @@ provider "registry.terraform.io/hashicorp/local" {
   constraints = ">= 1.0.0"
   hashes = [
     "h1:9rBZCMNpxKwMlRbWH2QpwD3kqUCAejdOZQ/aiiDObXQ=",
+    "h1:m24fjcInWvTVZ1XSo2MaNuKPe+X/gfG8SIi09rA7a7M=",
     "h1:oF4vw1rikPMqQtMMBoUjc/pERp50DlWwO+C2I6/sNI8=",
     "zh:0baa4566cf77f1ff52f4293d1c8536202dd23edc197c3196413a28343c3ac3a0",
     "zh:16b5559c3c07088ddad11a9bb9e9c0799999363c2958e9a5be2bcbbf2cd9ca64",
@@ -96,6 +100,7 @@ provider "registry.terraform.io/hashicorp/null" {
   constraints = ">= 2.0.0, >= 3.0.0"
   hashes = [
     "h1:Gq+xRK4yvwDpBJ2KFJkrmcNZikDiAEuFhAWeDtzanJc=",
+    "h1:a14TKo7Xvg4W8+H1VA6p+oLZTLxVQnYUD8LOaOs14A8=",
     "h1:l+dm3lhmu4ys7GbvIldfn544olSPH0DOiYruuFSfQkY=",
     "zh:021748b5ea3b5f6956f2e75c42c5cdc113b391fb98ac71364a4965d23b37000f",
     "zh:3b27956f8541d46704fda234e0d535c2ae2a4b33411848b1ee262a1ec03568b0",
@@ -117,6 +122,7 @@ provider "registry.terraform.io/hashicorp/random" {
   version     = "3.9.0"
   constraints = ">= 3.0.0"
   hashes = [
+    "h1:OO+IuvQJSPmWdN8AyyIEvPJbLvDQpgX/zbktoa9KsJE=",
     "h1:UlBuNVuCGJ39tTv2c5gz2NRZnQbXfbIWbTzWcth5o74=",
     "h1:o0s5Mk9NXMP60nlheO1r0LsDGGratFb3oL0t7bD2QnM=",
     "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
@@ -139,6 +145,7 @@ provider "registry.terraform.io/hashicorp/tls" {
   version     = "4.3.0"
   constraints = ">= 4.0.0"
   hashes = [
+    "h1:5bCU/c+2HUh7GhclzNSH6gAuoCS4inW3obEtRAwu6WQ=",
     "h1:QjGpJjmvOB973D0BM9rPv/h9ln+wM64IGY/tfuOginw=",
     "h1:j/BqLS2N2AScZyotd9nZpHdieJ7e5S8y+A+ZfIu8kL8=",
     "zh:0ab58d6f8991d436c7d2dbd89ed814709b949b07ac5a54ee53b0aec1fa772a8b",
@@ -163,6 +170,7 @@ provider "registry.terraform.io/newrelic/newrelic" {
   hashes = [
     "h1:5fyvZAS7mNc1QrMrcD4aezZhedNJfz18GG8xoI5wJvU=",
     "h1:6NQZslIJrE5+dAwbCMX8SRvW1M7+kqb2dX7ieGnQmic=",
+    "h1:IxtKhjfNamuiYiNSI87swaZifPN3s+YbbllTIdaObFY=",
     "zh:2e6c67c57a7fbe1cc5fe97019c4a7b3ceb9d463ee47d7a7fb9759ccdcc2b2490",
     "zh:3d31be6db4d2718af8ef594a9b8b43c4a213732721262105431eb4b071455456",
     "zh:40c29835f71f19e59bb18a2d17c2af232908a1bcf71652201482ed8799baa7b9",

--- a/environments/production/common/waf.tf
+++ b/environments/production/common/waf.tf
@@ -90,7 +90,7 @@ module "waf" {
       limit                 = var.waf_search_rpm_limit
       action                = "block"
       search_string         = "/search"
-      positional_constraint = "STARTS_WITH"
+      positional_constraint = "EXACTLY"
     },
   ]
 


### PR DESCRIPTION
## What:
Changes the `rate-limit-search` WAF rule's match from `STARTS_WITH "/search"` to `EXACTLY "/search"`, so it no longer also catches `/search_suggestions`.

## Why:
The typeahead endpoint `/search_suggestions` fires one request per keystroke. Because the existing rule matched any path starting with `/search`, a single legitimate user search could trip the 60req/5min `rate-limit-search` limit on its own — and worse for shared office/NAT IPs (HMRC, brokers) where many users' searches pool into one IP bucket. This surfaced as intermittent 403s reported by Lauren and 5 others since last Friday. `/search_suggestions` now falls through to the global per-IP rate limit instead. `/search?q=...` is unaffected, since AWS WAF's `uri_path` field excludes the query string. Only production defines `ip_rate_url_based_rules`, so staging/dev needed no changes.

## Ticket:
N/A

## Risk:
**Risk level:** 🟠

**Reason for rating:** Modifies a WAF rule's match condition on production CloudFront — falls under "Adding or modifying WAF rules" in the Amber category. No resource replacement and the change only narrows what's matched (more permissive for `/search_suggestions`, unchanged for `/search` itself), but flagging for visibility per the template.