### PR TITLE
Fix: Move Enhanced Monitoring configuration to Aurora cluster instances

### DIFF
--- a/modules/rds_cluster/main.tf
+++ b/modules/rds_cluster/main.tf
@@ -44,8 +44,6 @@ resource "aws_rds_cluster" "this" {
   performance_insights_retention_period = var.performance_insights_enabled ? var.performance_insights_retention_period : null
   performance_insights_kms_key_id       = var.performance_insights_enabled ? try(aws_kms_key.this[0].arn, var.kms_key_id) : null
   database_insights_mode                = var.database_insights_mode
-  monitoring_interval                   = var.monitoring_interval
-  monitoring_role_arn                   = var.monitoring_role_arn
 
   tags = var.tags
 }
@@ -60,6 +58,9 @@ resource "aws_rds_cluster_instance" "this" {
   db_subnet_group_name = var.create_subnet_group ? aws_db_subnet_group.rds_private_subnet[0].name : var.db_subnet_group_name
 
   instance_class = var.instance_class
+
+  monitoring_interval = var.monitoring_interval
+  monitoring_role_arn = var.monitoring_role_arn
 
   auto_minor_version_upgrade = true
   # apply db modifications during maintenance windows only


### PR DESCRIPTION
## What:
Move the Enhanced Monitoring configuration `(monitoring_interval` and `monitoring_role_arn)` from the Aurora cluster resource to the Aurora cluster instance resource.

## Why:
AWS rejects instance updates when MonitoringInterval is configured at the cluster level, returning:
`InvalidParameterCombination: MonitoringInterval conflicts with cluster level parameter.`

Managing these settings on the cluster instances aligns the Terraform configuration with the RDS API behaviour and prevents unrelated instance updates from failing.

## Ticket:
<!-- Link to the relevant Jira/ticket, or 'N/A' if not applicable -->

## Risk:
**Risk level:** 🟢 

**Reason for rating:**
This change only moves where Terraform manages the Enhanced Monitoring configuration. It does not change the monitoring interval, IAM role, or database configuration, and should not require a restart or cause downtime.
