### PR TITLE
refactor: add all subdomains as SANs to the main certificate

### DIFF
--- a/environments/development/common/acm.tf
+++ b/environments/development/common/acm.tf
@@ -3,8 +3,22 @@ module "acm" {
   domain_name    = var.domain_name
   environment    = var.environment
   hosted_zone_id = data.aws_route53_zone.this.zone_id
+
   subject_alternative_names = [
+    "admin.${var.domain_name}",
+    "api.${var.domain_name}",
     "auth.id.${var.domain_name}",
+    "docs.${var.domain_name}",
+    "dumps.${var.domain_name}",
+    "eval.${var.domain_name}",
+    "examples.${var.domain_name}",
+    "flags-edge.${var.domain_name}",
+    "flags.${var.domain_name}",
+    "hub.${var.domain_name}",
+    "id.${var.domain_name}",
+    "mcp.${var.domain_name}",
+    "reporting.${var.domain_name}",
+    "search.${var.domain_name}"
   ]
 
   providers = {

--- a/environments/production/common/.terraform.lock.hcl
+++ b/environments/production/common/.terraform.lock.hcl
@@ -27,6 +27,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "6.56.0"
   constraints = ">= 6.0.0, >= 6.28.0, >= 6.37.0, >= 6.42.0"
   hashes = [
+    "h1:VAJZ8Z7LhSf7+LNNgYWB2V7Fd/WFxMbJ4hTdxf5Tf8I=",
     "h1:gSTd4VOv0lEjCGP5deZ4hRMBZhIOUbtS4AlCML+3gIo=",
     "zh:2b3fbb3bebcc663b85d5fd9bbc2d131ab89322d696ff5c6ac6b7ffb7b5fe92e7",
     "zh:30e56ccc7f33a7778ab323a28fe893d8e9200dc5fb92ccb7023bee808db3c1b0",
@@ -167,6 +168,7 @@ provider "registry.terraform.io/newrelic/newrelic" {
   constraints = ">= 3.78.0"
   hashes = [
     "h1:7RNshwNrgEzUSFiu/Q7+G6wj2YBXagRnixGqcFNF/sQ=",
+    "h1:cltvFBBibRc13wWDF2rVLusk0pxwllbdbtzJlYMgbB0=",
     "zh:118cf4b320b8cc2adc9e4ac72e1bc3cfdf31c2a4fccda253ce73ace72385dcf7",
     "zh:1e108de8200bedab01e2d338d1b0e35841e1d42b229c3c94df50b85b875fe2fd",
     "zh:2e1dc78916e4aee66e5730735176132e37005f1bc7df154155bb7c6683b7e598",

--- a/environments/staging/common/.terraform.lock.hcl
+++ b/environments/staging/common/.terraform.lock.hcl
@@ -163,31 +163,3 @@ provider "registry.terraform.io/hashicorp/tls" {
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }
-
-provider "registry.terraform.io/newrelic/newrelic" {
-  version     = "3.93.1"
-  constraints = ">= 3.78.0"
-  hashes = [
-    "h1:5fyvZAS7mNc1QrMrcD4aezZhedNJfz18GG8xoI5wJvU=",
-    "h1:6NQZslIJrE5+dAwbCMX8SRvW1M7+kqb2dX7ieGnQmic=",
-    "h1:IxtKhjfNamuiYiNSI87swaZifPN3s+YbbllTIdaObFY=",
-    "zh:2e6c67c57a7fbe1cc5fe97019c4a7b3ceb9d463ee47d7a7fb9759ccdcc2b2490",
-    "zh:3d31be6db4d2718af8ef594a9b8b43c4a213732721262105431eb4b071455456",
-    "zh:40c29835f71f19e59bb18a2d17c2af232908a1bcf71652201482ed8799baa7b9",
-    "zh:813a008f8bae24471fc0879404ec47873330e253ba048cb77a13c9425ce18a7b",
-    "zh:86d56c11e4afd6006c49aaa112d6cf0fc921159ae51dafb7adff2bc5776f18b3",
-    "zh:8aeebdaee67c1d1d8cb848d266db72ed89e5c7eaa95aafd4b1a4b997cff40618",
-    "zh:a364f6c18d63c8bf1eacfa35b6b9dbaa30cdbb0bb6bbaed4b89498952f6316ef",
-    "zh:afb115da156a5fadd7ed57324c92711482c82f6dafae890a03f00bc3e96fdea3",
-    "zh:b0b698159c003c4ac2a96c992ce66cb6efff30e019c420482fa76613591dd2cd",
-    "zh:b610d39eb0c45c797082dfd8954190815626cd8b7bdc12cecb53780bfd0c1b3f",
-    "zh:b847dfe7b635253264ed69794d436b8d7a41c4bf442d8cb929f369f9a5d2c721",
-    "zh:cdd455e5e4529eea6150210b59145939c731ee38043dcb47321fe61c44f7098e",
-    "zh:ea91aff62b53c9ae724f4d2634b375e6bccb8600fbca712ea47f739fb0de5d96",
-    "zh:ead8a2258746a379e40f8dd2094981012281bd0b5f6c6a5bf95c6d32688ce0a5",
-    "zh:eec98b37c679ab1ac4b272c093b6233a5ba7d005f0813ca46dde9b25cd0f52f7",
-    "zh:ef92cd068340514476f4e347019e2e90591dd12e977543bef37f91f74f5c6a6b",
-    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
-    "zh:ff4dcf8ba47a6501e19a4b69648421f5f208f566505aa0d7322caee93cefe065",
-  ]
-}

--- a/environments/staging/common/acm.tf
+++ b/environments/staging/common/acm.tf
@@ -3,8 +3,22 @@ module "acm" {
   domain_name    = var.domain_name
   environment    = var.environment
   hosted_zone_id = data.aws_route53_zone.this.zone_id
+
   subject_alternative_names = [
+    "admin.${var.domain_name}",
+    "api.${var.domain_name}",
     "auth.id.${var.domain_name}",
+    "docs.${var.domain_name}",
+    "dumps.${var.domain_name}",
+    "eval.${var.domain_name}",
+    "examples.${var.domain_name}",
+    "flags-edge.${var.domain_name}",
+    "flags.${var.domain_name}",
+    "hub.${var.domain_name}",
+    "id.${var.domain_name}",
+    "mcp.${var.domain_name}",
+    "reporting.${var.domain_name}",
+    "search.${var.domain_name}"
   ]
 
   providers = {


### PR DESCRIPTION
## What:

- Add all used subdomains as SANs to the main SSL certificate.

## Why:

- The last pentest identified that we should remove the wildcard certificate and cover only the subdomains that we use.

## Ticket:

[HMRC-2576](https://transformuk.atlassian.net/browse/HMRC-2576)

## Risk:
**Risk level:** 🟢

**Reason for rating:**

Adds all our subdomains to the current wildcard certificate. This does not remove the wildcard or alter the current SSL certificate in any other way.
