### PR TITLE
feat(HMRC-2608): add CloudWatch alarms for Sidekiq queue depth and latency

### DIFF
--- a/environments/production/common/slack-notify.tf
+++ b/environments/production/common/slack-notify.tf
@@ -242,6 +242,61 @@ resource "aws_cloudwatch_metric_alarm" "apigw_p99_latency" {
 }
 
 #----------------------------------------------------------#
+# CloudWatch alarms for Sidekiq queue depth and latency
+#----------------------------------------------------------#
+
+locals {
+  sidekiq_queue_depth_thresholds = {
+    sync          = 10
+    default       = 100
+    within_1_hour = 50
+    within_1_day  = 200
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "sidekiq_queue_depth" {
+  for_each = local.sidekiq_queue_depth_thresholds
+
+  alarm_name          = "sidekiq-queue-depth-${each.key}-${var.environment}"
+  alarm_description   = "Sidekiq ${each.key} queue has more than ${each.value} jobs in ${var.environment}. Check Sidekiq Web UI for stuck or failing jobs."
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "QueueDepth"
+  namespace           = "TradeTariff/Sidekiq"
+  period              = 300
+  statistic           = "Maximum"
+  threshold           = each.value
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    Queue       = each.key
+    Environment = var.environment
+  }
+
+  alarm_actions = local.alert_actions
+}
+
+resource "aws_cloudwatch_metric_alarm" "sidekiq_sync_queue_latency" {
+  alarm_name          = "sidekiq-sync-queue-latency-${var.environment}"
+  alarm_description   = "Sidekiq sync queue has jobs waiting more than 30 minutes in ${var.environment}. CDS/TARIC sync may be stalled — check Sidekiq Web UI and worker logs."
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "QueueLatency"
+  namespace           = "TradeTariff/Sidekiq"
+  period              = 300
+  statistic           = "Maximum"
+  threshold           = 1800
+  treat_missing_data  = "notBreaching"
+
+  dimensions = {
+    Queue       = "sync"
+    Environment = var.environment
+  }
+
+  alarm_actions = local.alert_actions
+}
+
+#----------------------------------------------------------#
 # CloudWatch alarms for Valkey clusters
 #----------------------------------------------------------#
 


### PR DESCRIPTION
## What:
Adds five CloudWatch alarms against the `TradeTariff/Sidekiq` custom metric namespace (fed by the worker in the [companion backend PR](https://github.com/trade-tariff/trade-tariff-backend/pull/3634)):

| Alarm | Threshold | Queue |
|-------|-----------|-------|
| `sidekiq-queue-depth-sync` | > 10 jobs | sync |
| `sidekiq-queue-depth-within_1_hour` | > 50 jobs | within_1_hour |
| `sidekiq-queue-depth-default` | > 100 jobs | default |
| `sidekiq-queue-depth-within_1_day` | > 200 jobs | within_1_day |
| `sidekiq-sync-queue-latency` | > 1800 s (30 min) | sync |

All alarms use `Maximum` statistic over 300 s, `treat_missing_data = notBreaching`, and route to `#production-alerts` via the existing SNS → notify_slack Lambda chain.

## Why:
Queue depth was completely unmonitored. A stalled or fan-out worker could queue millions of jobs before anyone noticed. The sync queue latency alarm specifically catches a stalled CDS/TARIC sync worker before the daily import window closes.

Thresholds are starting points — tune after a week of observing normal traffic.

## Ticket:
https://transformuk.atlassian.net/browse/HMRC-2608

## Risk:
**Risk level:** 🟢

**Reason for rating:** Adding CloudWatch alarms is read-only observability. No resources are created, modified, or destroyed beyond new `aws_cloudwatch_metric_alarm` resources. Worst case: the alarms fire immediately if thresholds need tuning — they can be silenced or retuned without any deployment.