### PR TITLE
HMRC-2176: Stabilise Aurora final snapshot identifier

### DIFF
--- a/modules/rds/README.md
+++ b/modules/rds/README.md
@@ -32,6 +32,7 @@ No modules.
 | [aws_kms_key.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_secretsmanager_secret.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret_version.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
+| [random_id.final_snapshot](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [random_password.master_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [random_string.master_username](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [random_string.prefix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -16,7 +16,7 @@ resource "aws_db_instance" "this" {
   maintenance_window        = var.maintenance_window
   skip_final_snapshot       = false
   copy_tags_to_snapshot     = true
-  final_snapshot_identifier = "${var.name}-final-${formatdate("YYYYMMDDHHmm", timestamp())}"
+  final_snapshot_identifier = "${var.name}-final-${random_id.final_snapshot.hex}"
 
   allow_major_version_upgrade = var.allow_major_version_upgrade
   auto_minor_version_upgrade  = true
@@ -145,4 +145,12 @@ resource "aws_kms_key" "this" {
   key_usage           = "ENCRYPT_DECRYPT"
   enable_key_rotation = true
   tags                = local.tags
+}
+
+resource "random_id" "final_snapshot" {
+  byte_length = 2
+
+  keepers = {
+    cluster_name = var.name
+  }
 }

--- a/modules/rds_cluster/README.md
+++ b/modules/rds_cluster/README.md
@@ -28,6 +28,7 @@ No modules.
 | [aws_kms_key.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_rds_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster) | resource |
 | [aws_rds_cluster_instance.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_instance) | resource |
+| [random_id.final_snapshot](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [random_password.master_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 
 ## Inputs

--- a/modules/rds_cluster/main.tf
+++ b/modules/rds_cluster/main.tf
@@ -18,7 +18,7 @@ resource "aws_rds_cluster" "this" {
   preferred_backup_window   = var.backup_window
   skip_final_snapshot       = false
   copy_tags_to_snapshot     = true
-  final_snapshot_identifier = "${var.cluster_name}-final-${formatdate("YYYYMMDDHHmm", timestamp())}"
+  final_snapshot_identifier = "${var.cluster_name}-final-${random_id.final_snapshot.hex}"
 
   storage_encrypted = var.encryption_at_rest
   kms_key_id        = try(aws_kms_key.this[0].arn, var.kms_key_id)
@@ -90,4 +90,12 @@ resource "aws_kms_key" "this" {
   key_usage           = "ENCRYPT_DECRYPT"
   enable_key_rotation = true
   tags                = var.tags
+}
+
+resource "random_id" "final_snapshot" {
+  byte_length = 2
+
+  keepers = {
+    cluster_name = var.cluster_name
+  }
 }


### PR DESCRIPTION
## What:
- Replaced the timestamp-based `final_snapshot_identifier` with a stable `random_id` suffix.
- Eliminates perpetual Terraform plan diffs caused by `timestamp()` being re-evaluated on every plan.
- Maintains unique final snapshot names while keeping Terraform state stable.

## Why:
Using `timestamp()` caused Terraform to detect a change to `final_snapshot_identifier` on every plan, even when no infrastructure changes had occurred. Replacing it with a persistent `random_id` provides uniqueness without generating unnecessary plan noise.

## Ticket:
[HMRC-2176](https://transformuk.atlassian.net/browse/HMRC-2176)

## Risk:
**Risk level:** 🟢 

**Reason for rating:**
This change only affects the generated name used for final snapshots during cluster deletion. It does not modify the running database, backup retention settings, networking, or application behaviour.
