### PR TITLE
HMRC-2578: Enable Least Outstanding Requests (LOR) for ALB target group

### DIFF
--- a/modules/application-load-balancer/main.tf
+++ b/modules/application-load-balancer/main.tf
@@ -32,6 +32,8 @@ resource "aws_lb_target_group" "trade_tariff_https_target_groups" {
   vpc_id               = var.vpc_id
   deregistration_delay = 20
 
+  load_balancing_algorithm_type = "least_outstanding_requests"
+
   health_check {
     enabled             = true
     interval            = 30


### PR DESCRIPTION
## What:
This change updates the ALB target group load balancing algorithm from Round Robin to Least Outstanding Requests (LOR).

## Why:
Production monitoring shows a significant and persistent gap between Average and Maximum CPU Utilisation across ECS tasks. Individual tasks frequently experience high CPU utilisation while overall service utilisation remains relatively low.
LOR is designed to route requests towards targets with fewer outstanding requests, which may:

- Improve request distribution
- Reduce task hot-spotting
- Lower peak CPU utilisation
- Improve response times
- Reduce overload-related 5XX errors

Testing in staging was inconclusive due to differences in traffic volume and request characteristics compared to production.

## Ticket:
[HMRC-2578](https://transformuk.atlassian.net/browse/HMRC-2578)

## Risk:
**Risk level:** 🟢

**Reason for rating:**

- AWS-supported target group attribute change.
- No infrastructure replacement.
- No application code changes.
- Change can be reverted immediately by restoring Round Robin.
- Existing health checks remain unchanged.

Potential risks:

- Traffic distribution behaviour will change.
- Expected benefits may not materialise if the root cause is application or database related rather than load distribution.
