### PR TITLE
Bump Lambda Python runtimes to python3.14

### DIFF
--- a/modules/aws-notify-slack/main.tf
+++ b/modules/aws-notify-slack/main.tf
@@ -82,7 +82,7 @@ module "lambda" {
   handler                        = "${local.lambda_handler}.lambda_handler"
   source_path                    = var.lambda_source_path != null ? "${path.root}/${var.lambda_source_path}" : "${path.module}/functions/notify_slack.py"
   recreate_missing_package       = var.recreate_missing_package
-  runtime                        = "python3.12"
+  runtime                        = "python3.14"
   timeout                        = 30
   kms_key_arn                    = var.kms_key_arn
   reserved_concurrent_executions = var.reserved_concurrent_executions

--- a/modules/cloudwatch_log_exporter/main.tf
+++ b/modules/cloudwatch_log_exporter/main.tf
@@ -96,7 +96,7 @@ resource "aws_lambda_function" "log_exporter" {
   source_code_hash = data.archive_file.log_exporter.output_base64sha256
   timeout          = 300
 
-  runtime = "python3.8"
+  runtime = "python3.14"
 
   environment {
     variables = {


### PR DESCRIPTION
## What:
Bumps the Python runtime on two Lambda functions to `python3.14`:
- `modules/cloudwatch_log_exporter/main.tf` — `python3.8` → `python3.14` (used by `log-exporter-production`, `-staging`, `-development`)
- `modules/aws-notify-slack/main.tf` — `python3.12` → `python3.14` (Slack SNS-notify Lambda)

## Why:
AWS Health flagged `python3.8` on `log-exporter-production` for end-of-support. Bumped `aws-notify-slack` off `python3.12` at the same time to avoid a repeat of this soon. `python3.14` is GA on Lambda since Nov 2025 and supported by the pinned `hashicorp/aws` provider (`>= 6.37.0`).

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
`runtime` is a mutable attribute on `aws_lambda_function` — this is an in-place update with zero resource recreation, and neither Lambda's source uses anything version-specific (stdlib + boto3 only), so no code changes were needed.