### PR TITLE
Split staging alerting: mute Slack noise, keep critical-email live

### DIFF
--- a/environments/staging/common/slack-notify.tf
+++ b/environments/staging/common/slack-notify.tf
@@ -16,7 +16,8 @@ module "notify_slack" {
 }
 
 locals {
-  alert_actions = var.enable_sns_alerts ? [module.notify_slack.slack_topic_arn] : []
+  alert_actions          = var.enable_slack_alerts ? [module.notify_slack.slack_topic_arn] : []
+  critical_alert_actions = var.enable_critical_alerts ? [aws_sns_topic.critical_email_alerts.arn] : []
 }
 
 resource "aws_cloudwatch_metric_alarm" "high_5xx_codes" {
@@ -123,7 +124,7 @@ resource "aws_cloudwatch_metric_alarm" "slack_notify_self_monitor" {
     FunctionName = "notify_slack_${var.environment}"
   }
 
-  alarm_actions = var.enable_sns_alerts ? [aws_sns_topic.critical_email_alerts.arn] : []
+  alarm_actions = local.critical_alert_actions
 }
 
 #----------------------------------------------------------#
@@ -216,7 +217,7 @@ resource "aws_cloudwatch_metric_alarm" "valkey_memory_usage" {
   evaluation_periods  = 5
   datapoints_to_alarm = 5
   treat_missing_data  = "notBreaching"
-  alarm_actions       = local.alert_actions
+  alarm_actions       = local.critical_alert_actions
 
 
   metric_name = "DatabaseMemoryUsagePercentage"

--- a/environments/staging/common/variables.tf
+++ b/environments/staging/common/variables.tf
@@ -36,8 +36,14 @@ variable "WAF_E2E_SECRET_TOKEN" {
   default     = ""
 }
 
-variable "enable_sns_alerts" {
-  description = "Enable SNS alerts for all CloudWatch alarms"
+variable "enable_slack_alerts" {
+  description = "Enable Slack notifications for request-path CloudWatch alarms (5xx, latency, Lambda errors)"
+  type        = bool
+  default     = false
+}
+
+variable "enable_critical_alerts" {
+  description = "Enable critical-email notifications for alarms that protect the alerting pipeline and data-tier resources (slack_notify self-monitor, Valkey memory)"
   type        = bool
   default     = true
 }


### PR DESCRIPTION
## What:
Splits staging's single `enable_sns_alerts` variable into `enable_slack_alerts` (default `false`) and `enable_critical_alerts` (default `true`). Slack notifications are now muted for the noisy request-path alarms (`high_5xx_codes`, `long_response_times`, `lambds_errors`, `apigw_5xx_error_rate`, `apigw_p99_latency`), while the alerting self-monitor (`slack_notify_self_monitor`) and Valkey memory alarm (`valkey_memory_usage`) keep sending critical-email notifications via the existing `critical_email_alerts` SNS topic.

## Why:
Staging Slack alerts were noisy and not actionable for the team. However, silencing everything wholesale would also blind us to the alerting pipeline itself breaking and to Valkey (Elasticache, a data-tier resource) running out of memory — both of which can affect UAT sign-off. This keeps those two signals live on the critical-email channel while dropping the request-path Slack noise.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Purely additive variable rename/split with safe defaults; `alarm_actions` updates in place on existing CloudWatch alarms with no resource replacement. Scoped to `environments/staging/common` only — dev and production are untouched.