### PR TITLE
HMRC-2529: Migrate ip rate based rule

### DIFF
--- a/modules/waf/README.md
+++ b/modules/waf/README.md
@@ -25,12 +25,14 @@ No modules.
 | [aws_wafv2_regex_pattern_set.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_regex_pattern_set) | resource |
 | [aws_wafv2_web_acl.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl) | resource |
 | [aws_wafv2_web_acl_association.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_association) | resource |
+| [aws_wafv2_web_acl_rule.allow_assets_from_rate_limit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_rule) | resource |
 | [aws_wafv2_web_acl_rule.allow_bot_control_excluded_paths](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_rule) | resource |
 | [aws_wafv2_web_acl_rule.bot_control](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_rule) | resource |
 | [aws_wafv2_web_acl_rule.filtered_header](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_rule) | resource |
 | [aws_wafv2_web_acl_rule.group_rules](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_rule) | resource |
 | [aws_wafv2_web_acl_rule.header_allow](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_rule) | resource |
 | [aws_wafv2_web_acl_rule.host_path_allow](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_rule) | resource |
+| [aws_wafv2_web_acl_rule.ip_rate_based](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_rule) | resource |
 | [aws_wafv2_web_acl_rule.ip_rate_url_based](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_rule) | resource |
 | [aws_wafv2_web_acl_rule.ip_sets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_rule) | resource |
 | [aws_wafv2_web_acl_rule.managed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/wafv2_web_acl_rule) | resource |

--- a/modules/waf/main.tf
+++ b/modules/waf/main.tf
@@ -41,81 +41,6 @@ resource "aws_wafv2_web_acl" "this" {
     metric_name                = var.name
   }
 
-  # ---------------------------------------------------------------------
-  # NOTE: Because `ignore_changes = [rule]` applies to the entire Web ACL
-  # rule list, this inline rule is effectively unmanaged by Terraform.
-  # Changes to this block will not be applied until the rule is migrated to
-  # a standalone `aws_wafv2_web_acl_rule` resource (HMRC-2529).
-
-  # Do not remove `ignore_changes` without first reviewing the Terraform
-  # plan, as other rules in this Web ACL are now managed via standalone
-  # resources.
-  # ---------------------------------------------------------------------
-
-  dynamic "rule" {
-    for_each = var.ip_rate_based_rule != null ? [var.ip_rate_based_rule] : []
-    content {
-      name     = rule.value.name
-      priority = rule.value.priority
-
-      action {
-        dynamic "count" {
-          for_each = rule.value.action == "count" ? [1] : []
-          content {
-            # Nothing to do, these go into Cloudwatch
-          }
-        }
-
-        dynamic "block" {
-          for_each = rule.value.action == "block" ? [1] : []
-          content {
-            custom_response {
-              custom_response_body_key = rule.value.custom_response.body_key
-              response_code            = rule.value.custom_response.response_code
-              response_header {
-                name  = rule.value.custom_response.response_header.name
-                value = rule.value.custom_response.response_header.value
-              }
-            }
-          }
-        }
-
-      }
-
-      statement {
-        rate_based_statement {
-          limit                 = rule.value.rpm_limit
-          evaluation_window_sec = 60
-          aggregate_key_type    = "IP"
-
-          # NOTE: This block will exclude assets from the rate limiting rules since these are all cached in the CDN.
-          scope_down_statement {
-            not_statement {
-              statement {
-                regex_pattern_set_reference_statement {
-                  arn = aws_wafv2_regex_pattern_set.this.arn
-                  field_to_match {
-                    uri_path {}
-                  }
-                  text_transformation {
-                    priority = 0
-                    type     = "LOWERCASE"
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-
-      visibility_config {
-        cloudwatch_metrics_enabled = true
-        metric_name                = rule.value.name
-        sampled_requests_enabled   = true
-      }
-    }
-  }
-
   # Do NOT remove - required permanently as long as any rule is managed
   # via a standalone aws_wafv2_web_acl_rule resource (see HMRC-2529).
   # Removing this without first re-adding matching inline `rule` blocks
@@ -158,6 +83,82 @@ resource "aws_wafv2_web_acl_association" "this" {
 # attempting to delete and recreate rules unnecessarily when the Web ACL
 # is updated.
 # ---------------------------------------------------------------------
+
+resource "aws_wafv2_web_acl_rule" "allow_assets_from_rate_limit" {
+  for_each = var.ip_rate_based_rule != null ? { "allow-assets-from-rate-limit" = var.ip_rate_based_rule } : {}
+
+  web_acl_arn = aws_wafv2_web_acl.this.arn
+  name        = "allow-assets-from-rate-limit"
+  priority    = each.value.priority - 1
+
+  action {
+    allow {}
+  }
+
+  statement {
+    regex_pattern_set_reference_statement {
+      arn = aws_wafv2_regex_pattern_set.this.arn
+      field_to_match {
+        uri_path {}
+      }
+      text_transformation {
+        priority = 0
+        type     = "LOWERCASE"
+      }
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "allow-assets-from-rate-limit"
+    sampled_requests_enabled   = true
+  }
+}
+
+resource "aws_wafv2_web_acl_rule" "ip_rate_based" {
+  for_each = var.ip_rate_based_rule != null ? { (var.ip_rate_based_rule.name) = var.ip_rate_based_rule } : {}
+
+  web_acl_arn = aws_wafv2_web_acl.this.arn
+  name        = each.value.name
+  priority    = each.value.priority
+
+  action {
+    dynamic "count" {
+      for_each = each.value.action == "count" ? [1] : []
+      content {}
+    }
+
+    dynamic "block" {
+      for_each = each.value.action == "block" ? [1] : []
+      content {
+        custom_response {
+          custom_response_body_key = each.value.custom_response.body_key
+          response_code            = each.value.custom_response.response_code
+          response_header {
+            name  = each.value.custom_response.response_header.name
+            value = each.value.custom_response.response_header.value
+          }
+        }
+      }
+    }
+  }
+
+  statement {
+    rate_based_statement {
+      limit                 = each.value.rpm_limit
+      evaluation_window_sec = 60
+      aggregate_key_type    = "IP"
+      # scope_down_statement removed - asset exclusion now handled by
+      # allow_assets_from_rate_limit above instead of a not_statement here.
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = each.value.name
+    sampled_requests_enabled   = true
+  }
+}
 
 resource "aws_wafv2_web_acl_rule" "ip_sets" {
   for_each = { for r in var.ip_sets_rule : r.name => r }

--- a/modules/waf/tests/ip_rate_based.tftest.hcl
+++ b/modules/waf/tests/ip_rate_based.tftest.hcl
@@ -1,0 +1,51 @@
+mock_provider "aws" {}
+
+run "allow_assets_from_rate_limit_created_at_priority_0" {
+  command = apply
+
+  override_resource {
+    target = aws_wafv2_regex_pattern_set.this
+
+    values = {
+      arn = "arn:aws:wafv2:us-east-1:123456789012:global/regexpatternset/test-waf/12345678-abcd-1234-abcd-123456789012"
+    }
+  }
+
+  variables {
+    name  = "test-waf"
+    scope = "CLOUDFRONT"
+
+    ip_rate_based_rule = {
+      name      = "ratelimiting"
+      priority  = 1
+      rpm_limit = 500
+      action    = "block"
+
+      custom_response = {
+        response_code = 429
+        body_key      = "rate-limit-exceeded"
+
+        response_header = {
+          name  = "X-Rate-Limit"
+          value = "1"
+        }
+      }
+    }
+  }
+
+  assert {
+    condition     = aws_wafv2_web_acl_rule.allow_assets_from_rate_limit["allow-assets-from-rate-limit"].priority == 0
+    error_message = "allow-assets rule priority should be ip_rate_based_rule.priority - 1 (1 - 1 = 0)"
+  }
+
+  assert {
+    condition     = length(aws_wafv2_web_acl_rule.allow_assets_from_rate_limit["allow-assets-from-rate-limit"].action[0].allow) == 1
+    error_message = "allow-assets rule action must be allow"
+  }
+
+  assert {
+    condition = aws_wafv2_web_acl_rule.allow_assets_from_rate_limit["allow-assets-from-rate-limit"].statement[0].regex_pattern_set_reference_statement[0].arn == aws_wafv2_regex_pattern_set.this.arn
+
+    error_message = "allow-assets rule must reference the shared asset regex pattern set"
+  }
+}

--- a/modules/waf/variables.tf
+++ b/modules/waf/variables.tf
@@ -106,6 +106,11 @@ variable "ip_rate_based_rule" {
   })
   description = "A rate-based rule tracks the rate of requests for each originating IP address, and triggers the rule action when the rate exceeds a limit that you specify on the number of requests in any 5-minute time span"
   default     = null
+
+  validation {
+    condition     = var.ip_rate_based_rule == null || var.ip_rate_based_rule.priority >= 1
+    error_message = "ip_rate_based_rule.priority must be >= 1, since allow_assets_from_rate_limit reserves priority - 1 immediately ahead of it."
+  }
 }
 
 variable "ip_rate_url_based_rules" {


### PR DESCRIPTION
## What:
- Migrated `ip_rate_based_rule` from an inline rule block to a standalone `aws_wafv2_web_acl_rule` resource.
- Replaced its `not_statement-based` asset exclusion (unsupported by the standalone resource's `rate_based_statement.scope_down_statement)` with a separate `allow_assets_from_rate_limit` rule, computed at `priority = ip_rate_based_rule.priority - 1.`
- Added terraform test coverage for both rules, including the priority invariant and the priority >= 1 validation guard.

## Why:
Same rationale as the rest of the migration: the inline rule set produced noisy, opaque plan diffs on unrelated PRs. This is the last remaining rule family that was left inline; the ACL no longer has any inline rules, and `ignore_changes = [rule] `on the parent ACL now applies without exception.

## Ticket:
[HMRC-2529](https://transformuk.atlassian.net/browse/HMRC-2529)

## Risk:
**Risk level:**  🟠 

**Reason for rating:**

- allow_assets_from_rate_limit's allow action terminates ACL evaluation for matching requests. Because it now sits near the top of the priority order, asset paths bypass rate limiting and every other rule with a higher priority number (managed rule groups, SQLi, Bot Control, etc.), not just rate limiting as before. Team explicitly accepted this wider exclusion scope as a reasonable tradeoff for cached, static asset paths.