### PR TITLE
HMRC-2584: Update the `high_5xx_codes` and `long_response_times` CloudWatch alarms

### DIFF
--- a/environments/production/common/slack-notify.tf
+++ b/environments/production/common/slack-notify.tf
@@ -31,8 +31,7 @@ module "notify_slack_observability" {
 }
 
 locals {
-  alert_actions               = var.enable_sns_alerts ? [module.notify_slack.slack_topic_arn] : []
-  observability_alert_actions = var.enable_sns_alerts ? [module.notify_slack_observability.slack_topic_arn] : []
+  alert_actions = var.enable_sns_alerts ? [module.notify_slack.slack_topic_arn] : []
 }
 
 resource "aws_cloudwatch_metric_alarm" "high_5xx_codes" {
@@ -50,8 +49,8 @@ resource "aws_cloudwatch_metric_alarm" "high_5xx_codes" {
   alarm_description   = "Too many HTTP 5xx errors in ${var.environment} environment for target group ${each.value.name}"
   treat_missing_data  = "notBreaching"
 
-  alarm_actions = local.observability_alert_actions
-  ok_actions    = local.observability_alert_actions
+  alarm_actions = local.alert_actions
+  ok_actions    = local.alert_actions
 
   dimensions = {
     LoadBalancer = module.alb.arn_suffix
@@ -74,8 +73,8 @@ resource "aws_cloudwatch_metric_alarm" "long_response_times" {
   alarm_description   = "Long response times in ${var.environment} environment for target group ${each.value.name}"
   treat_missing_data  = "notBreaching"
 
-  alarm_actions = local.observability_alert_actions
-  ok_actions    = local.observability_alert_actions
+  alarm_actions = local.alert_actions
+  ok_actions    = local.alert_actions
 
   dimensions = {
     LoadBalancer = module.alb.arn_suffix


### PR DESCRIPTION
## What:
Update the `high_5xx_codes` and `long_response_times` CloudWatch alarms in production to route notifications to `#production-alerts` instead of `#production-observability` for both `alarm_actions` and `ok_actions.`

## Why:
These alarms represent active user impact and align with the Notification Guidelines requirement that production-impacting issues alert in `#production-alerts.` High 5xx error rates and sustained latency breaches require immediate operational awareness and response.

## Ticket:
[HMRC-2584](https://transformuk.atlassian.net/browse/HMRC-2584)

## Risk:
**Risk level:** 🟢 

**Reason for rating:**
This change only updates SNS/Slack notification routing for existing CloudWatch alarms. No changes to alarm logic, thresholds, infrastructure, or application behaviour. The risk is limited to alert destination changes, ensuring affected teams receive notifications in the correct channel.