### PR TITLE
[HMRC-2476] - Blocks categorisations paths that must only be reachable via API Gate…

### DIFF
--- a/environments/development/common/alb.tf
+++ b/environments/development/common/alb.tf
@@ -112,6 +112,17 @@ module "alb" {
       priority         = 2
     }
   }
+
+  denied_paths = {
+    # Broad on purpose: catches every prefixed/versioned/unprefixed form
+    # (including the legacy VersionedForwarder route, e.g. /api/v2/categorisation/*),
+    # not just the current /uk|xi/api(/v2)/categorisation/* combinations.
+    # "categorisation" is not used as a path segment anywhere else in the app.
+    categorisation = {
+      paths    = ["*categorisation*"]
+      priority = 5
+    }
+  }
 }
 
 # The ALB's primary cert covers *.origin.domain — attach the wildcard public cert

--- a/environments/production/common/alb.tf
+++ b/environments/production/common/alb.tf
@@ -101,6 +101,17 @@ module "alb" {
       priority         = 2
     }
   }
+
+  denied_paths = {
+    # Broad on purpose: catches every prefixed/versioned/unprefixed form
+    # (including the legacy VersionedForwarder route, e.g. /api/v2/categorisation/*),
+    # not just the current /uk|xi/api(/v2)/categorisation/* combinations.
+    # "categorisation" is not used as a path segment anywhere else in the app.
+    categorisation = {
+      paths    = ["*categorisation*"]
+      priority = 5
+    }
+  }
 }
 
 resource "aws_lb_listener_certificate" "mcp" {

--- a/environments/staging/common/alb.tf
+++ b/environments/staging/common/alb.tf
@@ -104,6 +104,17 @@ module "alb" {
       priority         = 2
     }
   }
+
+  denied_paths = {
+    # Broad on purpose: catches every prefixed/versioned/unprefixed form
+    # (including the legacy VersionedForwarder route, e.g. /api/v2/categorisation/*),
+    # not just the current /uk|xi/api(/v2)/categorisation/* combinations.
+    # "categorisation" is not used as a path segment anywhere else in the app.
+    categorisation = {
+      paths    = ["*categorisation*"]
+      priority = 5
+    }
+  }
 }
 
 resource "aws_lb_listener_certificate" "mcp" {

--- a/modules/application-load-balancer/README.md
+++ b/modules/application-load-balancer/README.md
@@ -48,6 +48,7 @@ No modules.
 | [aws_lb.application_load_balancer](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb) | resource |
 | [aws_lb_listener.redirect_http](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
 | [aws_lb_listener.trade_tariff_listeners](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener) | resource |
+| [aws_lb_listener_rule.denied_paths](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener_rule) | resource |
 | [aws_lb_listener_rule.http_services](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener_rule) | resource |
 | [aws_lb_listener_rule.redirect_http_rules](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener_rule) | resource |
 | [aws_lb_listener_rule.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener_rule) | resource |
@@ -71,6 +72,7 @@ No modules.
 | <a name="input_alb_security_group_id"></a> [alb\_security\_group\_id](#input\_alb\_security\_group\_id) | Application load balancer security group ID. | `string` | n/a | yes |
 | <a name="input_certificate_arn"></a> [certificate\_arn](#input\_certificate\_arn) | ARN of the default SSL server certificate. | `string` | n/a | yes |
 | <a name="input_custom_header"></a> [custom\_header](#input\_custom\_header) | Custom header required in all requests to the load balancer. | <pre>object({<br/>    name  = string<br/>    value = string<br/>  })</pre> | n/a | yes |
+| <a name="input_denied_paths"></a> [denied\_paths](#input\_denied\_paths) | Map of path patterns to block with a fixed 403 response on the HTTPS listener, evaluated ahead of `services`. Used for paths that must only be reachable via API Gateway (the port-80 `gateway_services` listener), not directly through CloudFront/ALB on port 443. | <pre>map(<br/>    object({<br/>      paths    = list(string)<br/>      priority = number<br/>    })<br/>  )</pre> | `{}` | no |
 | <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | The domain name for the application. | `string` | n/a | yes |
 | <a name="input_enable_access_logs"></a> [enable\_access\_logs](#input\_enable\_access\_logs) | Whether to enable access logs for ALB. | `bool` | `false` | no |
 | <a name="input_enable_deletion_protection"></a> [enable\_deletion\_protection](#input\_enable\_deletion\_protection) | If true, deletion of the load balancer will be disabled via the AWS API. | `bool` | `true` | no |

--- a/modules/application-load-balancer/main.tf
+++ b/modules/application-load-balancer/main.tf
@@ -152,6 +152,34 @@ resource "aws_lb_listener_rule" "this" {
   }
 }
 
+# Blocks paths that must only be reachable via API Gateway's VPC Link (the
+# port-80 redirect_http_rules/gateway_services listener rule below) from also
+# being reachable directly through CloudFront/ALB on this HTTPS listener. The
+# custom_header check above cannot distinguish CloudFront-origin traffic from
+# API-Gateway-origin traffic, since both currently share the same secret.
+resource "aws_lb_listener_rule" "denied_paths" {
+  for_each     = var.denied_paths
+  listener_arn = aws_lb_listener.trade_tariff_listeners.arn
+
+  priority = each.value.priority
+
+  action {
+    type = "fixed-response"
+
+    fixed_response {
+      content_type = "text/plain"
+      message_body = "Access denied"
+      status_code  = "403"
+    }
+  }
+
+  condition {
+    path_pattern {
+      values = each.value.paths
+    }
+  }
+}
+
 # HTTP target groups — for services whose containers serve plain HTTP.
 # The ALB terminates TLS on the HTTPS listener and forwards here over HTTP.
 resource "aws_lb_target_group" "http_target_groups" {

--- a/modules/application-load-balancer/variables.tf
+++ b/modules/application-load-balancer/variables.tf
@@ -107,6 +107,17 @@ variable "gateway_services" {
   default = {}
 }
 
+variable "denied_paths" {
+  description = "Map of path patterns to block with a fixed 403 response on the HTTPS listener, evaluated ahead of `services`. Used for paths that must only be reachable via API Gateway (the port-80 `gateway_services` listener), not directly through CloudFront/ALB on port 443."
+  type = map(
+    object({
+      paths    = list(string)
+      priority = number
+    })
+  )
+  default = {}
+}
+
 variable "enable_access_logs" {
   description = "Whether to enable access logs for ALB."
   type        = bool


### PR DESCRIPTION

## What:
Adds a new ALB listener rule that returns a fixed 403 Access denied for any path containing categorisation, evaluated ahead of the existing `backend_xi/backend_uk `catch-all rules on the HTTPS (443) listener that _CloudFront/public traffic_ hits. Wired into all three environments (development, staging, production) via a new `denied_paths` variable on the application-load-balancer module.

## Why:

The new Categorisation API routes (trade-tariff-backend, in flight on a separate branch) authenticate exclusively via API Gateway's Lambda authoriser (`tariff/categorisation `OAuth scope) — the Rails controllers deliberately skip all Rails-level auth. Those same paths are also reachable directly through the existing `CloudFront → ALB` route today, which never touches API Gateway or the authoriser:

- CloudFront's only origin for` /xi/api/*` and` /uk/api/*` is the ALB.
- The ALB's services.backend_xi/backend_uk (port 443, CloudFront-facing) and `gateway_services.backend_xi/backend_uk` (port 80, API-Gateway-only VPC Link) both forward to the same target group — the same Rails app either way.
- The only gate on port 443 is a shared-secret header CloudFront injects on every request uniformly, and it's the same secret API Gateway uses, so it can't distinguish "should go through API Gateway" from "shouldn't."

Net effect without this fix: anyone hitting the public CloudFront domain could call `/xi/api/categorisation/... ` directly with no token and no scope check.

This closes the gap at the network layer, before the request ever reaches Rails. The block is deliberately a broad *categorisation* substring match rather than an enumerated list of prefix/version combinations, because `config/routes.rb` in trade-tariff-backend also has a legacy unprefixed route (VersionedForwarde ) that rewrites `/api/v2/categorisation/*` (no uk/xi prefix) into the same controller — an enumerated list would have missed that form. Confirmed "categorisation" isn't used as a path segment anywhere else in the app, so the broad pattern won't collide with anything unrelated.

Legitimate API-Gateway-routed traffic is unaffected: it arrives on the separate port-80 gateway_services/redirect_http_rules listener, a different aws_lb_listener resource entirely from the one this rule is added to.

## Ticket:

https://transformuk.atlassian.net/jira/software/c/projects/HMRC/boards/155?selectedIssue=HMRC-2476

## Risk:

**Risk level:** 🟠

**Reason for rating:**
Reason for rating: Adds a new listener rule on the production HTTPS listener (falls under this template's "ALB listener    rules" Amber criterion). No resource replacement — confirmed via terraform validate in all three environments and a       targeted terraform plan showing only the one new resource added — but it changes public routing behaviour, so worth socialising before merge.
  
## Testing:                                                                                                                  
                                                                                                                            
Static verification (pre-apply, all three environments):                                                                  
  - terragrunt init + terraform validate — clean in development, staging, and production.                                   
  - terraform plan targeted at the new resource — confirmed exactly one resource added per environment                      
  (module.alb.aws_lb_listener_rule.denied_paths["categorisation"]), no changes or replacements to any existing resource.    
                                                                                                                            
End-to-end, deployed to development:                                                                                      
  - Called the Categorisation API with a tariff/categorisation-scoped token via API Gateway — succeeded.                    
  - Called the same endpoint with a different scope — denied.                                                               
  - Called the equivalent public URL directly (bypassing API Gateway) without a token — blocked, confirming the            CloudFront/ALB direct-access path this PR closes is actually closed.                                                      
                                                                                                                            
  (Development doesn't have the api.* custom domain provisioned, so the API-Gateway-routed calls above went via API Gateway directly rather than through that custom domain — doesn't affect what's being verified here.)