### PR TITLE
HMRC-2587: Remove OK notifications from CW alarms

### DIFF
--- a/environments/development/common/slack-notify.tf
+++ b/environments/development/common/slack-notify.tf
@@ -35,7 +35,6 @@ resource "aws_cloudwatch_metric_alarm" "high_5xx_codes" {
   treat_missing_data  = "notBreaching"
 
   alarm_actions = local.alert_actions
-  ok_actions    = local.alert_actions
 
   dimensions = {
     LoadBalancer = module.alb.arn_suffix
@@ -59,7 +58,7 @@ resource "aws_cloudwatch_metric_alarm" "long_response_times" {
   treat_missing_data  = "notBreaching"
 
   alarm_actions = local.alert_actions
-  ok_actions    = local.alert_actions
+
 
   dimensions = {
     LoadBalancer = module.alb.arn_suffix
@@ -90,7 +89,7 @@ resource "aws_cloudwatch_metric_alarm" "lambds_errors" {
   treat_missing_data  = "notBreaching"
 
   alarm_actions = local.alert_actions
-  ok_actions    = local.alert_actions
+
 
   dimensions = {
     FunctionName = each.value
@@ -124,7 +123,6 @@ resource "aws_cloudwatch_metric_alarm" "slack_notify_self_monitor" {
   }
 
   alarm_actions = var.enable_sns_alerts ? [aws_sns_topic.critical_email_alerts.arn] : []
-  ok_actions    = var.enable_sns_alerts ? [aws_sns_topic.critical_email_alerts.arn] : []
 }
 
 #----------------------------------------------------------#
@@ -139,7 +137,6 @@ resource "aws_cloudwatch_metric_alarm" "apigw_5xx_error_rate" {
   datapoints_to_alarm = 5
   treat_missing_data  = "notBreaching"
   alarm_actions       = local.alert_actions
-  ok_actions          = local.alert_actions
 
   metric_query {
     id          = "errors"
@@ -190,7 +187,7 @@ resource "aws_cloudwatch_metric_alarm" "apigw_p99_latency" {
   datapoints_to_alarm = 5
   treat_missing_data  = "notBreaching"
   alarm_actions       = local.alert_actions
-  ok_actions          = local.alert_actions
+
 
   metric_name        = "Latency"
   namespace          = "AWS/ApiGateway"
@@ -218,7 +215,7 @@ resource "aws_cloudwatch_metric_alarm" "valkey_memory_usage" {
   datapoints_to_alarm = 5
   treat_missing_data  = "notBreaching"
   alarm_actions       = local.alert_actions
-  ok_actions          = local.alert_actions
+
 
   metric_name = "DatabaseMemoryUsagePercentage"
   namespace   = "AWS/Elasticache"

--- a/environments/production/common/slack-notify.tf
+++ b/environments/production/common/slack-notify.tf
@@ -50,7 +50,7 @@ resource "aws_cloudwatch_metric_alarm" "high_5xx_codes" {
   treat_missing_data  = "notBreaching"
 
   alarm_actions = local.alert_actions
-  ok_actions    = local.alert_actions
+
 
   dimensions = {
     LoadBalancer = module.alb.arn_suffix
@@ -74,7 +74,7 @@ resource "aws_cloudwatch_metric_alarm" "long_response_times" {
   treat_missing_data  = "notBreaching"
 
   alarm_actions = local.alert_actions
-  ok_actions    = local.alert_actions
+
 
   dimensions = {
     LoadBalancer = module.alb.arn_suffix
@@ -105,7 +105,7 @@ resource "aws_cloudwatch_metric_alarm" "lambds_errors" {
   treat_missing_data  = "notBreaching"
 
   alarm_actions = local.alert_actions
-  ok_actions    = local.alert_actions
+
 
   dimensions = {
     FunctionName = each.value
@@ -139,7 +139,6 @@ resource "aws_cloudwatch_metric_alarm" "slack_notify_self_monitor" {
   }
 
   alarm_actions = var.enable_sns_alerts ? [aws_sns_topic.critical_email_alerts.arn] : []
-  ok_actions    = var.enable_sns_alerts ? [aws_sns_topic.critical_email_alerts.arn] : []
 }
 
 #----------------------------------------------------------#
@@ -154,7 +153,7 @@ resource "aws_cloudwatch_metric_alarm" "apigw_5xx_error_rate" {
   datapoints_to_alarm = 5
   treat_missing_data  = "notBreaching"
   alarm_actions       = local.alert_actions
-  ok_actions          = local.alert_actions
+
 
   metric_query {
     id          = "errors"
@@ -205,7 +204,7 @@ resource "aws_cloudwatch_metric_alarm" "apigw_p99_latency" {
   datapoints_to_alarm = 5
   treat_missing_data  = "notBreaching"
   alarm_actions       = local.alert_actions
-  ok_actions          = local.alert_actions
+
 
   metric_name        = "Latency"
   namespace          = "AWS/ApiGateway"
@@ -234,7 +233,7 @@ resource "aws_cloudwatch_metric_alarm" "valkey_memory_usage" {
   datapoints_to_alarm = 5
   treat_missing_data  = "notBreaching"
   alarm_actions       = local.alert_actions
-  ok_actions          = local.alert_actions
+
 
   metric_name = "DatabaseMemoryUsagePercentage"
   namespace   = "AWS/Elasticache"

--- a/environments/staging/common/slack-notify.tf
+++ b/environments/staging/common/slack-notify.tf
@@ -35,7 +35,7 @@ resource "aws_cloudwatch_metric_alarm" "high_5xx_codes" {
   treat_missing_data  = "notBreaching"
 
   alarm_actions = local.alert_actions
-  ok_actions    = local.alert_actions
+
 
   dimensions = {
     LoadBalancer = module.alb.arn_suffix
@@ -59,7 +59,7 @@ resource "aws_cloudwatch_metric_alarm" "long_response_times" {
   treat_missing_data  = "notBreaching"
 
   alarm_actions = local.alert_actions
-  ok_actions    = local.alert_actions
+
 
   dimensions = {
     LoadBalancer = module.alb.arn_suffix
@@ -90,7 +90,7 @@ resource "aws_cloudwatch_metric_alarm" "lambds_errors" {
   treat_missing_data  = "notBreaching"
 
   alarm_actions = local.alert_actions
-  ok_actions    = local.alert_actions
+
 
   dimensions = {
     FunctionName = each.value
@@ -124,7 +124,6 @@ resource "aws_cloudwatch_metric_alarm" "slack_notify_self_monitor" {
   }
 
   alarm_actions = var.enable_sns_alerts ? [aws_sns_topic.critical_email_alerts.arn] : []
-  ok_actions    = var.enable_sns_alerts ? [aws_sns_topic.critical_email_alerts.arn] : []
 }
 
 #----------------------------------------------------------#
@@ -139,7 +138,7 @@ resource "aws_cloudwatch_metric_alarm" "apigw_5xx_error_rate" {
   datapoints_to_alarm = 5
   treat_missing_data  = "notBreaching"
   alarm_actions       = local.alert_actions
-  ok_actions          = local.alert_actions
+
 
   metric_query {
     id          = "errors"
@@ -190,7 +189,7 @@ resource "aws_cloudwatch_metric_alarm" "apigw_p99_latency" {
   datapoints_to_alarm = 5
   treat_missing_data  = "notBreaching"
   alarm_actions       = local.alert_actions
-  ok_actions          = local.alert_actions
+
 
   metric_name        = "Latency"
   namespace          = "AWS/ApiGateway"
@@ -218,7 +217,7 @@ resource "aws_cloudwatch_metric_alarm" "valkey_memory_usage" {
   datapoints_to_alarm = 5
   treat_missing_data  = "notBreaching"
   alarm_actions       = local.alert_actions
-  ok_actions          = local.alert_actions
+
 
   metric_name = "DatabaseMemoryUsagePercentage"
   namespace   = "AWS/Elasticache"


### PR DESCRIPTION
## What:
Removed `ok_actions` from the following CloudWatch alarms across all three environments (dev, staging and production):
- high_5xx_codes
- long_response_times
- lambda_errors
- slack_notify_self_monitor
- apigw_5xx_error_rate
- apigw_p99_latency
- valkey_memory_usage

Alarm notifications (`alarm_actions`) remain unchanged.

## Why:

- These alarms are threshold-based observability signals that frequently recover without intervention. Sending OK notifications to the same Slack channels as alarm notifications generates unnecessary noise and contributes to alert fatigue.
- Recovery status remains available through CloudWatch and New Relic, while alert channels will contain fewer non-actionable messages.
- This aligns with the notification guidelines to avoid notifications for conditions that self-resolve before action is required.

## Ticket:
[HMRC-2587](https://transformuk.atlassian.net/browse/HMRC-2587)

## Risk:
**Risk level:** 🟢 

**Reason for rating:**

- No changes to alarm thresholds, metrics, or alert triggering behaviour.
- Alarms will continue to notify when entering the ALARM state.
- Only OK state notifications are removed.
- Monitoring coverage and incident detection remain unchanged.