### PR TITLE
Provision the AI search evaluation service

### DIFF
--- a/environments/development/common/alb.tf
+++ b/environments/development/common/alb.tf
@@ -65,10 +65,9 @@ module "alb" {
     }
 
     ai_eval = {
-      hosts                = ["eval.*"]
-      healthcheck_path     = "/healthcheckz"
-      priority             = 27
-      bypass_custom_header = true
+      hosts            = ["eval.*"]
+      healthcheck_path = "/healthcheckz"
+      priority         = 27
     }
 
     frontend = {

--- a/environments/development/common/alb.tf
+++ b/environments/development/common/alb.tf
@@ -64,6 +64,13 @@ module "alb" {
       priority         = 26
     }
 
+    ai_eval = {
+      hosts                = ["eval.*"]
+      healthcheck_path     = "/healthcheckz"
+      priority             = 27
+      bypass_custom_header = true
+    }
+
     frontend = {
       paths            = ["/*"]
       healthcheck_path = "/healthcheckz"

--- a/environments/development/common/cloudfront.tf
+++ b/environments/development/common/cloudfront.tf
@@ -33,6 +33,7 @@ module "cdn" {
   aliases = [
     var.domain_name,
     "admin.${var.domain_name}",
+    "eval.${var.domain_name}",
     "examples.${var.domain_name}",
     "hub.${var.domain_name}",
     "id.${var.domain_name}",

--- a/environments/development/common/iam-roles.tf
+++ b/environments/development/common/iam-roles.tf
@@ -216,6 +216,7 @@ resource "aws_iam_role" "ci_ecs_deployments_role" {
           },
           StringLike = {
             "${aws_iam_openid_connect_provider.github_oidc.url}:sub" = [
+              "repo:trade-tariff/ai-search-evaluation-suite:*",
               "repo:trade-tariff/mcp:*",
               "repo:trade-tariff/trade-tariff-admin:*",
               "repo:trade-tariff/trade-tariff-api-docs:*",

--- a/environments/production/common/alb.tf
+++ b/environments/production/common/alb.tf
@@ -58,10 +58,9 @@ module "alb" {
     }
 
     ai_eval = {
-      hosts                = ["eval.*"]
-      healthcheck_path     = "/healthcheckz"
-      priority             = 27
-      bypass_custom_header = true
+      hosts            = ["eval.*"]
+      healthcheck_path = "/healthcheckz"
+      priority         = 27
     }
 
     frontend = {

--- a/environments/production/common/alb.tf
+++ b/environments/production/common/alb.tf
@@ -57,6 +57,13 @@ module "alb" {
       bypass_custom_header = true
     }
 
+    ai_eval = {
+      hosts                = ["eval.*"]
+      healthcheck_path     = "/healthcheckz"
+      priority             = 27
+      bypass_custom_header = true
+    }
+
     frontend = {
       paths            = ["/*"]
       healthcheck_path = "/healthcheckz"

--- a/environments/production/common/cloudfront.tf
+++ b/environments/production/common/cloudfront.tf
@@ -4,6 +4,7 @@ module "cdn" {
   aliases = [
     var.domain_name,
     "admin.${var.domain_name}",
+    "eval.${var.domain_name}",
     "hub.${var.domain_name}",
     "id.${var.domain_name}",
     "www.${var.domain_name}",

--- a/environments/production/common/iam-roles.tf
+++ b/environments/production/common/iam-roles.tf
@@ -283,6 +283,7 @@ resource "aws_iam_role" "ci_ecs_deployments_role" {
           },
           StringLike = {
             "${aws_iam_openid_connect_provider.github_oidc.url}:sub" = [
+              "repo:trade-tariff/ai-search-evaluation-suite:*",
               "repo:trade-tariff/mcp:*",
               "repo:trade-tariff/trade-tariff-admin:*",
               "repo:trade-tariff/trade-tariff-api-docs:*",

--- a/environments/staging/common/alb.tf
+++ b/environments/staging/common/alb.tf
@@ -60,10 +60,9 @@ module "alb" {
     }
 
     ai_eval = {
-      hosts                = ["eval.*"]
-      healthcheck_path     = "/healthcheckz"
-      priority             = 27
-      bypass_custom_header = true
+      hosts            = ["eval.*"]
+      healthcheck_path = "/healthcheckz"
+      priority         = 27
     }
 
     frontend = {

--- a/environments/staging/common/alb.tf
+++ b/environments/staging/common/alb.tf
@@ -59,6 +59,13 @@ module "alb" {
       bypass_custom_header = true
     }
 
+    ai_eval = {
+      hosts                = ["eval.*"]
+      healthcheck_path     = "/healthcheckz"
+      priority             = 27
+      bypass_custom_header = true
+    }
+
     frontend = {
       paths            = ["/*"]
       healthcheck_path = "/healthcheckz"

--- a/environments/staging/common/cloudfront.tf
+++ b/environments/staging/common/cloudfront.tf
@@ -32,6 +32,7 @@ module "cdn" {
   aliases = [
     var.domain_name,
     "admin.${var.domain_name}",
+    "eval.${var.domain_name}",
     "hub.${var.domain_name}",
     "id.${var.domain_name}",
   ]

--- a/environments/staging/common/iam-roles.tf
+++ b/environments/staging/common/iam-roles.tf
@@ -213,6 +213,7 @@ resource "aws_iam_role" "ci_ecs_deployments_role" {
           },
           StringLike = {
             "${aws_iam_openid_connect_provider.github_oidc.url}:sub" = [
+              "repo:trade-tariff/ai-search-evaluation-suite:*",
               "repo:trade-tariff/mcp:*",
               "repo:trade-tariff/trade-tariff-admin:*",
               "repo:trade-tariff/trade-tariff-api-docs:*",

--- a/modules/ecr/locals.tf
+++ b/modules/ecr/locals.tf
@@ -68,6 +68,11 @@ locals {
       production_images_to_keep  = 10
       development_images_to_keep = 30
     },
+    "ai-search-evaluation-suite" = {
+      lifecycle_policy           = true
+      production_images_to_keep  = 10
+      development_images_to_keep = 30
+    },
     "mcp" = {
       lifecycle_policy           = true
       production_images_to_keep  = 10


### PR DESCRIPTION
## What:

- Creates the centrally managed ECR repository for the AI search evaluation suite.
- Adds an `ai-eval-https` target group and `eval.*` listener rule in development, staging, and production.
- Allows `trade-tariff/ai-search-evaluation-suite` to assume the standard ECS deployment role in each environment.

## Why:

AI-1064 needs the same ECS deployment path used by dev-hub and identity before the backend-only evaluation service can be deployed. The application PR will initially serve only an `OKAY` placeholder and will not connect to a database or deploy Gabriel's frontend.

## Ticket:

https://transformuk.atlassian.net/browse/AI-1064

## Risk:

**Risk level:** 🟢

**Reason for rating:**

This is additive infrastructure for a new, currently unused capability. It does not modify existing service traffic or data, and the new route has no registered tasks until the application is deployed.