### PR TITLE
HMRC-2171: Standardise Aurora snapshot naming, retention and backup defaults

### DIFF
--- a/environments/development/common/flagsmith.tf
+++ b/environments/development/common/flagsmith.tf
@@ -20,11 +20,8 @@ module "postgres_flagsmith" {
 
   multi_az = false
 
-  instance_type           = "db.t3.micro"
-  backup_window           = "22:00-23:00"
-  maintenance_window      = "Fri:23:00-Sat:01:00"
-  backup_retention_period = 7
-  private_subnet_ids      = data.terraform_remote_state.base.outputs.private_subnet_ids
+  instance_type      = "db.t3.micro"
+  private_subnet_ids = data.terraform_remote_state.base.outputs.private_subnet_ids
 
   allocated_storage  = 20
   security_group_ids = [aws_security_group.flagsmith_rds.id]

--- a/environments/development/common/rds.tf
+++ b/environments/development/common/rds.tf
@@ -96,11 +96,8 @@ module "postgres_developer_hub" {
 
   multi_az = false
 
-  instance_type           = "db.t3.micro"
-  backup_window           = "22:00-23:00"
-  maintenance_window      = "Fri:23:00-Sat:01:00"
-  backup_retention_period = 7
-  private_subnet_ids      = data.terraform_remote_state.base.outputs.private_subnet_ids
+  instance_type      = "db.t3.micro"
+  private_subnet_ids = data.terraform_remote_state.base.outputs.private_subnet_ids
 
   allocated_storage  = 10
   security_group_ids = [module.alb-security-group.be_to_rds_security_group_id]

--- a/environments/production/common/flagsmith.tf
+++ b/environments/production/common/flagsmith.tf
@@ -20,11 +20,8 @@ module "postgres_flagsmith" {
 
   multi_az = true
 
-  instance_type           = "db.t3.small"
-  backup_window           = "22:00-23:00"
-  maintenance_window      = "Fri:23:00-Sat:01:00"
-  backup_retention_period = 7
-  private_subnet_ids      = data.terraform_remote_state.base.outputs.private_subnet_ids
+  instance_type      = "db.t3.small"
+  private_subnet_ids = data.terraform_remote_state.base.outputs.private_subnet_ids
 
   allocated_storage  = 20
   security_group_ids = [aws_security_group.flagsmith_rds.id]

--- a/environments/production/common/rds.tf
+++ b/environments/production/common/rds.tf
@@ -79,11 +79,8 @@ module "postgres_developer_hub" {
 
   multi_az = false
 
-  instance_type           = "db.t3.micro"
-  backup_window           = "22:00-23:00"
-  maintenance_window      = "Fri:23:00-Sat:01:00"
-  backup_retention_period = 7
-  private_subnet_ids      = data.terraform_remote_state.base.outputs.private_subnet_ids
+  instance_type      = "db.t3.micro"
+  private_subnet_ids = data.terraform_remote_state.base.outputs.private_subnet_ids
 
   allocated_storage  = 10
   security_group_ids = [module.alb-security-group.be_to_rds_security_group_id]
@@ -122,6 +119,8 @@ module "postgres_aurora" {
   performance_insights_enabled          = true
   performance_insights_retention_period = 465 # minimum required for Advanced
   database_insights_mode                = "advanced"
+
+  backup_retention_period = 30
 
   min_capacity = 2
   max_capacity = 64

--- a/environments/staging/common/flagsmith.tf
+++ b/environments/staging/common/flagsmith.tf
@@ -20,11 +20,8 @@ module "postgres_flagsmith" {
 
   multi_az = false
 
-  instance_type           = "db.t3.micro"
-  backup_window           = "22:00-23:00"
-  maintenance_window      = "Fri:23:00-Sat:01:00"
-  backup_retention_period = 7
-  private_subnet_ids      = data.terraform_remote_state.base.outputs.private_subnet_ids
+  instance_type      = "db.t3.micro"
+  private_subnet_ids = data.terraform_remote_state.base.outputs.private_subnet_ids
 
   allocated_storage  = 20
   security_group_ids = [aws_security_group.flagsmith_rds.id]

--- a/environments/staging/common/rds.tf
+++ b/environments/staging/common/rds.tf
@@ -96,11 +96,8 @@ module "postgres_developer_hub" {
 
   multi_az = false
 
-  instance_type           = "db.t3.micro"
-  backup_window           = "22:00-23:00"
-  maintenance_window      = "Fri:23:00-Sat:01:00"
-  backup_retention_period = 7
-  private_subnet_ids      = data.terraform_remote_state.base.outputs.private_subnet_ids
+  instance_type      = "db.t3.micro"
+  private_subnet_ids = data.terraform_remote_state.base.outputs.private_subnet_ids
 
   allocated_storage  = 10
   security_group_ids = [module.alb-security-group.be_to_rds_security_group_id]

--- a/modules/rds/README.md
+++ b/modules/rds/README.md
@@ -43,15 +43,15 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_allocated_storage"></a> [allocated\_storage](#input\_allocated\_storage) | Storage to allocate initially to the instance in gibibytes (i.e. 2^30 bytes). Can autoscale. | `number` | `5` | no |
 | <a name="input_allow_major_version_upgrade"></a> [allow\_major\_version\_upgrade](#input\_allow\_major\_version\_upgrade) | Whether to allow major version upgrades. | `bool` | `false` | no |
-| <a name="input_backup_retention_period"></a> [backup\_retention\_period](#input\_backup\_retention\_period) | Amount of time, in days, (between 0 and 35) that backups should be retained for. | `number` | `30` | no |
-| <a name="input_backup_window"></a> [backup\_window](#input\_backup\_window) | The daily time range (in UTC) during which automated backups are created if they are enabled, eg: `09:46-10:16` | `string` | n/a | yes |
+| <a name="input_backup_retention_period"></a> [backup\_retention\_period](#input\_backup\_retention\_period) | Amount of time, in days, (between 0 and 35) that backups should be retained for. | `number` | `7` | no |
+| <a name="input_backup_window"></a> [backup\_window](#input\_backup\_window) | The daily time range (in UTC) during which automated backups are created if they are enabled, eg: `09:46-10:16` | `string` | `"22:00-23:00"` | no |
 | <a name="input_database_insights_mode"></a> [database\_insights\_mode](#input\_database\_insights\_mode) | The mode of Database Insights that is enabled for the instance. Valid values: standard, advanced. | `string` | `"standard"` | no |
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Whether to protect the database from deletion. Defaults to `true`. | `bool` | `true` | no |
 | <a name="input_engine"></a> [engine](#input\_engine) | Database engine to use. | `string` | n/a | yes |
 | <a name="input_engine_version"></a> [engine\_version](#input\_engine\_version) | Version of the database engine to use. | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | Deployment environment. | `string` | n/a | yes |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type for the database. See https://aws.amazon.com/rds/instance-types/ | `string` | n/a | yes |
-| <a name="input_maintenance_window"></a> [maintenance\_window](#input\_maintenance\_window) | The time window (in UTC) to perform maintenance in. Syntax: `ddd:hh24:mi-ddd:hh24:mi`, eg: `Mon:00:00-Mon:01:30`. | `string` | n/a | yes |
+| <a name="input_maintenance_window"></a> [maintenance\_window](#input\_maintenance\_window) | The time window (in UTC) to perform maintenance in. Syntax: `ddd:hh24:mi-ddd:hh24:mi`, eg: `Mon:00:00-Mon:01:30`. | `string` | `"Fri:23:00-Sat:01:00"` | no |
 | <a name="input_max_allocated_storage"></a> [max\_allocated\_storage](#input\_max\_allocated\_storage) | Maximum allocated storage for the instance. Defaults to `null` (no autoscaling). | `number` | `1` | no |
 | <a name="input_multi_az"></a> [multi\_az](#input\_multi\_az) | If the RDS instance is multi-AZ. | `bool` | `false` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the database. | `string` | n/a | yes |

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -10,11 +10,13 @@ resource "aws_db_instance" "this" {
   db_subnet_group_name  = aws_db_subnet_group.rds_private_subnet.name
   multi_az              = var.multi_az
 
-  deletion_protection     = var.deletion_protection
-  backup_retention_period = var.backup_retention_period
-  backup_window           = var.backup_window
-  maintenance_window      = var.maintenance_window
-  skip_final_snapshot     = true
+  deletion_protection       = var.deletion_protection
+  backup_retention_period   = var.backup_retention_period
+  backup_window             = var.backup_window
+  maintenance_window        = var.maintenance_window
+  skip_final_snapshot       = false
+  copy_tags_to_snapshot     = true
+  final_snapshot_identifier = "${var.name}-final-${formatdate("YYYYMMDDHHmm", timestamp())}"
 
   allow_major_version_upgrade = var.allow_major_version_upgrade
   auto_minor_version_upgrade  = true

--- a/modules/rds/variables.tf
+++ b/modules/rds/variables.tf
@@ -23,7 +23,7 @@ variable "instance_type" {
 variable "backup_retention_period" {
   description = "Amount of time, in days, (between 0 and 35) that backups should be retained for."
   type        = number
-  default     = 30
+  default     = 7
 }
 
 variable "performance_insights_enabled" {
@@ -53,11 +53,13 @@ variable "security_group_ids" {
 variable "backup_window" {
   description = "The daily time range (in UTC) during which automated backups are created if they are enabled, eg: `09:46-10:16`"
   type        = string
+  default     = "22:00-23:00"
 }
 
 variable "maintenance_window" {
   description = "The time window (in UTC) to perform maintenance in. Syntax: `ddd:hh24:mi-ddd:hh24:mi`, eg: `Mon:00:00-Mon:01:30`."
   type        = string
+  default     = "Fri:23:00-Sat:01:00"
 }
 
 variable "name" {

--- a/modules/rds_cluster/README.md
+++ b/modules/rds_cluster/README.md
@@ -36,6 +36,8 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_allow_major_version_upgrade"></a> [allow\_major\_version\_upgrade](#input\_allow\_major\_version\_upgrade) | Whether to allow major version upgrades. | `bool` | `false` | no |
 | <a name="input_apply_immediately"></a> [apply\_immediately](#input\_apply\_immediately) | Whether to apply changes immediately. Set to `true` when required. Defaults to `false`. | `bool` | `false` | no |
+| <a name="input_backup_retention_period"></a> [backup\_retention\_period](#input\_backup\_retention\_period) | Amount of time, in days, (between 0 and 35) that backups should be retained for. | `number` | `7` | no |
+| <a name="input_backup_window"></a> [backup\_window](#input\_backup\_window) | The daily time range (in UTC) during which automated backups are created if they are enabled, eg: `09:46-10:16` | `string` | `"22:00-23:00"` | no |
 | <a name="input_cloudwatch_log_exports"></a> [cloudwatch\_log\_exports](#input\_cloudwatch\_log\_exports) | A list of log types to export to CloudWatch Logs. Supported values: `postgresql`, `upgrade`, `iam-db-auth-error`. | `list(string)` | `[]` | no |
 | <a name="input_cluster_instances"></a> [cluster\_instances](#input\_cluster\_instances) | n/a | `number` | `0` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | n/a | `string` | n/a | yes |
@@ -52,7 +54,7 @@ No modules.
 | <a name="input_instance_class"></a> [instance\_class](#input\_instance\_class) | n/a | `string` | n/a | yes |
 | <a name="input_instance_identifiers"></a> [instance\_identifiers](#input\_instance\_identifiers) | To avoid renames after a snapshot restore, we manually pass the cluster identifiers to have these identifiers reflected in terraform state and avoid alterations to the writer/reader instances. | `list(string)` | `[]` | no |
 | <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | KMS key ARN for encryption at rest. | `string` | `null` | no |
-| <a name="input_maintenance_window"></a> [maintenance\_window](#input\_maintenance\_window) | The time window (in UTC) to perform maintenance in. Syntax: `ddd:hh24:mi-ddd:hh24:mi`, eg: `Mon:00:00-Mon:01:30`. | `string` | `"sun:05:00-sun:06:00"` | no |
+| <a name="input_maintenance_window"></a> [maintenance\_window](#input\_maintenance\_window) | The time window (in UTC) to perform maintenance in. Syntax: `ddd:hh24:mi-ddd:hh24:mi`, eg: `Mon:00:00-Mon:01:30`. | `string` | `"Fri:23:00-Sat:01:00"` | no |
 | <a name="input_max_capacity"></a> [max\_capacity](#input\_max\_capacity) | Maximum capacity (ACUs). Defaults to `256`. | `number` | `256` | no |
 | <a name="input_min_capacity"></a> [min\_capacity](#input\_min\_capacity) | Minimum capacity (ACUs). Defaults to `0`. | `number` | `0` | no |
 | <a name="input_performance_insights_enabled"></a> [performance\_insights\_enabled](#input\_performance\_insights\_enabled) | Whether to enable Performance Insights. Defaults to `true`. | `bool` | `false` | no |

--- a/modules/rds_cluster/main.tf
+++ b/modules/rds_cluster/main.tf
@@ -14,8 +14,11 @@ resource "aws_rds_cluster" "this" {
   database_name = var.database_name
 
   deletion_protection       = var.deletion_protection
+  backup_retention_period   = var.backup_retention_period
+  preferred_backup_window   = var.backup_window
   skip_final_snapshot       = false
-  final_snapshot_identifier = "${var.cluster_name}-final"
+  copy_tags_to_snapshot     = true
+  final_snapshot_identifier = "${var.cluster_name}-final-${formatdate("YYYYMMDDHHmm", timestamp())}"
 
   storage_encrypted = var.encryption_at_rest
   kms_key_id        = try(aws_kms_key.this[0].arn, var.kms_key_id)

--- a/modules/rds_cluster/variables.tf
+++ b/modules/rds_cluster/variables.tf
@@ -144,5 +144,17 @@ variable "allow_major_version_upgrade" {
 variable "maintenance_window" {
   description = "The time window (in UTC) to perform maintenance in. Syntax: `ddd:hh24:mi-ddd:hh24:mi`, eg: `Mon:00:00-Mon:01:30`."
   type        = string
-  default     = "sun:05:00-sun:06:00"
+  default     = "Fri:23:00-Sat:01:00"
+}
+
+variable "backup_retention_period" {
+  description = "Amount of time, in days, (between 0 and 35) that backups should be retained for."
+  type        = number
+  default     = 7
+}
+
+variable "backup_window" {
+  description = "The daily time range (in UTC) during which automated backups are created if they are enabled, eg: `09:46-10:16`"
+  type        = string
+  default     = "22:00-23:00"
 }


### PR DESCRIPTION
## What:
- Standardised Aurora snapshot naming by adding a unique timestamp to final snapshots: `cluster-name-final-YYYYMMDDHHmm`
- Enabled snapshot tag inheritance with `copy_tags_to_snapshot = true`.
- Added support for configurable backup retention and backup windows:  
  - `backup_retention_period`
  -  `backup_window`
- Moved default values for `maintenance_window`, `backup_window`, and `backup_retention_period` into the module to reduce duplication.
-  Removed duplicate default settings from parent modules where they matched the module defaults.
- Defined and demonstrated the manual snapshot naming convention:  `env-dbname-manual-reason-yyyymmdd`.
 
### Why:
- Establish a consistent naming standard for Aurora snapshots across environments.
- Prevent final snapshot creation failures caused by duplicate snapshot identifiers.
- Improve backup governance and traceability through inherited tags.
- Make backup retention explicitly managed within the module.
- Reduce configuration repetition and simplify maintenance by centralising default values.
- Provide a clear naming convention for operational manual snapshots.

## Ticket:
[HMRC-2171](https://transformuk.atlassian.net/browse/HMRC-2171)

## Risk:
**Risk level:** 🟢 

**Reason for rating:**
This is a low-risk Terraform configuration change. No database engine, schema, networking, or application changes are being made. The changes standardise backup configuration, snapshot naming, and module defaults while maintaining existing database functionality.