### PR TITLE
feat(HMRC-2606): add Valkey eviction alarms

### DIFF
--- a/environments/production/common/redis.tf
+++ b/environments/production/common/redis.tf
@@ -176,7 +176,7 @@ resource "aws_cloudwatch_metric_alarm" "valkey_evictions" {
   for_each = local.valkey
 
   alarm_name          = "valkey-${each.key}-evictions"
-  alarm_description   = "Valkey ${each.key} is evicting keys — Sidekiq clusters with noeviction policy should never evict"
+  alarm_description   = "Valkey ${each.key} (${var.environment}) is evicting keys. Sidekiq clusters must never evict — any eviction means jobs are being dropped silently. Cache clusters alert above 100 evictions per 5 min. Check the Valkey-Stats-${title(var.environment)} CloudWatch dashboard."
   comparison_operator = "GreaterThanThreshold"
   evaluation_periods  = 1
   metric_name         = "Evictions"
@@ -195,27 +195,6 @@ resource "aws_cloudwatch_metric_alarm" "valkey_evictions" {
   alarm_actions = local.alert_actions
 }
 
-resource "aws_cloudwatch_metric_alarm" "valkey_replication_lag" {
-  for_each = local.valkey
-
-  alarm_name          = "valkey-${each.key}-replication-lag"
-  alarm_description   = "Valkey ${each.key} replica is falling behind the primary (lag > 5s)"
-  comparison_operator = "GreaterThanThreshold"
-  evaluation_periods  = 2
-  datapoints_to_alarm = 2
-  metric_name         = "ReplicationLag"
-  namespace           = "AWS/ElastiCache"
-  period              = 120
-  statistic           = "Maximum"
-  threshold           = 5
-  treat_missing_data  = "notBreaching"
-
-  dimensions = {
-    ReplicationGroupId = "valkey-${each.key}-${var.environment}"
-  }
-
-  alarm_actions = local.observability_alert_actions
-}
 
 resource "aws_cloudwatch_dashboard" "valkey" {
   dashboard_name = "Valkey-Stats-${title(var.environment)}"

--- a/environments/production/common/redis.tf
+++ b/environments/production/common/redis.tf
@@ -172,6 +172,51 @@ locals {
   ]
 }
 
+resource "aws_cloudwatch_metric_alarm" "valkey_evictions" {
+  for_each = local.valkey
+
+  alarm_name          = "valkey-${each.key}-evictions"
+  alarm_description   = "Valkey ${each.key} is evicting keys — Sidekiq clusters with noeviction policy should never evict"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "Evictions"
+  namespace           = "AWS/ElastiCache"
+  period              = 300
+  statistic           = "Sum"
+  # Sidekiq clusters: any eviction means jobs are being dropped silently (noeviction policy).
+  # Cache clusters: tolerate low eviction rates, alert above a reasonable threshold.
+  threshold          = strcontains(each.key, "sidekiq") ? 0 : 100
+  treat_missing_data = "notBreaching"
+
+  dimensions = {
+    ReplicationGroupId = "valkey-${each.key}-${var.environment}"
+  }
+
+  alarm_actions = local.alert_actions
+}
+
+resource "aws_cloudwatch_metric_alarm" "valkey_replication_lag" {
+  for_each = local.valkey
+
+  alarm_name          = "valkey-${each.key}-replication-lag"
+  alarm_description   = "Valkey ${each.key} replica is falling behind the primary (lag > 5s)"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  datapoints_to_alarm = 2
+  metric_name         = "ReplicationLag"
+  namespace           = "AWS/ElastiCache"
+  period              = 120
+  statistic           = "Maximum"
+  threshold           = 5
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    ReplicationGroupId = "valkey-${each.key}-${var.environment}"
+  }
+
+  alarm_actions = local.observability_alert_actions
+}
+
 resource "aws_cloudwatch_dashboard" "valkey" {
   dashboard_name = "Valkey-Stats-${title(var.environment)}"
   dashboard_body = jsonencode({

--- a/environments/production/common/slack-notify.tf
+++ b/environments/production/common/slack-notify.tf
@@ -31,8 +31,7 @@ module "notify_slack_observability" {
 }
 
 locals {
-  alert_actions               = var.enable_sns_alerts ? [module.notify_slack.slack_topic_arn] : []
-  observability_alert_actions = var.enable_sns_alerts ? [module.notify_slack_observability.slack_topic_arn] : []
+  alert_actions = var.enable_sns_alerts ? [module.notify_slack.slack_topic_arn] : []
 }
 
 resource "aws_cloudwatch_metric_alarm" "high_5xx_codes" {

--- a/environments/production/common/slack-notify.tf
+++ b/environments/production/common/slack-notify.tf
@@ -31,7 +31,8 @@ module "notify_slack_observability" {
 }
 
 locals {
-  alert_actions = var.enable_sns_alerts ? [module.notify_slack.slack_topic_arn] : []
+  alert_actions               = var.enable_sns_alerts ? [module.notify_slack.slack_topic_arn] : []
+  observability_alert_actions = var.enable_sns_alerts ? [module.notify_slack_observability.slack_topic_arn] : []
 }
 
 resource "aws_cloudwatch_metric_alarm" "high_5xx_codes" {


### PR DESCRIPTION
## What:
Add a CloudWatch evictions alarm across all five Valkey clusters (`frontend`, `backend-uk`, `backend-xi`, `sidekiq-uk`, `sidekiq-xi`).

The alarm fires to `#production-alerts` with a description that includes the environment, the impact, and a link to the `Valkey-Stats-Production` CloudWatch dashboard as the first action.

Thresholds:
- `sidekiq-uk` / `sidekiq-xi`: threshold = 0 (noeviction policy — any eviction means jobs are silently dropped)
- `frontend` / `backend-uk` / `backend-xi`: threshold = 100 evictions per 5-minute window

## Why:
Evictions are visible in the `Valkey-Stats-Production` dashboard but had no alert. Sidekiq clusters use a `noeviction` parameter group, so any eviction there means Sidekiq jobs are being dropped silently and without trace.

A replication lag alarm was considered but dropped — it doesn't meet the urgency bar (degrades failover readiness but isn't immediately actionable) and is better served by the existing dashboard.

## Ticket:
https://transformuk.atlassian.net/browse/HMRC-2606

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Adding CloudWatch alarms is read-only observability — no resources are created, modified, or destroyed beyond the alarm definitions themselves.