### PR TITLE
HMRC-2429: Add application-autoscaling:PutScheduledAction to the ecs deployment …

### DIFF
--- a/environments/development/common/iam-policies.tf
+++ b/environments/development/common/iam-policies.tf
@@ -84,6 +84,7 @@ resource "aws_iam_policy" "ci_ecs_deployment_policy" {
           "application-autoscaling:DescribeScheduledActions",
           "application-autoscaling:ListTagsForResource",
           "application-autoscaling:PutScalingPolicy",
+          "application-autoscaling:PutScheduledAction",
           "application-autoscaling:RegisterScalableTarget",
           # CloudWatch - alarms for service health, dashboards (backend)
           "cloudwatch:DeleteAlarms",

--- a/environments/production/common/iam-policies.tf
+++ b/environments/production/common/iam-policies.tf
@@ -174,6 +174,7 @@ resource "aws_iam_policy" "ci_ecs_deployment_policy" {
           "application-autoscaling:DescribeScheduledActions",
           "application-autoscaling:ListTagsForResource",
           "application-autoscaling:PutScalingPolicy",
+          "application-autoscaling:PutScheduledAction",
           "application-autoscaling:RegisterScalableTarget",
           # CloudWatch - alarms for service health, dashboards (backend)
           "cloudwatch:DeleteAlarms",

--- a/environments/staging/common/iam-policies.tf
+++ b/environments/staging/common/iam-policies.tf
@@ -173,6 +173,7 @@ resource "aws_iam_policy" "ci_ecs_deployment_policy" {
           "application-autoscaling:DescribeScheduledActions",
           "application-autoscaling:ListTagsForResource",
           "application-autoscaling:PutScalingPolicy",
+          "application-autoscaling:PutScheduledAction",
           "application-autoscaling:RegisterScalableTarget",
           # CloudWatch - alarms for service health, dashboards (backend)
           "cloudwatch:DeleteAlarms",


### PR DESCRIPTION
## What:
Added `application-autoscaling:PutScheduledAction` to GitHub Actions CI deployment policy.

## Why:
To be able to create a scheduled autoscaling actions in ECS services

## Ticket:
[HMRC-2429](https://transformuk.atlassian.net/browse/HMRC-2429)

## Risk:
**Risk level:** 🟢 

**Reason for rating:**
<!-- One or two sentences explaining your assessment, especially for Amber or Red -->


