### PR TITLE
feat(HMRC-2609): add CloudWatch alarm for GOV.UK Notify delivery failures

### DIFF
--- a/environments/production/common/slack-notify.tf
+++ b/environments/production/common/slack-notify.tf
@@ -142,6 +142,29 @@ resource "aws_cloudwatch_metric_alarm" "slack_notify_self_monitor" {
 }
 
 #----------------------------------------------------------#
+# CloudWatch alarms for GOV.UK Notify delivery failures
+#----------------------------------------------------------#
+resource "aws_cloudwatch_metric_alarm" "notify_delivery_failures" {
+  alarm_name          = "notify-delivery-failures-${var.environment}"
+  alarm_description   = "GOV.UK Notify is reporting permanent or technical delivery failures"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "DeliveryFailures"
+  namespace           = "TradeTariff/Notify"
+  period              = 300
+  statistic           = "Sum"
+  threshold           = 0
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    Environment = var.environment
+  }
+
+  alarm_actions = local.alert_actions
+  ok_actions    = local.alert_actions
+}
+
+#----------------------------------------------------------#
 # CloudWatch alarms for API Gateway
 #----------------------------------------------------------#
 resource "aws_cloudwatch_metric_alarm" "apigw_5xx_error_rate" {

--- a/environments/production/common/slack-notify.tf
+++ b/environments/production/common/slack-notify.tf
@@ -161,7 +161,6 @@ resource "aws_cloudwatch_metric_alarm" "notify_delivery_failures" {
   }
 
   alarm_actions = local.alert_actions
-  ok_actions    = local.alert_actions
 }
 
 #----------------------------------------------------------#


### PR DESCRIPTION
## What:
Adds a CloudWatch alarm that fires to `#production-alerts` when GOV.UK Notify reports permanent or technical delivery failures.

- Adds `aws_cloudwatch_metric_alarm.notify_delivery_failures` in `environments/production/common/slack-notify.tf`
- Watches the `TradeTariff/Notify / DeliveryFailures` custom metric, alarming when the 5-minute sum exceeds 0
- `treat_missing_data = notBreaching` keeps the alarm quiet when no Notify status checks are running
- Companion backend PR that emits the metric: [trade-tariff-backend#3633](https://github.com/trade-tariff/trade-tariff-backend/pull/3633)

## Why:
MyOTT subscription emails and Appendix 5a notifications could fail silently at scale. The backend now emits a CloudWatch metric on each permanent or technical failure; this alarm surfaces those failures to the on-call team in `#production-alerts`.

## Ticket:
https://transformuk.atlassian.net/browse/HMRC-2609

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Adds a new CloudWatch alarm only. No resource recreation, no IAM changes, no networking changes. Follows the same pattern as the existing Lambda error alarms.