### PR TITLE
Add age-based expiry rule for untagged ECR images

### DIFF
--- a/modules/ecr/ecr.tf
+++ b/modules/ecr/ecr.tf
@@ -49,6 +49,19 @@ resource "aws_ecr_lifecycle_policy" "expire_untagged_images_policy" {
       },
       {
         rulePriority = 2
+        description  = "Expire untagged images older than ${local.untagged_image_expiry_days} days."
+        selection = {
+          tagStatus   = "untagged"
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = local.untagged_image_expiry_days
+        }
+        action = {
+          type = "expire"
+        }
+      },
+      {
+        rulePriority = 3
         description  = "Keep last ${each.value.development_images_to_keep} development images."
         selection = {
           tagStatus   = "any"

--- a/modules/ecr/locals.tf
+++ b/modules/ecr/locals.tf
@@ -24,6 +24,14 @@ locals {
   #
   # The lifecycle policy is just a convenience to disable application lifecycles
   # in an emergency.
+  #
+  # Untagged images are dangling layers/manifests left behind by rebuilds
+  # (e.g. a branch re-pushing "latest") -- they can only be referenced by
+  # digest, not deployed, so pruning them by age is safe regardless of the
+  # count-based rules below. This is a backstop against them accumulating
+  # indefinitely between count-threshold breaches.
+  untagged_image_expiry_days = 14
+
   applications = {
     # Manually deployed typical applications
     "admin" = {


### PR DESCRIPTION
## What:
Adds a third rule to the ECR lifecycle policy (`modules/ecr/ecr.tf`) that expires **untagged** images older than 14 days (`local.untagged_image_expiry_days` in `modules/ecr/locals.tf`), inserted between the existing "keep last N release-tagged images" rule (priority 1) and the "keep last N images of any status" rule (now bumped to priority 3, since AWS ECR requires the single `tagStatus: any` rule to always have the highest `rulePriority`).

## Why:
Untagged images (dangling layers/manifests left behind by rebuilds, e.g. a branch re-pushing the same tag) were previously only pruned once a repo's total image count exceeded the development threshold (30). Low-traffic repos could go a long time without hitting that count, letting genuinely orphaned images linger indefinitely. This adds an age-based backstop so they get cleaned up within 14 days regardless of count.

Checked for the multi-arch caveat (untagged child manifests of a buildx manifest list could otherwise be pruned while still referenced by a live tag): confirmed no multi-arch builds across `identity`, `admin`, `frontend`, `backend`, `dev-hub`, `fpo-search`, `database-backups` — all build via the shared `trade-tariff-tools/.github/actions/build-and-push` composite action.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Adding a CloudWatch/ECR lifecycle rule is additive with a safe default per this repo's own risk guidance, and causes no Terraform resource replacement (in-place policy update). Multi-arch risk ruled out for 8/10 repos via the shared build action; remaining 3 inferred to use the same pipeline.