### PR TITLE
HMRC-2586: Remove apigw_cache_hit_ratio CW alarm

### DIFF
--- a/environments/development/common/slack-notify.tf
+++ b/environments/development/common/slack-notify.tf
@@ -204,58 +204,6 @@ resource "aws_cloudwatch_metric_alarm" "apigw_p99_latency" {
   }
 }
 
-resource "aws_cloudwatch_metric_alarm" "apigw_cache_hit_ratio" {
-  count               = var.environment == "production" ? 1 : 0
-  alarm_name          = "cache-hit-ratio-${module.gateway.rest_api_name}"
-  alarm_description   = "Cache hit ratio < 50% for 15 minutes"
-  comparison_operator = "LessThanThreshold"
-  threshold           = 50
-  evaluation_periods  = 15
-  datapoints_to_alarm = 15
-  treat_missing_data  = "breaching"
-  alarm_actions       = local.alert_actions
-  ok_actions          = local.alert_actions
-
-  metric_query {
-    id = "hits"
-
-    metric {
-      namespace   = "AWS/ApiGateway"
-      metric_name = "CacheHitCount"
-      period      = 60
-      stat        = "Sum"
-
-      dimensions = {
-        ApiName = module.gateway.rest_api_name
-        Stage   = module.gateway.stage_name
-      }
-    }
-  }
-
-  metric_query {
-    id = "misses"
-
-    metric {
-      namespace   = "AWS/ApiGateway"
-      metric_name = "CacheMissCount"
-      period      = 60
-      stat        = "Sum"
-
-      dimensions = {
-        ApiName = module.gateway.rest_api_name
-        Stage   = module.gateway.stage_name
-      }
-    }
-  }
-
-  metric_query {
-    id          = "hit_ratio"
-    expression  = "(hits / (hits + misses)) * 100"
-    label       = "Cache Hit Ratio"
-    return_data = true
-  }
-}
-
 # Alarms for Valkey clusters
 resource "aws_cloudwatch_metric_alarm" "valkey_memory_usage" {
   for_each = local.valkey

--- a/environments/staging/common/slack-notify.tf
+++ b/environments/staging/common/slack-notify.tf
@@ -204,58 +204,6 @@ resource "aws_cloudwatch_metric_alarm" "apigw_p99_latency" {
   }
 }
 
-resource "aws_cloudwatch_metric_alarm" "apigw_cache_hit_ratio" {
-  count               = var.environment == "production" ? 1 : 0
-  alarm_name          = "cache-hit-ratio-${module.gateway.rest_api_name}"
-  alarm_description   = "Cache hit ratio < 50% for 15 minutes"
-  comparison_operator = "LessThanThreshold"
-  threshold           = 50
-  evaluation_periods  = 15
-  datapoints_to_alarm = 15
-  treat_missing_data  = "breaching"
-  alarm_actions       = local.alert_actions
-  ok_actions          = local.alert_actions
-
-  metric_query {
-    id = "hits"
-
-    metric {
-      namespace   = "AWS/ApiGateway"
-      metric_name = "CacheHitCount"
-      period      = 60
-      stat        = "Sum"
-
-      dimensions = {
-        ApiName = module.gateway.rest_api_name
-        Stage   = module.gateway.stage_name
-      }
-    }
-  }
-
-  metric_query {
-    id = "misses"
-
-    metric {
-      namespace   = "AWS/ApiGateway"
-      metric_name = "CacheMissCount"
-      period      = 60
-      stat        = "Sum"
-
-      dimensions = {
-        ApiName = module.gateway.rest_api_name
-        Stage   = module.gateway.stage_name
-      }
-    }
-  }
-
-  metric_query {
-    id          = "hit_ratio"
-    expression  = "(hits / (hits + misses)) * 100"
-    label       = "Cache Hit Ratio"
-    return_data = true
-  }
-}
-
 # Alarms for Valkey clusters
 resource "aws_cloudwatch_metric_alarm" "valkey_memory_usage" {
   for_each = local.valkey


### PR DESCRIPTION
## What:

- Removed the unused `apigw_cache_hit_ratio` CloudWatch alarm definition from staging and development environments.
- Choose to delete the dormant alarm configuration rather than deploying it to production.

## Why:

- The alarm has never been deployed in any environment.
- Cache hit ratio is not clearly actionable and may legitimately fluctuate due to cache warm-up, cache flushes, or traffic pattern changes.
- The alert currently has no documented owner, runbook, or operational response.
- Avoids introducing a potentially noisy production alert without a clear remediation path.

## Ticket:
[<HMRC-2586](https://transformuk.atlassian.net/browse/HMRC-2586)

## Risk:
**Risk level:** 🟢 

**Reason for rating:**

- No active infrastructure or monitoring is being modified.
- Removes dead Terraform configuration only.
- No impact on production workloads or existing alerting.
