### PR TITLE
feat(HMRC-2607): add OpenSearch cluster health monitoring

### DIFF
--- a/environments/production/common/new-relic-stream.tf
+++ b/environments/production/common/new-relic-stream.tf
@@ -18,6 +18,7 @@ module "cw_metric_stream" {
   include_metric_filters = {
     "ECS/ContainerInsights" = [],
     "AWS/ECS"               = [],
-    "AWS/RDS"               = []
+    "AWS/RDS"               = [],
+    "AWS/ES"                = []
   }
 }

--- a/environments/production/common/opensearch.tf
+++ b/environments/production/common/opensearch.tf
@@ -82,7 +82,7 @@ module "opensearch" {
 
 resource "aws_cloudwatch_metric_alarm" "opensearch_cluster_red" {
   alarm_name          = "opensearch-cluster-red-${var.environment}"
-  alarm_description   = "OpenSearch cluster status is RED — at least one primary shard is unassigned"
+  alarm_description   = "OpenSearch cluster status is RED in ${var.environment} — at least one primary shard is unassigned. Check: AWS Console → OpenSearch → tariff-search-${var.environment} → Cluster health."
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 1
   metric_name         = "ClusterStatus.red"
@@ -102,7 +102,7 @@ resource "aws_cloudwatch_metric_alarm" "opensearch_cluster_red" {
 
 resource "aws_cloudwatch_metric_alarm" "opensearch_cluster_yellow" {
   alarm_name          = "opensearch-cluster-yellow-${var.environment}"
-  alarm_description   = "OpenSearch cluster status is YELLOW — replica shards unassigned"
+  alarm_description   = "OpenSearch cluster status is YELLOW in ${var.environment} — replica shards unassigned. Check: AWS Console → OpenSearch → tariff-search-${var.environment} → Cluster health."
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 3
   datapoints_to_alarm = 3
@@ -123,7 +123,7 @@ resource "aws_cloudwatch_metric_alarm" "opensearch_cluster_yellow" {
 
 resource "aws_cloudwatch_metric_alarm" "opensearch_free_storage" {
   alarm_name          = "opensearch-low-storage-${var.environment}"
-  alarm_description   = "OpenSearch free storage is below 10GB"
+  alarm_description   = "OpenSearch free storage is below 10GB in ${var.environment}. Check: AWS Console → OpenSearch → tariff-search-${var.environment} → Storage."
   comparison_operator = "LessThanThreshold"
   evaluation_periods  = 1
   metric_name         = "FreeStorageSpace"
@@ -143,7 +143,7 @@ resource "aws_cloudwatch_metric_alarm" "opensearch_free_storage" {
 
 resource "aws_cloudwatch_metric_alarm" "opensearch_jvm_pressure" {
   alarm_name          = "opensearch-jvm-pressure-${var.environment}"
-  alarm_description   = "OpenSearch JVM memory pressure above 85%"
+  alarm_description   = "OpenSearch JVM memory pressure above 85% in ${var.environment}. Check: AWS Console → OpenSearch → tariff-search-${var.environment} → JVM memory pressure."
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 3
   datapoints_to_alarm = 3

--- a/environments/production/common/opensearch.tf
+++ b/environments/production/common/opensearch.tf
@@ -75,3 +75,89 @@ module "opensearch" {
   encrypt_kms_key_id = aws_kms_key.opensearch_kms_key.key_id
   ssm_secret_name    = "/${var.environment}/ELASTICSEARCH_URL"
 }
+
+#----------------------------------------------------------#
+# CloudWatch alarms for OpenSearch cluster health
+#----------------------------------------------------------#
+
+resource "aws_cloudwatch_metric_alarm" "opensearch_cluster_red" {
+  alarm_name          = "opensearch-cluster-red-${var.environment}"
+  alarm_description   = "OpenSearch cluster status is RED — at least one primary shard is unassigned"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "ClusterStatus.red"
+  namespace           = "AWS/ES"
+  period              = 60
+  statistic           = "Maximum"
+  threshold           = 0
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    DomainName = "tariff-search-${var.environment}"
+    ClientId   = local.account_id
+  }
+
+  alarm_actions = local.alert_actions
+}
+
+resource "aws_cloudwatch_metric_alarm" "opensearch_cluster_yellow" {
+  alarm_name          = "opensearch-cluster-yellow-${var.environment}"
+  alarm_description   = "OpenSearch cluster status is YELLOW — replica shards unassigned"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 3
+  datapoints_to_alarm = 3
+  metric_name         = "ClusterStatus.yellow"
+  namespace           = "AWS/ES"
+  period              = 120
+  statistic           = "Maximum"
+  threshold           = 0
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    DomainName = "tariff-search-${var.environment}"
+    ClientId   = local.account_id
+  }
+
+  alarm_actions = local.observability_alert_actions
+}
+
+resource "aws_cloudwatch_metric_alarm" "opensearch_free_storage" {
+  alarm_name          = "opensearch-low-storage-${var.environment}"
+  alarm_description   = "OpenSearch free storage is below 10GB"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "FreeStorageSpace"
+  namespace           = "AWS/ES"
+  period              = 300
+  statistic           = "Minimum"
+  threshold           = 10000
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    DomainName = "tariff-search-${var.environment}"
+    ClientId   = local.account_id
+  }
+
+  alarm_actions = local.alert_actions
+}
+
+resource "aws_cloudwatch_metric_alarm" "opensearch_jvm_pressure" {
+  alarm_name          = "opensearch-jvm-pressure-${var.environment}"
+  alarm_description   = "OpenSearch JVM memory pressure above 85%"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 3
+  datapoints_to_alarm = 3
+  metric_name         = "JVMMemoryPressure"
+  namespace           = "AWS/ES"
+  period              = 300
+  statistic           = "Maximum"
+  threshold           = 85
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    DomainName = "tariff-search-${var.environment}"
+    ClientId   = local.account_id
+  }
+
+  alarm_actions = local.observability_alert_actions
+}

--- a/environments/production/common/slack-notify.tf
+++ b/environments/production/common/slack-notify.tf
@@ -31,7 +31,8 @@ module "notify_slack_observability" {
 }
 
 locals {
-  alert_actions = var.enable_sns_alerts ? [module.notify_slack.slack_topic_arn] : []
+  alert_actions               = var.enable_sns_alerts ? [module.notify_slack.slack_topic_arn] : []
+  observability_alert_actions = var.enable_sns_alerts ? [module.notify_slack_observability.slack_topic_arn] : []
 }
 
 resource "aws_cloudwatch_metric_alarm" "high_5xx_codes" {


### PR DESCRIPTION
## What:
Add CloudWatch alarms for OpenSearch cluster health and pipe `AWS/ES` metrics into the New Relic metric stream.

Four alarms are added to `environments/production/common/opensearch.tf`:
- `ClusterStatus.red` → `#production-alerts` (1-period, 60 s — critical)
- `ClusterStatus.yellow` → `#production-observability` (3-of-3 periods, 120 s — non-critical)
- `FreeStorageSpace` < 10 GB → `#production-alerts`
- `JVMMemoryPressure` > 85% → `#production-observability` (3-of-3 periods, 300 s)

`local.observability_alert_actions` is defined in `slack-notify.tf` (referencing the existing `notify_slack_observability` SNS topic). `AWS/ES` is added to the CloudWatch Metric Stream in `new-relic-stream.tf`.

## Why:
OpenSearch had no monitoring — a degraded cluster, shard failure, or failed post-sync reindex would go undetected until users reported poor search results.

## Ticket:
https://transformuk.atlassian.net/browse/HMRC-2607

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Adding CloudWatch alarms and a metric stream namespace entry is purely additive and read-only observability — no resources are replaced or removed.