### PR TITLE
feat(rds): enable database enhanced monitoring in prod

### DIFF
--- a/environments/development/common/flagsmith.tf
+++ b/environments/development/common/flagsmith.tf
@@ -29,7 +29,6 @@ module "postgres_flagsmith" {
   secret_kms_key_arn     = aws_kms_key.secretsmanager_kms_key.arn
   secret_recovery_window = local.development_secret_recovery_window
 
-  performance_insights_enabled = true
 
   depends_on = [
     aws_security_group.flagsmith_rds

--- a/environments/production/common/iam-roles.tf
+++ b/environments/production/common/iam-roles.tf
@@ -464,3 +464,25 @@ resource "aws_iam_role_policy_attachment" "ecs_task_cleanup_ci_policy_attachment
   role       = aws_iam_role.ci_ecs_task_cleanup_role.name
   policy_arn = aws_iam_policy.ci_ecs_task_cleanup_policy.arn
 }
+
+resource "aws_iam_role" "rds_enhanced_monitoring" {
+  name = "RDS-Enhanced-Monitoring-Role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "://amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "rds_enhanced_monitoring_attach" {
+  role       = aws_iam_role.rds_enhanced_monitoring.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
+}

--- a/environments/production/common/rds.tf
+++ b/environments/production/common/rds.tf
@@ -119,6 +119,8 @@ module "postgres_aurora" {
   performance_insights_enabled          = true
   performance_insights_retention_period = 465 # minimum required for Advanced
   database_insights_mode                = "advanced"
+  monitoring_interval                   = 60
+  monitoring_role_arn                   = aws_iam_role.rds_enhanced_monitoring.arn
 
   backup_retention_period = 30
 

--- a/environments/staging/common/flagsmith.tf
+++ b/environments/staging/common/flagsmith.tf
@@ -28,8 +28,6 @@ module "postgres_flagsmith" {
 
   secret_kms_key_arn = aws_kms_key.secretsmanager_kms_key.arn
 
-  performance_insights_enabled = true
-
   depends_on = [
     aws_security_group.flagsmith_rds
   ]

--- a/modules/rds/README.md
+++ b/modules/rds/README.md
@@ -54,6 +54,8 @@ No modules.
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | Instance type for the database. See https://aws.amazon.com/rds/instance-types/ | `string` | n/a | yes |
 | <a name="input_maintenance_window"></a> [maintenance\_window](#input\_maintenance\_window) | The time window (in UTC) to perform maintenance in. Syntax: `ddd:hh24:mi-ddd:hh24:mi`, eg: `Mon:00:00-Mon:01:30`. | `string` | `"Fri:23:00-Sat:01:00"` | no |
 | <a name="input_max_allocated_storage"></a> [max\_allocated\_storage](#input\_max\_allocated\_storage) | Maximum allocated storage for the instance. Defaults to `null` (no autoscaling). | `number` | `1` | no |
+| <a name="input_monitoring_interval"></a> [monitoring\_interval](#input\_monitoring\_interval) | The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. Default is 60 seconds. | `number` | `0` | no |
+| <a name="input_monitoring_role_arn"></a> [monitoring\_role\_arn](#input\_monitoring\_role\_arn) | The ARN for the IAM role that permits RDS to send metrics to CloudWatch Logs. | `string` | `null` | no |
 | <a name="input_multi_az"></a> [multi\_az](#input\_multi\_az) | If the RDS instance is multi-AZ. | `bool` | `false` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the database. | `string` | n/a | yes |
 | <a name="input_performance_insights_enabled"></a> [performance\_insights\_enabled](#input\_performance\_insights\_enabled) | Whether to enable Performance Insights. Defaults to `true`. | `bool` | `false` | no |

--- a/modules/rds/main.tf
+++ b/modules/rds/main.tf
@@ -32,6 +32,8 @@ resource "aws_db_instance" "this" {
   performance_insights_retention_period = var.performance_insights_enabled ? var.performance_insights_retention_period : null
   performance_insights_kms_key_id       = aws_kms_key.this.arn
   database_insights_mode                = var.database_insights_mode
+  monitoring_interval                   = var.monitoring_interval
+  monitoring_role_arn                   = var.monitoring_role_arn
 
   parameter_group_name = aws_db_parameter_group.postgres[0].name
 

--- a/modules/rds/variables.tf
+++ b/modules/rds/variables.tf
@@ -44,6 +44,19 @@ variable "database_insights_mode" {
   default     = "standard"
 }
 
+variable "monitoring_role_arn" {
+  description = "The ARN for the IAM role that permits RDS to send metrics to CloudWatch Logs."
+  type        = string
+  default     = null
+}
+
+variable "monitoring_interval" {
+  description = "The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. Default is 60 seconds."
+  type        = number
+  default     = 0 # 0 completely disables Enhanced Monitoring
+}
+
+
 variable "security_group_ids" {
   description = "A list of security group IDs to associate with this RDS instance."
   type        = list(string)

--- a/modules/rds_cluster/README.md
+++ b/modules/rds_cluster/README.md
@@ -58,8 +58,10 @@ No modules.
 | <a name="input_maintenance_window"></a> [maintenance\_window](#input\_maintenance\_window) | The time window (in UTC) to perform maintenance in. Syntax: `ddd:hh24:mi-ddd:hh24:mi`, eg: `Mon:00:00-Mon:01:30`. | `string` | `"Fri:23:00-Sat:01:00"` | no |
 | <a name="input_max_capacity"></a> [max\_capacity](#input\_max\_capacity) | Maximum capacity (ACUs). Defaults to `256`. | `number` | `256` | no |
 | <a name="input_min_capacity"></a> [min\_capacity](#input\_min\_capacity) | Minimum capacity (ACUs). Defaults to `0`. | `number` | `0` | no |
+| <a name="input_monitoring_interval"></a> [monitoring\_interval](#input\_monitoring\_interval) | The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. Default is 60 seconds. | `number` | `0` | no |
+| <a name="input_monitoring_role_arn"></a> [monitoring\_role\_arn](#input\_monitoring\_role\_arn) | The ARN for the IAM role that permits RDS to send metrics to CloudWatch Logs. | `string` | `null` | no |
 | <a name="input_performance_insights_enabled"></a> [performance\_insights\_enabled](#input\_performance\_insights\_enabled) | Whether to enable Performance Insights. Defaults to `true`. | `bool` | `false` | no |
-| <a name="input_performance_insights_retention_period"></a> [performance\_insights\_retention\_period](#input\_performance\_insights\_retention\_period) | Amount of time, in days, (minimum 7, maximum 731, or any multiple of 31) to retain performance insights data. | `number` | `31` | no |
+| <a name="input_performance_insights_retention_period"></a> [performance\_insights\_retention\_period](#input\_performance\_insights\_retention\_period) | Amount of time, in days, (minimum 7, maximum 731, or any multiple of 31) to retain performance insights data. | `number` | `7` | no |
 | <a name="input_private_subnet_ids"></a> [private\_subnet\_ids](#input\_private\_subnet\_ids) | A list of private subnet IDs to associate with this cluster. | `list(string)` | n/a | yes |
 | <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | A list of security group IDs to associate with this cluster. | `list(string)` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to all resources in the module. | `map(any)` | `{}` | no |

--- a/modules/rds_cluster/main.tf
+++ b/modules/rds_cluster/main.tf
@@ -44,6 +44,8 @@ resource "aws_rds_cluster" "this" {
   performance_insights_retention_period = var.performance_insights_enabled ? var.performance_insights_retention_period : null
   performance_insights_kms_key_id       = var.performance_insights_enabled ? try(aws_kms_key.this[0].arn, var.kms_key_id) : null
   database_insights_mode                = var.database_insights_mode
+  monitoring_interval                   = var.monitoring_interval
+  monitoring_role_arn                   = var.monitoring_role_arn
 
   tags = var.tags
 }

--- a/modules/rds_cluster/variables.tf
+++ b/modules/rds_cluster/variables.tf
@@ -119,13 +119,25 @@ variable "performance_insights_enabled" {
 variable "performance_insights_retention_period" {
   description = "Amount of time, in days, (minimum 7, maximum 731, or any multiple of 31) to retain performance insights data."
   type        = number
-  default     = 31
+  default     = 7
 }
 
 variable "database_insights_mode" {
   description = "The mode of Database Insights that is enabled for the instance. Valid values: standard, advanced."
   type        = string
   default     = "standard"
+}
+
+variable "monitoring_role_arn" {
+  description = "The ARN for the IAM role that permits RDS to send metrics to CloudWatch Logs."
+  type        = string
+  default     = null
+}
+
+variable "monitoring_interval" {
+  description = "The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. Default is 60 seconds."
+  type        = number
+  default     = 0 # 0 completely disables Enhanced Monitoring
 }
 
 variable "instance_identifiers" {


### PR DESCRIPTION
## What:
- Enabled Enhanced Monitoring at a 60-second logging frequency and created a dedicated IAM role `(rds-enhanced-monitoring-role)` in prod to authorise OS metric delivery to CloudWatch Logs.
- Disabled `performance_insights_enabled` across Flagsmith database instances in dev and staging to clean up unnecessary telemetry.


## Why:
Production Observability: We need long-term historical performance trends, SQL execution plans, and OS process analytics to troubleshoot live application issues and manage traffic scaling.
Cost Efficiency: Non-production environments do not require advanced diagnostic history or active tracing. Turning off Performance Insights in Dev/Staging prevents waste.

## Ticket:
BAU

## Risk:
**Risk level:** 🟢 

**Reason for rating:**
Activating these settings triggers a zero-downtime, rolling modification at the AWS API level. No database restart or connection drop will occur. 
Non-production environments will immediately stop recording Performance Insight active session histories, which has zero functional impact on application code execution.
