### PR TITLE
feat(HMRC-2611): add CloudWatch heartbeat alarms for scheduled jobs

### DIFF
--- a/environments/production/common/slack-notify.tf
+++ b/environments/production/common/slack-notify.tf
@@ -165,6 +165,43 @@ resource "aws_cloudwatch_metric_alarm" "notify_delivery_failures" {
 }
 
 #----------------------------------------------------------#
+# CloudWatch dead man's switch alarms for scheduled jobs
+#----------------------------------------------------------#
+locals {
+  # period is the expected run interval in seconds; alarm fires if no heartbeat
+  # is seen within one interval. Tune these windows once real run times are known.
+  heartbeat_jobs = {
+    ImportCustomsTariffDocumentWorker     = 86400 # daily
+    ImportXiCnDocumentWorker              = 86400 # daily
+    GoodsNomenclatureReconciliationWorker = 86400 # daily
+    ReportWorker                          = 86400 # post-sync daily
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "scheduled_job_heartbeat" {
+  for_each = local.heartbeat_jobs
+
+  alarm_name          = "scheduled-job-no-heartbeat-${lower(replace(each.key, "Worker", ""))}-${var.environment}"
+  alarm_description   = "${each.key} has not reported a successful completion in the expected window"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "JobSuccess"
+  namespace           = "TradeTariff/ScheduledJobs"
+  period              = each.value
+  statistic           = "Sum"
+  threshold           = 1
+  treat_missing_data  = "breaching"
+
+  dimensions = {
+    Job         = each.key
+    Environment = var.environment
+  }
+
+  alarm_actions = local.alert_actions
+  ok_actions    = local.alert_actions
+}
+
+#----------------------------------------------------------#
 # CloudWatch alarms for API Gateway
 #----------------------------------------------------------#
 resource "aws_cloudwatch_metric_alarm" "apigw_5xx_error_rate" {

--- a/environments/production/common/slack-notify.tf
+++ b/environments/production/common/slack-notify.tf
@@ -198,7 +198,6 @@ resource "aws_cloudwatch_metric_alarm" "scheduled_job_heartbeat" {
   }
 
   alarm_actions = local.alert_actions
-  ok_actions    = local.alert_actions
 }
 
 #----------------------------------------------------------#


### PR DESCRIPTION
## What:
Adds dead man's switch CloudWatch alarms for 4 prioritised scheduled Sidekiq workers. Each alarm fires to `#production-alerts` if the worker's `JobSuccess` metric stops appearing within its expected run window.

## Why:
Scheduled job failures are currently only surfaced after all Sidekiq retries are exhausted. Jobs like `ImportCustomsTariffDocumentWorker` can fail silently for an entire day before anyone is alerted. The `ScheduledJobHeartbeat` concern (added in trade-tariff-backend [PR #3635](https://github.com/trade-tariff/trade-tariff-backend/pull/3635)) emits a `JobSuccess` metric on each successful completion; these alarms detect when the metric goes missing.

## Ticket:
https://transformuk.atlassian.net/browse/HMRC-2611

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Adding CloudWatch alarms is read-only observability — no existing infrastructure is modified, no resource is recreated, and a false alarm can be silenced immediately.