### PR TITLE
HMRC-2433: Extend production CDN timeout

### DIFF
--- a/environments/production/common/cloudfront.tf
+++ b/environments/production/common/cloudfront.tf
@@ -32,6 +32,7 @@ module "cdn" {
         https_port             = 443
         origin_protocol_policy = "https-only"
         origin_ssl_protocols   = ["TLSv1.2"]
+        origin_read_timeout    = 100
       }
 
       custom_header = [{


### PR DESCRIPTION
## What:
Extend the production main CloudFront distribution origin read timeout to 100 seconds, matching staging.

## Why:
Testing is moving to production, so the main production CDN should use the same read timeout currently configured in staging.

## Ticket:
https://transformuk.atlassian.net/browse/HMRC-2433

## Risk:
**Risk level:** 🟠 Amber

**Reason for rating:**
This changes production CloudFront origin behaviour for the main CDN by allowing requests to wait longer for the origin before timing out. It should be socialised with the team before merging because it affects production request handling.