### PR TITLE
fix: allow flagsmith ecs task ingress

### DIFF
--- a/environments/development/common/flagsmith.tf
+++ b/environments/development/common/flagsmith.tf
@@ -60,6 +60,22 @@ resource "aws_security_group" "flagsmith_ecs" {
     security_groups = [module.alb-security-group.alb_security_group_id]
   }
 
+  ingress {
+    description = "HTTP 8000 between Flagsmith ECS tasks"
+    from_port   = 8000
+    to_port     = 8000
+    protocol    = "tcp"
+    self        = true
+  }
+
+  ingress {
+    description     = "HTTP 8000 from shared ECS tasks"
+    from_port       = 8000
+    to_port         = 8000
+    protocol        = "tcp"
+    security_groups = [module.alb-security-group.ecs_security_group_id]
+  }
+
   egress {
     description = "Allow all egress (Docker Hub pulls, RDS, etc.)"
     from_port   = 0

--- a/environments/production/common/flagsmith.tf
+++ b/environments/production/common/flagsmith.tf
@@ -59,6 +59,22 @@ resource "aws_security_group" "flagsmith_ecs" {
     security_groups = [module.alb-security-group.alb_security_group_id]
   }
 
+  ingress {
+    description = "HTTP 8000 between Flagsmith ECS tasks"
+    from_port   = 8000
+    to_port     = 8000
+    protocol    = "tcp"
+    self        = true
+  }
+
+  ingress {
+    description     = "HTTP 8000 from shared ECS tasks"
+    from_port       = 8000
+    to_port         = 8000
+    protocol        = "tcp"
+    security_groups = [module.alb-security-group.ecs_security_group_id]
+  }
+
   egress {
     description = "Allow all egress (Docker Hub pulls, RDS, etc.)"
     from_port   = 0

--- a/environments/staging/common/flagsmith.tf
+++ b/environments/staging/common/flagsmith.tf
@@ -59,6 +59,22 @@ resource "aws_security_group" "flagsmith_ecs" {
     security_groups = [module.alb-security-group.alb_security_group_id]
   }
 
+  ingress {
+    description = "HTTP 8000 between Flagsmith ECS tasks"
+    from_port   = 8000
+    to_port     = 8000
+    protocol    = "tcp"
+    self        = true
+  }
+
+  ingress {
+    description     = "HTTP 8000 from shared ECS tasks"
+    from_port       = 8000
+    to_port         = 8000
+    protocol        = "tcp"
+    security_groups = [module.alb-security-group.ecs_security_group_id]
+  }
+
   egress {
     description = "Allow all egress (Docker Hub pulls, RDS, etc.)"
     from_port   = 0


### PR DESCRIPTION
## What:
Allow the dedicated Flagsmith ECS security group to receive HTTP 8000 traffic from:

- other tasks using the same Flagsmith ECS security group
- standard/shared ECS tasks, including frontend

This adds two ingress rules to `flagsmith-ecs-${environment}` in development, staging, and production.

## Why:
Flagsmith Edge now uses Cloud Map to call the Flagsmith API internally at `flagsmith.tariff.internal:8000`. The frontend will also call Flagsmith Edge internally at `flagsmith-edge.tariff.internal:8000`.

The existing security group only allowed port 8000 from the ALB security group, so internal ECS callers could resolve the Cloud Map DNS names but timed out connecting to the target task.

## Ticket:
AI-928

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Scoped defect fix for the Flagsmith internal traffic path. The new ingress is limited to known ECS security groups on port 8000 and does not expose Flagsmith beyond existing ECS callers.
