### PR TITLE
BAU:Upgrade S3 bucket module to v5.15.1 and fix lifecycle rule validation

### DIFF
--- a/environments/production/common/cloudwatch.tf
+++ b/environments/production/common/cloudwatch.tf
@@ -100,7 +100,7 @@ resource "aws_kms_key_policy" "logs_bucket_kms_key_policy" {
 }
 
 module "logs" {
-  source = "git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git?ref=v5.1.0"
+  source = "git@github.com:terraform-aws-modules/terraform-aws-s3-bucket.git?ref=v5.15.1"
 
   bucket = "trade-tariff-logs-${local.account_id}"
   acl    = "log-delivery-write"
@@ -126,6 +126,7 @@ module "logs" {
     enabled = true
 
     transition = [{
+      days          = 90
       storage_class = "DEEP_ARCHIVE"
     }]
 


### PR DESCRIPTION
## What:
- Upgraded `terraform-aws-s3-bucket` from `v5.1.0` to `v5.15.1`
- Updated the S3 lifecycle configuration for the logs bucket to include a transition period before moving objects to the `DEEP_ARCHIVE` storage class.

## Why:
- The current lifecycle rule defines a transition storage class but does not specify either days or dates, which is required by the AWS provider. This currently generates a warning during Terraform runs and will become an error in future AWS provider versions.
- The module upgrade also brings the S3 bucket module to the latest v5 release stream and aligns it with the provider upgrade work.

## Ticket:
BAU

## Risk:
**Risk level:** 🟢

**Reason for rating:**
<!-- One or two sentences explaining your assessment, especially for Amber or Red -->
