### PR TITLE
Allow development CloudWatch query validation

### DIFF
--- a/environments/development/common/iam-policies.tf
+++ b/environments/development/common/iam-policies.tf
@@ -175,8 +175,10 @@ resource "aws_iam_policy" "ci_ecs_deployment_policy" {
           "logs:DescribeLogGroups",
           "logs:DescribeLogStreams",
           "logs:GetLogEvents",
+          "logs:GetQueryResults",
           "logs:ListTagsForResource",
           "logs:PutRetentionPolicy",
+          "logs:StartQuery",
           # Secrets Manager - read secrets for task environment variables
           "secretsmanager:BatchGetSecretValue",
           "secretsmanager:DescribeSecret",


### PR DESCRIPTION
## What:

- [x] Allow the development ECS deployment role to start CloudWatch Logs Insights queries
- [x] Allow the role to poll query results to completion

## Why:

The backend development deployment will execute its generated Search Analytics aggregate queries against AWS so malformed CloudWatch Logs Insights syntax fails before merge.

## Ticket:

N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:** This adds two read-only/query-execution permissions to an existing development-only deployment role. It does not alter production infrastructure or replace any resources.