### PR TITLE
Fix\: replace the Principal.Service value in RDS IAM role

### DIFF
--- a/environments/production/common/iam-roles.tf
+++ b/environments/production/common/iam-roles.tf
@@ -475,7 +475,7 @@ resource "aws_iam_role" "rds_enhanced_monitoring" {
         Action = "sts:AssumeRole"
         Effect = "Allow"
         Principal = {
-          Service = "://amazonaws.com"
+          Service = "monitoring.rds.amazonaws.com"
         }
       }
     ]


### PR DESCRIPTION
## What:
Replaced he Principal.Service value in RDS IAM role `://amazonaws.com` with `monitoring.rds.amazonaws.com`

## Why:
It was incorrect config

## Ticket:
BAU

## Risk:
**Risk level:** 🟢 

**Reason for rating:**
