### PR TITLE
feat: configure API docs CDN to use 404 and extensionless URLs

### DIFF
--- a/common/directory_index_rewrite.js
+++ b/common/directory_index_rewrite.js
@@ -1,0 +1,15 @@
+// rewrite extensionless requests to '.html'
+// and any requests ending in '/' to the index.html
+
+async function handler(event) {
+  var request = event.request;
+  var uri = request.uri;
+
+  if (uri.endsWith('/')) {
+    request.uri += "index.html";
+  } else if (!uri.includes('.')) {
+    request.uri += '.html';
+  }
+
+  return request;
+}

--- a/environments/development/common/cloudfront.tf
+++ b/environments/development/common/cloudfront.tf
@@ -369,6 +369,21 @@ module "docs_cdn" {
     prefix = "cloudfront/${var.environment}"
   }
 
+  // redirect 403/404 errors to the 404 page
+  // to avoid S3 XML responses
+  custom_error_response = [
+    {
+      error_code         = 403
+      response_code      = 404
+      response_page_path = "/404.html"
+    },
+    {
+      error_code         = 404
+      response_code      = 404
+      response_page_path = "/404.html"
+    }
+  ]
+
   origin = {
     docs = {
       domain_name              = aws_s3_bucket.this["api-docs"].bucket_regional_domain_name
@@ -383,6 +398,12 @@ module "docs_cdn" {
       cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.s3.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+
+      function_association = {
+        "viewer-request" = {
+          function_arn = aws_cloudfront_function.docs_cdn_directory_index_rewrite.arn
+        }
+      }
     },
   ]
 
@@ -393,6 +414,13 @@ module "docs_cdn" {
       module.acm.validated_certificate_arn
     ]
   }
+}
+
+resource "aws_cloudfront_function" "docs_cdn_directory_index_rewrite" {
+  name    = "docs_cdn_directory_index_rewrite"
+  comment = "Allows extensionless URLs on the API docs CDN"
+  runtime = "cloudfront-js-2.0"
+  code    = file("../../../common/directory_index_rewrite.js")
 }
 
 module "reporting_cdn" {
@@ -492,7 +520,7 @@ module "backups_cdn" {
 
 resource "aws_cloudfront_function" "basic_auth" {
   name    = "backups-basic-auth"
-  runtime = "cloudfront-js-1.0"
+  runtime = "cloudfront-js-2.0"
   publish = true
   code    = local.cloudfront_auth
 }

--- a/environments/development/common/cloudfront.tf
+++ b/environments/development/common/cloudfront.tf
@@ -348,7 +348,6 @@ module "cdn" {
   }
 }
 
-
 module "docs_cdn" {
   source = "../../../modules/cloudfront"
 

--- a/environments/production/common/cloudfront.tf
+++ b/environments/production/common/cloudfront.tf
@@ -321,6 +321,21 @@ module "docs_cdn" {
     prefix = "cloudfront/${var.environment}"
   }
 
+  // redirect 403/404 errors to the 404 page
+  // to avoid S3 XML responses
+  custom_error_response = [
+    {
+      error_code         = 403
+      response_code      = 404
+      response_page_path = "/404.html"
+    },
+    {
+      error_code         = 404
+      response_code      = 404
+      response_page_path = "/404.html"
+    }
+  ]
+
   origin = {
     docs = {
       domain_name              = aws_s3_bucket.this["api-docs"].bucket_regional_domain_name
@@ -335,6 +350,12 @@ module "docs_cdn" {
       cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.s3.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+
+      function_association = {
+        "viewer-request" = {
+          function_arn = aws_cloudfront_function.docs_cdn_directory_index_rewrite.arn
+        }
+      }
     },
   ]
 
@@ -345,6 +366,13 @@ module "docs_cdn" {
       module.acm.validated_certificate_arn
     ]
   }
+}
+
+resource "aws_cloudfront_function" "docs_cdn_directory_index_rewrite" {
+  name    = "docs_cdn_directory_index_rewrite"
+  comment = "Allows extensionless URLs on the API docs CDN"
+  runtime = "cloudfront-js-2.0"
+  code    = file("../../../common/directory_index_rewrite.js")
 }
 
 module "reporting_cdn" {

--- a/environments/staging/common/cloudfront.tf
+++ b/environments/staging/common/cloudfront.tf
@@ -345,7 +345,6 @@ module "cdn" {
   }
 }
 
-
 module "docs_cdn" {
   source = "../../../modules/cloudfront"
 
@@ -366,6 +365,21 @@ module "docs_cdn" {
     prefix = "cloudfront/${var.environment}"
   }
 
+  // redirect 403/404 errors to the 404 page
+  // to avoid S3 XML responses
+  custom_error_response = [
+    {
+      error_code         = 403
+      response_code      = 404
+      response_page_path = "/404.html"
+    },
+    {
+      error_code         = 404
+      response_code      = 404
+      response_page_path = "/404.html"
+    }
+  ]
+
   origin = {
     docs = {
       domain_name              = aws_s3_bucket.this["api-docs"].bucket_regional_domain_name
@@ -380,6 +394,12 @@ module "docs_cdn" {
       cache_policy_id            = data.aws_cloudfront_cache_policy.caching_disabled.id
       origin_request_policy_id   = aws_cloudfront_origin_request_policy.s3.id
       response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+
+      function_association = {
+        "viewer-request" = {
+          function_arn = aws_cloudfront_function.docs_cdn_directory_index_rewrite.arn
+        }
+      }
     },
   ]
 
@@ -390,6 +410,13 @@ module "docs_cdn" {
       module.acm.validated_certificate_arn
     ]
   }
+}
+
+resource "aws_cloudfront_function" "docs_cdn_directory_index_rewrite" {
+  name    = "docs_cdn_directory_index_rewrite"
+  comment = "Allows extensionless URLs on the API docs CDN"
+  runtime = "cloudfront-js-2.0"
+  code    = file("../../../common/directory_index_rewrite.js")
 }
 
 module "reporting_cdn" {

--- a/modules/cloudfront/README.md
+++ b/modules/cloudfront/README.md
@@ -34,10 +34,10 @@ No modules.
 | <a name="input_create_alias"></a> [create\_alias](#input\_create\_alias) | Whether to create a Route 53 A record. | `bool` | `false` | no |
 | <a name="input_create_cname"></a> [create\_cname](#input\_create\_cname) | Whether to create a Route 53 CNAME record. | `bool` | `false` | no |
 | <a name="input_create_distribution"></a> [create\_distribution](#input\_create\_distribution) | Controls if CloudFront distribution should be created | `bool` | `true` | no |
-| <a name="input_custom_error_response"></a> [custom\_error\_response](#input\_custom\_error\_response) | One or more custom error response elements | `any` | `{}` | no |
+| <a name="input_custom_error_response"></a> [custom\_error\_response](#input\_custom\_error\_response) | One or more custom error response elements | <pre>list(object({<br/>    error_caching_min_ttl = optional(number)<br/>    error_code            = number<br/>    response_code         = number<br/>    response_page_path    = optional(string)<br/>  }))</pre> | `null` | no |
 | <a name="input_default_root_object"></a> [default\_root\_object](#input\_default\_root\_object) | The object that you want CloudFront to return (for example, index.html) when an end user requests the root URL. | `string` | `null` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Whether the distribution is enabled to accept end user requests for content. | `bool` | `true` | no |
-| <a name="input_geo_restriction"></a> [geo\_restriction](#input\_geo\_restriction) | The restriction configuration for this distribution (geo\_restrictions) | `any` | `{}` | no |
+| <a name="input_geo_restriction"></a> [geo\_restriction](#input\_geo\_restriction) | The restriction configuration for this distribution (geo\_restrictions) | <pre>object({<br/>    restriction_type = optional(string, "none")<br/>    locations        = optional(list(string))<br/>  })</pre> | <pre>{<br/>  "restriction_type": "none"<br/>}</pre> | no |
 | <a name="input_health_check_id"></a> [health\_check\_id](#input\_health\_check\_id) | The health check the record should be associated with. | `string` | `null` | no |
 | <a name="input_http_version"></a> [http\_version](#input\_http\_version) | The maximum HTTP version to support on the distribution. Allowed values are http1.1 and http2. The default is http2. | `string` | `"http2"` | no |
 | <a name="input_is_ipv6_enabled"></a> [is\_ipv6\_enabled](#input\_is\_ipv6\_enabled) | Whether the IPv6 is enabled for the distribution. | `bool` | `null` | no |

--- a/modules/cloudfront/main.tf
+++ b/modules/cloudfront/main.tf
@@ -180,14 +180,13 @@ resource "aws_cloudfront_distribution" "this" {
   }
 
   dynamic "custom_error_response" {
-    for_each = var.custom_error_response
+    for_each = var.custom_error_response != null ? var.custom_error_response : []
 
     content {
-      error_code = custom_error_response.value["error_code"]
-
-      response_code         = lookup(custom_error_response.value, "response_code", null)
-      response_page_path    = lookup(custom_error_response.value, "response_page_path", null)
-      error_caching_min_ttl = lookup(custom_error_response.value, "error_caching_min_ttl", null)
+      error_caching_min_ttl = custom_error_response.value.error_caching_min_ttl
+      error_code            = custom_error_response.value.error_code
+      response_code         = custom_error_response.value.response_code
+      response_page_path    = custom_error_response.value.response_page_path
     }
   }
 
@@ -196,8 +195,8 @@ resource "aws_cloudfront_distribution" "this" {
       for_each = [var.geo_restriction]
 
       content {
-        restriction_type = lookup(geo_restriction.value, "restriction_type", "none")
-        locations        = lookup(geo_restriction.value, "locations", [])
+        restriction_type = geo_restriction.value.restriction_type
+        locations        = geo_restriction.value.locations
       }
     }
   }

--- a/modules/cloudfront/variables.tf
+++ b/modules/cloudfront/variables.tf
@@ -93,8 +93,40 @@ variable "viewer_certificate" {
 
 variable "geo_restriction" {
   description = "The restriction configuration for this distribution (geo_restrictions)"
-  type        = any
-  default     = {}
+
+  type = object({
+    restriction_type = optional(string, "none")
+    locations        = optional(list(string))
+  })
+
+  default = {
+    restriction_type = "none"
+  }
+
+  validation {
+    condition = alltrue(flatten([
+      [
+        var.geo_restriction.restriction_type == "none" ||
+        var.geo_restriction.restriction_type == "whitelist" ||
+        var.geo_restriction.restriction_type == "blacklist"
+      ],
+      [
+        for location in coalesce(var.geo_restriction.locations, []) : try(
+          length(location) == 2,
+          false
+        )
+      ]
+    ]))
+
+    error_message = <<-EOT
+      `restriction_type` must be one of:
+        - `none`
+        - `whitelist`
+        - `blacklist`
+
+      `locations` must be a list of 2-character ISO 3166 country codes.
+    EOT
+  }
 }
 
 variable "logging_config" {
@@ -105,8 +137,13 @@ variable "logging_config" {
 
 variable "custom_error_response" {
   description = "One or more custom error response elements"
-  type        = any
-  default     = {}
+  type = list(object({
+    error_caching_min_ttl = optional(number)
+    error_code            = number
+    response_code         = number
+    response_page_path    = optional(string)
+  }))
+  default = null
 }
 
 variable "cache_behaviors" {


### PR DESCRIPTION
## What:

- Adds a CloudFront function to the API docs CDN to rewrite requests without extensions.
- Redirect all 403 errors to the 404 page.

## Why:

### File extension rewrite

Unless the user explicitly wants the markdown version, currently the API docs requires `.html` in URLs. The end user shouldn't need to know the file extension of the files served by CloudFront to read the docs. Currently, navigating to a page without using the extension causes errors. The directory index rewrite will rewrite any request without them, while respecting other extensions, like `.md` for pure-markdown pages.

For example; `/developer-portal.html` becomes `/developer-portal`, but `/developer-portal.md` is unchanged. Query strings and URL fragments are unchanged and work the same way as before this change. 


### Custom error response

On our API docs CDN nothing requires authentication, so the only 403 errors users will see is if they navigate to a page that doesn't exist. The CloudFront 403 page is actually the S3 bucket returning a `NoSuchKey` XML file. This isn't great for an end user regardless of how technical they are and it should actually show them a 404 error (and our nice 404 page in the API docs).

<img width="900" height="229" alt="image" src="https://github.com/user-attachments/assets/7695aeae-d7da-4cee-8e56-0b64e5e0bf3e" />

_**Without rewrite**_

<img width="1217" height="750" alt="image" src="https://github.com/user-attachments/assets/dc4bc9b1-e65b-4cd5-9b45-f97033e33a0c" />

## Ticket:
N/A

## Risk:
**Risk level:** 🟢 

**Reason for rating:**

Changes the API docs CDN routing, but is additive-only. Requests that already have fully-formed URIs including file extensions will pass through unaltered.
